### PR TITLE
Add system deploys to merging

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -309,6 +309,7 @@ class MultiParentCasperImpl[F[_]
       index <- BlockIndex[F, Par, BindPattern, ListParWithRandom, TaggedContinuation](
                 b.blockHash,
                 b.body.deploys,
+                b.body.systemDeploys,
                 Blake2b256Hash.fromByteString(b.body.state.preStateHash),
                 Blake2b256Hash.fromByteString(b.body.state.postStateHash),
                 RuntimeManager[F].getHistoryRepo

--- a/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
@@ -2,7 +2,9 @@ package coop.rchain.casper.merging
 
 import cats.effect.Concurrent
 import cats.syntax.all._
-import coop.rchain.casper.protocol.ProcessedDeploy
+import coop.rchain.casper.merging.DeployIndex._
+import coop.rchain.casper.protocol.ProcessedSystemDeploy.Succeeded
+import coop.rchain.casper.protocol._
 import coop.rchain.casper.util.EventConverter
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.rspace.hashing.Blake2b256Hash
@@ -22,11 +24,11 @@ object BlockIndex {
   val cache = TrieMap.empty[BlockHash, BlockIndex]
 
   def createEventLogIndex[F[_]: Concurrent, C, P, A, K](
-      d: ProcessedDeploy,
+      events: List[Event],
       historyRepository: HistoryRepository[F, C, P, A, K],
       preStateHash: Blake2b256Hash
   ): F[EventLogIndex] = {
-    implicit val channelStore: HistoryRepository[F, C, P, A, K] = historyRepository
+    implicit val cs = historyRepository
     val preStateReader =
       historyRepository.getHistoryReader(preStateHash)
     val produceExistsInPreState = (p: Produce) =>
@@ -34,7 +36,7 @@ object BlockIndex {
     val produceTouchesPreStateJoin = (p: Produce) =>
       preStateReader.getJoinsFromChannelHash(p.channelsHash).map(_.exists(_.size > 1))
     EventLogIndex.apply(
-      d.deployLog.map(EventConverter.toRspaceEvent),
+      events.map(EventConverter.toRspaceEvent),
       produceExistsInPreState,
       produceTouchesPreStateJoin
     )
@@ -42,23 +44,47 @@ object BlockIndex {
 
   def apply[F[_]: Concurrent, C, P, A, K](
       blockHash: BlockHash,
-      processedDeploys: List[ProcessedDeploy],
+      usrProcessedDeploys: List[ProcessedDeploy],
+      sysProcessedDeploys: List[ProcessedSystemDeploy],
       preStateHash: Blake2b256Hash,
       postStateHash: Blake2b256Hash,
       historyRepository: HistoryRepository[F, C, P, A, K]
   ): F[BlockIndex] =
     for {
-      deployIndices <- processedDeploys
-                        .filterNot(_.isFailed)
-                        .traverse { d =>
-                          DeployIndex(d, createEventLogIndex(_, historyRepository, preStateHash))
-                        }
+      usrDeployIndices <- usrProcessedDeploys.toVector
+                           .filterNot(_.isFailed)
+                           .traverse { d =>
+                             DeployIndex(
+                               d.deploy.sig,
+                               d.cost.cost,
+                               d.deployLog,
+                               createEventLogIndex(_, historyRepository, preStateHash)
+                             )
+                           }
+      sysDeploysData = sysProcessedDeploys.toVector
+        .collect {
+          case Succeeded(log, SlashSystemDeployData(_, _)) =>
+            (SYS_SLASH_DEPLOY_ID, SYS_SLASH_DEPLOY_COST, log)
+          case Succeeded(log, CloseBlockSystemDeployData) =>
+            (SYS_CLOSE_BLOCK_DEPLOY_ID, SYS_CLOSE_BLOCK_DEPLOY_COST, log)
+          case Succeeded(log, Empty) =>
+            (SYS_EMPTY_DEPLOY_ID, SYS_EMPTY_DEPLOY_COST, log)
+        }
+      sysDeployIndices <- sysDeploysData.traverse {
+                           case (sig, cost, log) =>
+                             DeployIndex(
+                               sig,
+                               cost,
+                               log,
+                               createEventLogIndex(_, historyRepository, preStateHash)
+                             )
+                         }
 
       /** Here deploys from a single block are examined. Atm deploys in block are executed sequentially,
         * so all conflicts are resolved according to order of sequential execution.
         * Therefore there won't be any conflicts between event logs. But there can be dependencies. */
       deployChains = computeRelatedSets[DeployIndex](
-        deployIndices.toSet,
+        (usrDeployIndices ++ sysDeployIndices).toSet,
         (l, r) => MergingLogic.depends(l.eventLogIndex, r.eventLogIndex)
       )
       index <- deployChains.toVector

--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployIndex.scala
@@ -3,18 +3,31 @@ package coop.rchain.casper.merging
 import cats.effect.Concurrent
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.protocol.ProcessedDeploy
+import coop.rchain.casper.protocol.Event
 import coop.rchain.rspace.merger.EventLogIndex
 
 /** index of a single deploy */
-final case class DeployIndex(deployId: ByteString, cost: Long, eventLogIndex: EventLogIndex)
+final case class DeployIndex(
+    deployId: ByteString,
+    cost: Long,
+    eventLogIndex: EventLogIndex
+)
 
 object DeployIndex {
+  // This cost is required because rejection option selection rule depends on how much branch costs.
+  // For now system deploys do not have any weight, cost is 0.
+  val SYS_SLASH_DEPLOY_COST       = 0L
+  val SYS_CLOSE_BLOCK_DEPLOY_COST = 0L
+  val SYS_EMPTY_DEPLOY_COST       = 0L
+  // These are to be put in rejected set in blocks, so prefix format is defined for identification purposes.
+  val SYS_SLASH_DEPLOY_ID       = ByteString.copyFrom(64.toByte +: new Array[Byte](31))  // 1000000xxx
+  val SYS_CLOSE_BLOCK_DEPLOY_ID = ByteString.copyFrom(96.toByte +: new Array[Byte](31))  // 1100000xxx
+  val SYS_EMPTY_DEPLOY_ID       = ByteString.copyFrom(112.toByte +: new Array[Byte](31)) // 1110000xxx
+
   def apply[F[_]: Concurrent](
-      deploy: ProcessedDeploy,
-      createEventLogIndex: (ProcessedDeploy) => F[EventLogIndex]
-  ): F[DeployIndex] =
-    for {
-      eventLogIndex <- createEventLogIndex(deploy)
-    } yield DeployIndex(deploy.deploy.sig, deploy.cost.cost, eventLogIndex)
+      sig: ByteString,
+      cost: Long,
+      events: List[Event],
+      createEventLogIndex: List[Event] => F[EventLogIndex]
+  ): F[DeployIndex] = createEventLogIndex(events).map(DeployIndex(sig, cost, _))
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/InterpreterUtil.scala
@@ -260,6 +260,7 @@ object InterpreterUtil {
                 BlockIndex(
                   b.blockHash,
                   b.body.deploys,
+                  b.body.systemDeploys,
                   Blake2b256Hash.fromByteString(b.body.state.preStateHash),
                   Blake2b256Hash.fromByteString(b.body.state.postStateHash),
                   runtimeManager.getHistoryRepo

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
@@ -74,13 +74,13 @@ class MergingCases extends FlatSpec with Matchers {
               )
           (_, processedDeploys, _) = r
           _                        = processedDeploys.size shouldBe 2
-          idxs <- processedDeploys.toList.traverse(
+          idxs <- processedDeploys.toList.traverse { d =>
                    BlockIndex.createEventLogIndex(
-                     _,
+                     d.deployLog,
                      runtimeManager.getHistoryRepo,
                      Blake2b256Hash.fromByteString(baseState)
                    )
-                 )
+                 }
           firstDepends  = MergingLogic.depends(idxs.head, idxs(1))
           secondDepends = MergingLogic.depends(idxs(1), idxs.head)
           conflicts     = MergingLogic.areConflicting(idxs.head, idxs(1))

--- a/node/src/test/scala/coop/rchain/node/mergeablity/ComputeMerge.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/ComputeMerge.scala
@@ -82,9 +82,11 @@ trait ComputeMerge {
                   )
                   .whenA(rightDeploys.exists(_.isFailed))
             rightCheckpoint @ _ <- runtime.createCheckpoint
+
             leftIndex <- BlockIndex(
                           ByteString.copyFromUtf8("l"),
                           leftDeploys,
+                          List.empty,
                           baseCheckpoint.root,
                           leftCheckpoint.root,
                           historyRepo
@@ -92,12 +94,14 @@ trait ComputeMerge {
             rightIndex <- BlockIndex(
                            ByteString.copyFromUtf8("r"),
                            rightDeploys,
+                           List.empty,
                            baseCheckpoint.root,
                            rightCheckpoint.root,
                            historyRepo
                          )
             baseIndex <- BlockIndex(
                           ByteString.EMPTY,
+                          List.empty,
                           List.empty,
                           baseCheckpoint.root, // this does not matter
                           baseCheckpoint.root,

--- a/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
@@ -381,6 +381,7 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
                             BlockIndex(
                               b.blockHash,
                               b.body.deploys,
+                              b.body.systemDeploys,
                               Blake2b256Hash.fromByteString(b.body.state.preStateHash),
                               Blake2b256Hash.fromByteString(b.body.state.postStateHash),
                               runtimeManager.getHistoryRepo


### PR DESCRIPTION
## Overview
Current merging does not involve system deploys. It is required to perform epoch change and slashing. This PR adds ssystem deploys to index, so to conflict detection and merging.

Closing https://github.com/rchain/rchain/issues/3456

### Notes
Current optimal rejection policy involves cost to detect the cheapest branch to reject. For now all system deploys have zero cost for that purpose. 

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
