### PR TITLE
Migrate LFB from LastFinalisedStore to BlockDagStorage

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -258,7 +258,7 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
       errMsg = s"Attempting to finalize nonexistent hash ${PrettyPrinter.buildString(directlyFinalizedHash)}."
       _      <- dag.contains(directlyFinalizedHash).ifM(().pure, new Exception(errMsg).raiseError)
       // all non finalized ancestors should be finalized as well (indirectly)
-      indirectlyFinalized <- dag.withAncestors(directlyFinalizedHash, dag.isFinalized(_).not)
+      indirectlyFinalized <- dag.ancestors(directlyFinalizedHash, dag.isFinalized(_).not)
       // invoke effects
       _ <- finalizationEffect(indirectlyFinalized + directlyFinalizedHash)
       // persist finalization

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -15,11 +15,10 @@ trait BlockDagStorage[F[_]] {
       approved: Boolean = false
   ): F[BlockDagRepresentation[F]]
   def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A]
-  def recordDirectlyFinalised(blockHash: BlockHash): F[Unit]
-
-  /** As finalization advances in discrete chunks, batch of blocks are recorded as finalized at once,
-    * therefore List used here. */
-  def addFinalizedBlockHashes(hashes: List[BlockHash]): F[Unit]
+  def recordDirectlyFinalized(
+      direct: BlockHash,
+      finalizationEffect: Set[BlockHash] => F[Unit]
+  ): F[Unit]
 }
 
 object BlockDagStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -16,7 +16,10 @@ trait BlockDagStorage[F[_]] {
   ): F[BlockDagRepresentation[F]]
   def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A]
   def recordDirectlyFinalised(blockHash: BlockHash): F[Unit]
-  def addFinalizedBlockHash(blockHash: BlockHash): F[Unit]
+
+  /** As finalization advances in discrete chunks, batch of blocks are recorded as finalized at once,
+    * therefore List used here. */
+  def addFinalizedBlockHashes(hashes: List[BlockHash]): F[Unit]
 }
 
 object BlockDagStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -11,9 +11,11 @@ trait BlockDagStorage[F[_]] {
   def getRepresentation: F[BlockDagRepresentation[F]]
   def insert(
       block: BlockMessage,
-      invalid: Boolean
+      invalid: Boolean,
+      approved: Boolean = false
   ): F[BlockDagRepresentation[F]]
   def accessEquivocationsTracker[A](f: EquivocationsTracker[F] => F[A]): F[A]
+  def recordDirectlyFinalised(blockHash: BlockHash): F[Unit]
   def addFinalizedBlockHash(blockHash: BlockHash): F[Unit]
 }
 
@@ -37,6 +39,8 @@ trait BlockDagRepresentation[F[_]] {
       startBlockNumber: Long,
       maybeEndBlockNumber: Option[Long]
   ): F[Vector[Vector[BlockHash]]]
+  // DAG representation has to have finalized block, or it does not make sense
+  def lastFinalizedBlock: BlockHash
   def isFinalized(blockHash: BlockHash): F[Boolean]
 }
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedKeyValueStorage.scala
@@ -1,21 +1,24 @@
 package coop.rchain.blockstorage.finality
 
-import java.nio.file.Path
+import cats.Show
+import cats.effect.Sync
 import cats.syntax.all._
-import cats.effect.{Concurrent, Sync}
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.dag.codecs.{codecBlockHash, codecSeqNum}
-import coop.rchain.metrics.Metrics
+import coop.rchain.blockstorage.dag.BlockMetadataStore
+import coop.rchain.blockstorage.dag.codecs.{codecBlockHash, codecBlockMetadata, codecSeqNum}
+import coop.rchain.casper.PrettyPrinter
+import coop.rchain.dag.DagOps
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockMetadata
 import coop.rchain.shared.Log
-import coop.rchain.store.{KeyValueStore, KeyValueTypedStore}
 import coop.rchain.shared.syntax._
-import coop.rchain.blockstorage.syntax._
+import coop.rchain.store.{KeyValueStore, KeyValueStoreManager, KeyValueTypedStore}
 
 class LastFinalizedKeyValueStorage[F[_]: Sync] private (
     lastFinalizedBlockDb: KeyValueTypedStore[F, Int, BlockHash]
 ) extends LastFinalizedStorage[F] {
   val fixedKey = 1
+
   override def put(blockHash: BlockHash): F[Unit] =
     lastFinalizedBlockDb.put(Seq((fixedKey, blockHash)))
 
@@ -24,10 +27,68 @@ class LastFinalizedKeyValueStorage[F[_]: Sync] private (
 
   val DONE = ByteString.copyFrom(Array.fill[Byte](32)(-1))
 
-  def requireMigration: F[Boolean] =
-    get().map(_.exists(_ != DONE))
+  def requireMigration: F[Boolean] = get().map(_.exists(_ != DONE))
 
-  def recordMigrationDone: F[Unit] = put(DONE)
+  def migrateLfb(kvm: KeyValueStoreManager[F])(implicit log: Log[F]): F[Unit] = {
+    val errNoLfbInStorage   = "No LFB in LastFinalizedStorage when attempting migration."
+    val errNoMetadataForLfb = "No metadata found for LFB when attempting migration."
+
+    for {
+      blockMetadataDb <- kvm.database[BlockHash, BlockMetadata](
+                          "block-metadata",
+                          codecBlockHash,
+                          codecBlockMetadata
+                        )
+      // record LFB
+      lfb  <- get() >>= (_.liftTo(new Exception(errNoLfbInStorage)))
+      curV <- blockMetadataDb.get(lfb).flatMap(_.liftTo[F](new Exception(errNoMetadataForLfb)))
+      _    <- blockMetadataDb.put(lfb, curV.copy(directlyFinalized = true, finalized = true))
+      blocksInfoMap <- blockMetadataDb
+                        .collect {
+                          case (hash, metaData) =>
+                            (hash, BlockMetadataStore.blockMetadataToInfo(metaData()))
+                        }
+                        .map(_.toMap)
+      _ <- Log[F].info("Migration of LFB done.")
+
+      // record finalized blocks
+      finalizedBlockSet = DagOps
+        .bfTraverse(List(lfb)) { bh =>
+          blocksInfoMap.get(bh).map(_.parents.toList).getOrElse(List.empty)
+        }
+        .toList
+
+      processChunk = (chunk: List[BlockHash]) => {
+        implicit val s = new Show[BlockHash] {
+          override def show(t: BlockHash): String = PrettyPrinter.buildString(t)
+        }
+
+        for {
+          curVs <- blockMetadataDb.getUnsafeBatch(chunk)
+          // WARNING: migration should be done before block merge, as it assumes all blocks are directly finalized.
+          newVs = curVs.map(_.copy(directlyFinalized = true, finalized = true))
+          _     <- blockMetadataDb.put(newVs.map(v => (v.blockHash, v)))
+        } yield ()
+      }
+
+      chunkSize = 10000L
+      _ <- fs2.Stream
+            .fromIterator(finalizedBlockSet.grouped(chunkSize.toInt))
+            .evalMapAccumulate(0L)(
+              (processed, chunk) => {
+                val processSoFar = processed + chunk.size.toLong
+                processChunk(chunk) >> Log[F]
+                  .info(s"Finalized blocks recorded: ${processSoFar} of ${finalizedBlockSet.size}.")
+                  .as((processSoFar, ()))
+              }
+            )
+            .compile
+            .drain
+
+      // Mark migration as done
+      _ <- put(DONE)
+    } yield ()
+  }
 }
 
 object LastFinalizedKeyValueStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedKeyValueStorage.scala
@@ -24,10 +24,10 @@ class LastFinalizedKeyValueStorage[F[_]: Sync] private (
 
   val DONE = ByteString.copyFrom(Array.fill[Byte](32)(-1))
 
-  override def requireMigration: F[Boolean] =
+  def requireMigration: F[Boolean] =
     get().map(_.exists(_ != DONE))
 
-  override def recordMigrationDone: F[Unit] = put(DONE)
+  def recordMigrationDone: F[Unit] = put(DONE)
 }
 
 object LastFinalizedKeyValueStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
@@ -1,10 +1,9 @@
 package coop.rchain.blockstorage.finality
 
 import cats.Functor
+import cats.effect.Concurrent
 import cats.syntax.functor._
 import cats.syntax.option._
-import cats.effect.Concurrent
-import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.Cell
 

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
@@ -16,6 +16,10 @@ class LastFinalizedMemoryStorage[F[_]: Functor](
 
   override def get(): F[Option[BlockHash]] =
     lastFinalizedBlockHashState.read
+
+  override def requireMigration: F[Boolean] = ???
+
+  override def recordMigrationDone: F[Unit] = ???
 }
 
 object LastFinalizedMemoryStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedMemoryStorage.scala
@@ -16,10 +16,6 @@ class LastFinalizedMemoryStorage[F[_]: Functor](
 
   override def get(): F[Option[BlockHash]] =
     lastFinalizedBlockHashState.read
-
-  override def requireMigration: F[Boolean] = ???
-
-  override def recordMigrationDone: F[Unit] = ???
 }
 
 object LastFinalizedMemoryStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
@@ -6,10 +6,6 @@ import coop.rchain.models.BlockHash.BlockHash
 trait LastFinalizedStorage[F[_]] {
   def put(blockHash: BlockHash): F[Unit]
   def get(): F[Option[BlockHash]]
-
-  /** If LFB is migrated to BlockDagStorage metadata */
-  def requireMigration: F[Boolean]
-  def recordMigrationDone: F[Unit]
 }
 
 object LastFinalizedStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
@@ -6,6 +6,10 @@ import coop.rchain.models.BlockHash.BlockHash
 trait LastFinalizedStorage[F[_]] {
   def put(blockHash: BlockHash): F[Unit]
   def get(): F[Option[BlockHash]]
+
+  /** If LFB is migrated to BlockDagStorage metadata */
+  def requireMigration: F[Boolean]
+  def recordMigrationDone: F[Unit]
 }
 
 object LastFinalizedStorage {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedStorage.scala
@@ -1,6 +1,5 @@
 package coop.rchain.blockstorage.finality
 
-import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.models.BlockHash.BlockHash
 
 trait LastFinalizedStorage[F[_]] {

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
@@ -2,7 +2,6 @@ package coop.rchain
 
 import coop.rchain.blockstorage.{BlockStoreSyntax, ByteStringKVStoreSyntax}
 import coop.rchain.blockstorage.dag.BlockDagRepresentationSyntax
-import coop.rchain.blockstorage.finality.LastFinalizedStorageSyntax
 import coop.rchain.metrics.Metrics
 
 package object blockstorage {
@@ -18,4 +17,3 @@ trait AllSyntaxBlockStorage
     extends BlockStoreSyntax
     with BlockDagRepresentationSyntax
     with ByteStringKVStoreSyntax
-    with LastFinalizedStorageSyntax

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorageTest.scala
@@ -1,8 +1,10 @@
 package coop.rchain.blockstorage.dag
 
+import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.syntax._
+import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.metrics.Metrics
@@ -264,4 +266,76 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
       }
     }
   }
+
+  "recording of new directly finalized block" should "record finalized all non finalized ancestors of LFB" in
+    withDagStorage { storage =>
+      for {
+        _ <- storage.insert(genesis, false, true)
+        b1 = getRandomBlock(
+          setParentsHashList = List(genesis.blockHash).some,
+          setBlockNumber = 1L.some
+        )
+        _   <- storage.insert(b1, false)
+        b2  = getRandomBlock(setParentsHashList = List(b1.blockHash).some, setBlockNumber = 2L.some)
+        _   <- storage.insert(b2, false)
+        b3  = getRandomBlock(setParentsHashList = List(b2.blockHash).some, setBlockNumber = 3L.some)
+        _   <- storage.insert(b3, false)
+        b4  = getRandomBlock(setParentsHashList = List(b3.blockHash).some, setBlockNumber = 4L.some)
+        dag <- storage.insert(b4, false)
+
+        // only genesis is finalized
+        _ <- dag.lookupUnsafe(genesis.blockHash).map(_.finalized shouldBe true)
+        _ <- dag.isFinalized(genesis.blockHash).map(_ shouldBe true)
+        _ <- dag.isFinalized(b1.blockHash).map(_ shouldBe false)
+        _ <- dag.lookupUnsafe(b1.blockHash).map(_.finalized shouldBe false)
+        _ <- dag.isFinalized(b2.blockHash).map(_ shouldBe false)
+        _ <- dag.lookupUnsafe(b2.blockHash).map(_.finalized shouldBe false)
+        _ <- dag.isFinalized(b3.blockHash).map(_ shouldBe false)
+        _ <- dag.lookupUnsafe(b3.blockHash).map(_.finalized shouldBe false)
+        _ <- dag.isFinalized(b4.blockHash).map(_ shouldBe false)
+        _ <- dag.lookupUnsafe(b4.blockHash).map(_.finalized shouldBe false)
+
+        // record directly finalized block
+        effectsRef <- Ref.of[Task, Set[BlockHash]](Set.empty)
+        _          <- storage.recordDirectlyFinalized(b3.blockHash, effectsRef.set)
+        dag        <- storage.getRepresentation
+
+        // in mem DAG state should be correct
+        _ = dag.lastFinalizedBlock shouldBe b3.blockHash
+        _ <- dag.isFinalized(b1.blockHash).map(_ shouldBe true)
+        _ <- dag.isFinalized(b2.blockHash).map(_ shouldBe true)
+        _ <- dag.isFinalized(b3.blockHash).map(_ shouldBe true)
+        _ <- dag.isFinalized(b4.blockHash).map(_ shouldBe false)
+
+        // persisted state should be correct
+        _ <- dag
+              .lookupUnsafe(b1.blockHash)
+              .map(v => {
+                v.finalized shouldBe true
+                v.directlyFinalized shouldBe false
+              })
+        _ <- dag
+              .lookupUnsafe(b2.blockHash)
+              .map(v => {
+                v.finalized shouldBe true
+                v.directlyFinalized shouldBe false
+              })
+        _ <- dag
+              .lookupUnsafe(b3.blockHash)
+              .map(v => {
+                v.finalized shouldBe true
+                v.directlyFinalized shouldBe true
+              })
+        _ <- dag
+              .lookupUnsafe(b4.blockHash)
+              .map(v => {
+                v.finalized shouldBe false
+                v.directlyFinalized shouldBe false
+              })
+
+        // all finalized should be in set supplied for finalization effect
+        effects <- effectsRef.get
+        _       = effects shouldBe Set(b1, b2, b3).map(_.blockHash)
+      } yield ()
+    }
 }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -22,7 +22,11 @@ trait BlockDagStorageTest
 
   def withDagStorage[R](f: BlockDagStorage[Task] => Task[R]): R
 
-  val genesis = getRandomBlock(setBonds = Some(List.empty))
+  val genesis = getRandomBlock(
+    setBonds = Some(List.empty),
+    setParentsHashList = List.empty.some,
+    setBlockNumber = 0L.some
+  )
 
   "DAG Storage" should "be able to lookup a stored block" in {
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -1,5 +1,6 @@
 package coop.rchain.blockstorage.dag
 
+import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.syntax._
@@ -27,7 +28,7 @@ trait BlockDagStorageTest
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>
       withDagStorage { dagStorage =>
         for {
-          _   <- blockElements.traverse_(dagStorage.insert(_, false))
+          _   <- blockElements.traverse(dagStorage.insert(_, false))
           dag <- dagStorage.getRepresentation
           blockElementLookups <- blockElements.traverse { b =>
                                   for {
@@ -44,8 +45,8 @@ trait BlockDagStorageTest
               latestMessageHash shouldBe Some(b.blockHash)
               latestMessage shouldBe Some(BlockMetadata.fromBlock(b, false))
           }
-          _      = latestMessageHashes.size shouldBe blockElements.size
-          result = latestMessages.size shouldBe blockElements.size
+          _      = latestMessageHashes.size shouldBe blockElements.size + 1
+          result = latestMessages.size shouldBe blockElements.size + 1
         } yield ()
       }
     }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
@@ -69,11 +69,11 @@ final class IndexedBlockDagStorage[F[_]: Sync](
       underlying.accessEquivocationsTracker(f)
     )
 
-  def recordDirectlyFinalised(blockHash: BlockHash): F[Unit] =
-    lastFinalizedBlockRef.update(_ => blockHash)
-
-  def addFinalizedBlockHashes(hashes: List[BlockHash]): F[Unit] =
-    finalizedBlockHashRef.update(_ ++ hashes)
+  def recordDirectlyFinalized(
+      blockHash: BlockHash,
+      finalizationEffect: Set[BlockHash] => F[Unit]
+  ): F[Unit] =
+    underlying.recordDirectlyFinalized(blockHash, finalizationEffect)
 
   def lookupById(id: Int): F[Option[BlockMessage]] =
     idToBlocksRef.get.map(_.get(id.toLong))

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
@@ -72,8 +72,8 @@ final class IndexedBlockDagStorage[F[_]: Sync](
   def recordDirectlyFinalised(blockHash: BlockHash): F[Unit] =
     lastFinalizedBlockRef.update(_ => blockHash)
 
-  def addFinalizedBlockHash(blockHash: BlockHash): F[Unit] =
-    finalizedBlockHashRef.update(_ + blockHash)
+  def addFinalizedBlockHashes(hashes: List[BlockHash]): F[Unit] =
+    finalizedBlockHashRef.update(_ ++ hashes)
 
   def lookupById(id: Int): F[Option[BlockMessage]] =
     idToBlocksRef.get.map(_.get(id.toLong))

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/IndexedBlockDagStorage.scala
@@ -3,6 +3,7 @@ package coop.rchain.blockstorage.dag
 import cats.effect.concurrent.{Ref, Semaphore}
 import cats.effect.{Concurrent, Sync}
 import cats.implicits._
+import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStorageMetricsSource
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol.BlockMessage
@@ -16,6 +17,7 @@ final class IndexedBlockDagStorage[F[_]: Sync](
     underlying: BlockDagStorage[F],
     idToBlocksRef: Ref[F, Map[Long, BlockMessage]],
     currentIdRef: Ref[F, Long],
+    lastFinalizedBlockRef: Ref[F, BlockHash],
     finalizedBlockHashRef: Ref[F, Set[BlockHash]]
 ) extends BlockDagStorage[F] {
 
@@ -26,14 +28,16 @@ final class IndexedBlockDagStorage[F[_]: Sync](
 
   def insert(
       block: BlockMessage,
-      invalid: Boolean
+      invalid: Boolean,
+      approved: Boolean
   ): F[BlockDagRepresentation[F]] =
     lock.withPermit(
-      underlying.insert(block, invalid) >> underlying.getRepresentation
+      underlying.insert(block, invalid, approved)
     )
 
   def insertIndexed(block: BlockMessage, genesis: BlockMessage, invalid: Boolean): F[BlockMessage] =
     lock.withPermit(for {
+      _         <- underlying.insert(genesis, invalid = false, approved = true)
       currentId <- currentIdRef.get
       dag       <- underlying.getRepresentation
       nextCreatorSeqNum <- if (block.seqNum == 0)
@@ -65,6 +69,9 @@ final class IndexedBlockDagStorage[F[_]: Sync](
       underlying.accessEquivocationsTracker(f)
     )
 
+  def recordDirectlyFinalised(blockHash: BlockHash): F[Unit] =
+    lastFinalizedBlockRef.update(_ => blockHash)
+
   def addFinalizedBlockHash(blockHash: BlockHash): F[Unit] =
     finalizedBlockHashRef.update(_ + blockHash)
 
@@ -89,11 +96,13 @@ object IndexedBlockDagStorage {
       idToBlocks         <- Ref.of[F, Map[Long, BlockMessage]](Map.empty)
       currentId          <- Ref.of[F, Long](-1L)
       finalizedBlockHash <- Ref.of[F, Set[BlockHash]](Set.empty)
+      lastDinalizedBlock <- Ref.of[F, BlockHash](ByteString.EMPTY)
     } yield new IndexedBlockDagStorage[F](
       semaphore,
       underlying,
       idToBlocks,
       currentId,
+      lastDinalizedBlock,
       finalizedBlockHash
     )
 }

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -9,7 +9,6 @@ import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
 import coop.rchain.blockstorage.deploy.DeployStorage
-import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.engine.{BlockRetriever, Running}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.syntax._
@@ -135,7 +134,7 @@ sealed abstract class MultiParentCasperInstances {
   implicit val MetricsSource: Metrics.Source =
     Metrics.Source(CasperMetricsSource, "casper")
 
-  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: CommUtil: Log: Time: SafetyOracle: BlockStore: BlockDagStorage: LastFinalizedStorage: Span: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockRetriever](
+  def hashSetCasper[F[_]: Sync: Metrics: Concurrent: CommUtil: Log: Time: SafetyOracle: BlockStore: BlockDagStorage: Span: EventPublisher: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker: Estimator: DeployStorage: CasperBufferStorage: BlockRetriever](
       validatorId: Option[ValidatorIdentity],
       casperShardConf: CasperShardConf,
       approvedBlock: BlockMessage

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -7,7 +7,6 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.blockstorage.deploy.DeployStorage
-import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.engine.BlockRetriever
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.syntax._
@@ -159,7 +158,7 @@ object Proposer {
   def apply[F[_]
     /* Execution */   : Concurrent: Time
     /* Casper */      : Estimator: SynchronyConstraintChecker: LastFinalizedHeightConstraintChecker
-    /* Storage */     : BlockStore: BlockDagStorage: LastFinalizedStorage: DeployStorage
+    /* Storage */     : BlockStore: BlockDagStorage: DeployStorage
     /* Diagnostics */ : Log: Span: Metrics: EventPublisher
     /* Comm */        : CommUtil: BlockRetriever
   ] // format: on

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -10,7 +10,6 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.blockstorage.deploy.DeployStorage
-import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.blockstorage.util.io.IOError.RaiseIOError
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
@@ -41,7 +40,7 @@ object CasperLaunch {
     /* State */       : EnvVars: EngineCell: RPConfAsk: ConnectionsCell: LastApprovedBlock
     /* Rholang */     : RuntimeManager
     /* Casper */      : Estimator: SafetyOracle: LastFinalizedHeightConstraintChecker: SynchronyConstraintChecker
-    /* Storage */     : BlockStore: BlockDagStorage: LastFinalizedStorage: DeployStorage: CasperBufferStorage: RSpaceStateManager
+    /* Storage */     : BlockStore: BlockDagStorage: DeployStorage: CasperBufferStorage: RSpaceStateManager
     /* Diagnostics */ : Log: EventLog: Metrics: Span] // format: on
   (
       blockProcessingQueue: Queue[F, (Casper[F], BlockMessage)],

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -117,10 +117,6 @@ object Engine {
         init,
         disableStateExporter
       )
-      // this is required because before https://github.com/rchain/rchain/pull/3459 genesis as not added to
-      // last finalized storage on network init.
-      _ <- BlockDagStorage[F]
-            .recordDirectlyFinalized(approvedBlock.candidate.block.blockHash, _ => ().pure[F])
       _ <- EngineCell[F].set(running)
 
     } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -119,8 +119,8 @@ object Engine {
       )
       // this is required because before https://github.com/rchain/rchain/pull/3459 genesis as not added to
       // last finalized storage on network init.
-      _ <- BlockDagStorage[F].recordDirectlyFinalised(approvedBlock.candidate.block.blockHash)
-      _ <- BlockDagStorage[F].addFinalizedBlockHashes(List(approvedBlock.candidate.block.blockHash))
+      _ <- BlockDagStorage[F]
+            .recordDirectlyFinalized(approvedBlock.candidate.block.blockHash, _ => ().pure[F])
       _ <- EngineCell[F].set(running)
 
     } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -21,7 +21,6 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.blockstorage.deploy.DeployStorage
-import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.state.RNodeStateManager
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.models.BlockHash.BlockHash
@@ -67,7 +66,7 @@ object Engine {
   ): F[Unit] =
     for {
       _ <- BlockStore[F].put(genesis.blockHash, genesis)
-      _ <- BlockDagStorage[F].insert(genesis, invalid = false)
+      _ <- BlockDagStorage[F].insert(genesis, invalid = false, approved = true)
       _ <- BlockStore[F].putApprovedBlock(approvedBlock)
     } yield ()
 
@@ -90,7 +89,7 @@ object Engine {
     /* Execution */   : Concurrent: Time
     /* Transport */   : TransportLayer: CommUtil: BlockRetriever: EventPublisher
     /* State */       : EngineCell: RPConfAsk: ConnectionsCell
-    /* Storage */     : BlockStore: LastFinalizedStorage: CasperBufferStorage: RSpaceStateManager
+    /* Storage */     : BlockStore: BlockDagStorage: CasperBufferStorage: RSpaceStateManager
     /* Diagnostics */ : Log: EventLog: Metrics] // format: on
   (
       blockProcessingQueue: Queue[F, (Casper[F], BlockMessage)],
@@ -130,7 +129,7 @@ object Engine {
     /* State */       : EngineCell: RPConfAsk: ConnectionsCell: LastApprovedBlock
     /* Rholang */     : RuntimeManager
     /* Casper */      : Estimator: SafetyOracle: LastFinalizedHeightConstraintChecker: SynchronyConstraintChecker
-    /* Storage */     : BlockStore: BlockDagStorage: LastFinalizedStorage: DeployStorage: CasperBufferStorage: RSpaceStateManager
+    /* Storage */     : BlockStore: BlockDagStorage: DeployStorage: CasperBufferStorage: RSpaceStateManager
     /* Diagnostics */ : Log: EventLog: Metrics: Span] // format: on
   (
       blockProcessingQueue: Queue[F, (Casper[F], BlockMessage)],

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -117,6 +117,9 @@ object Engine {
         init,
         disableStateExporter
       )
+      // this is required because before https://github.com/rchain/rchain/pull/3459 genesis as not added to
+      // last finalized storage on network init.
+      _ <- BlockDagStorage[F].recordDirectlyFinalised(approvedBlock.candidate.block.blockHash)
       _ <- EngineCell[F].set(running)
 
     } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -120,6 +120,7 @@ object Engine {
       // this is required because before https://github.com/rchain/rchain/pull/3459 genesis as not added to
       // last finalized storage on network init.
       _ <- BlockDagStorage[F].recordDirectlyFinalised(approvedBlock.candidate.block.blockHash)
+      _ <- BlockDagStorage[F].addFinalizedBlockHashes(List(approvedBlock.candidate.block.blockHash))
       _ <- EngineCell[F].set(running)
 
     } yield ()

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -8,7 +8,6 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.blockstorage.deploy.DeployStorage
-import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
 import coop.rchain.casper.engine.EngineCell._
@@ -53,7 +52,7 @@ object GenesisCeremonyMaster {
     /* State */       : EngineCell: RPConfAsk: ConnectionsCell: LastApprovedBlock
     /* Rholang */     : RuntimeManager
     /* Casper */      : Estimator: SafetyOracle: LastFinalizedHeightConstraintChecker: SynchronyConstraintChecker
-    /* Storage */     : BlockStore: BlockDagStorage: LastFinalizedStorage: DeployStorage: CasperBufferStorage: RSpaceStateManager
+    /* Storage */     : BlockStore: BlockDagStorage: DeployStorage: CasperBufferStorage: RSpaceStateManager
     /* Diagnostics */ : Log: EventLog: Metrics: Span] // format: on
   (
       blockProcessingQueue: Queue[F, (Casper[F], BlockMessage)],

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisValidator.scala
@@ -7,7 +7,6 @@ import cats.implicits._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.blockstorage.deploy.DeployStorage
-import coop.rchain.blockstorage.finality.LastFinalizedStorage
 import coop.rchain.casper.LastApprovedBlock.LastApprovedBlock
 import coop.rchain.casper._
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
@@ -31,7 +30,7 @@ class GenesisValidator[F[_]
   /* State */       : EngineCell: RPConfAsk: ConnectionsCell: LastApprovedBlock
   /* Rholang */     : RuntimeManager
   /* Casper */      : Estimator: SafetyOracle: LastFinalizedHeightConstraintChecker: SynchronyConstraintChecker
-  /* Storage */     : BlockStore: BlockDagStorage: LastFinalizedStorage: DeployStorage: CasperBufferStorage: RSpaceStateManager
+  /* Storage */     : BlockStore: BlockDagStorage: DeployStorage: CasperBufferStorage: RSpaceStateManager
   /* Diagnostics */ : Log: EventLog: Metrics: Span] // format: on
 (
     blockProcessingQueue: Queue[F, (Casper[F], BlockMessage)],

--- a/casper/src/main/scala/coop/rchain/casper/finality/Finalizer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/finality/Finalizer.scala
@@ -93,7 +93,7 @@ object Finalizer {
       faultToleranceThreshold: Float,
       currLFBHeight: Long,
       newLfbEffect: BlockHash => F[Unit],
-      finalisationEffect: BlockHash => F[Unit]
+      finalisationEffect: Set[BlockHash] => F[Unit]
   ): F[Option[BlockHash]] = {
 
     /**
@@ -182,7 +182,7 @@ object Finalizer {
           case (lfb, _) =>
             dag
               .withAncestors(lfb.blockHash, dag.isFinalized(_).not)
-              .flatMap(_.toList.reverse.traverse(finalisationEffect)) >>
+              .flatMap(finalisationEffect) >>
               newLfbEffect(lfb.blockHash).as(lfb.blockHash)
         }
         .compile

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -275,7 +275,7 @@ class BlockQueryResponseAPITest
   ): Task[(LogStub[Task], EngineCell[Task], SafetyOracle[Task])] =
     runtimeManagerResource.use { implicit runtimeManager =>
       for {
-        _ <- blockDagStorage.insert(genesisBlock, false)
+        _ <- blockDagStorage.insert(genesisBlock, false, approved = true)
         _ <- blockDagStorage.insert(secondBlock, false)
         casperEffect <- NoOpsCasperEffect[Task](
                          HashMap[BlockHash, BlockMessage](
@@ -304,6 +304,7 @@ class BlockQueryResponseAPITest
                            (secondBlock.blockHash, secondBlock)
                          )
                        )(Sync[Task], blockStore, blockDagStorage, runtimeManager)
+        _          <- blockDagStorage.insert(genesisBlock, invalid = false, approved = true)
         logEff     = new LogStub[Task]()
         metricsEff = new Metrics.MetricsNOP[Task]
         engine     = new EngineWithCasper[Task](casperEffect)

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -47,6 +47,8 @@ class BlocksResponseAPITest
   ) =
     for {
       genesis <- createGenesis[Task](bonds = bonds)
+      _       <- dagstore.insert(genesis, invalid = false, approved = true)
+      _       <- blockstore.put(genesis)
       b2 <- createBlock[Task](
              Seq(genesis.blockHash),
              genesis,

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MergeabilityRules.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MergeabilityRules.scala
@@ -406,7 +406,7 @@ trait MergeabilityRules {
               setPostStateHash = ByteString.copyFrom(leftCheckpoint.root.bytes.toArray).some,
               setParentsHashList = List(bBlock.blockHash).some
             )
-            _   <- dagStore.insert(bBlock, false)
+            _   <- dagStore.insert(bBlock, false, approved = true)
             _   <- dagStore.insert(lBlock, false)
             _   <- dagStore.insert(rBlock, false)
             dag <- dagStore.getRepresentation

--- a/casper/src/test/scala/coop/rchain/casper/batch2/FinalizerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/FinalizerTest.scala
@@ -91,7 +91,7 @@ class FinalizerTest extends FlatSpec with Matchers with BlockGenerator with Bloc
                 faultToleranceThreshold = -1,
                 currLFBHeight = 0L,
                 m => (lfbStore = m).pure[Task],
-                m => finalisedStore.update(v => v + m)
+                m => finalisedStore.update(v => v ++ m)
               )
         // check output
         _ = lfb.get shouldBe b1.blockHash
@@ -139,7 +139,7 @@ class FinalizerTest extends FlatSpec with Matchers with BlockGenerator with Bloc
                 faultToleranceThreshold = -1,
                 currLFBHeight = 0L,
                 m => (lfbStore = m).pure[Task],
-                m => finalisedStore.update(v => v + m)
+                m => finalisedStore.update(v => v ++ m)
               )
         // check output
         _ = lfb shouldBe Some(b7.blockHash)

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -769,6 +769,7 @@ class ValidateTest
       val storageDirectory = Files.createTempDirectory(s"hash-set-casper-test-genesis-")
 
       for {
+        _                                 <- blockDagStorage.insert(genesis, false, approved = true)
         kvm                               <- mkTestRNodeStoreManager[Task](storageDirectory)
         store                             <- kvm.rSpaceStores
         runtimes                          <- RhoRuntime.createRuntimes[Task](store)
@@ -793,6 +794,7 @@ class ValidateTest
       val context  = buildGenesis()
       val (sk, pk) = context.validatorKeyPairs.head
       for {
+        _                <- blockDagStorage.insert(genesis, false, approved = true)
         dag              <- blockDagStorage.getRepresentation
         sender           = ByteString.copyFrom(pk.bytes)
         latestMessageOpt <- dag.latestMessage(sender)
@@ -819,6 +821,7 @@ class ValidateTest
       val (sk, pk) = context.validatorKeyPairs.head
       val sender   = ByteString.copyFrom(pk.bytes)
       for {
+        _                <- blockDagStorage.insert(genesis, false, approved = true)
         dag              <- blockDagStorage.getRepresentation
         latestMessageOpt <- dag.latestMessage(sender)
         seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
@@ -836,6 +839,7 @@ class ValidateTest
     val (sk, pk) = context.validatorKeyPairs.head
     val sender   = ByteString.copyFrom(pk.bytes)
     for {
+      _                <- blockDagStorage.insert(genesis, false, approved = true)
       dag              <- blockDagStorage.getRepresentation
       latestMessageOpt <- dag.latestMessage(sender)
       seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
@@ -27,7 +27,8 @@ class RunningSpec extends WordSpec with BeforeAndAfterEach with Matchers {
     transportLayer.reset()
 
   "Running state" should {
-    val genesis                = GenesisBuilder.createGenesis()
+    val genesis = GenesisBuilder.createGenesis()
+    blockDagStorage.insert(genesis, false, approved = true).runSyncUnsafe()
     val approvedBlockCandidate = ApprovedBlockCandidate(block = genesis, requiredSigs = 0)
     val approvedBlock: ApprovedBlock = ApprovedBlock(
       candidate = approvedBlockCandidate,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -199,6 +199,7 @@ class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDag
           implicit val logEff = log
           for {
             genesis <- fromInputFiles()(runtimeManager, genesisPath, log, time)
+            _       <- blockDagStorage.insert(genesis, false, approved = true)
             _       <- BlockStore[Task].put(genesis.blockHash, genesis)
             dag     <- blockDagStorage.getRepresentation
             maybePostGenesisStateHash <- InterpreterUtil

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -8,7 +8,7 @@ import coop.rchain.blockstorage.dag.{
   BlockDagStorage,
   IndexedBlockDagStorage
 }
-import coop.rchain.casper.util.GenesisBuilder.GenesisContext
+import coop.rchain.casper.util.GenesisBuilder.{createGenesis, GenesisContext}
 import coop.rchain.casper.util.rholang.{Resources, RuntimeManager}
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.metrics.Metrics
@@ -18,8 +18,8 @@ import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.{BeforeAndAfter, Suite}
-import java.nio.file.{Files, Path}
 
+import java.nio.file.{Files, Path}
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager
 
 trait BlockDagStorageFixture extends BeforeAndAfter { self: Suite =>

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -151,7 +151,7 @@ object GenesisBuilder {
       blockStore                   <- KeyValueBlockStore[Task](kvsManager)
       _                            <- blockStore.put(genesis.blockHash, genesis)
       blockDagStorage              <- BlockDagKeyValueStorage.create[Task](kvsManager)
-      _                            <- blockDagStorage.insert(genesis, invalid = false)
+      _                            <- blockDagStorage.insert(genesis, invalid = false, approved = true)
     } yield GenesisContext(genesis, validavalidatorKeyPairs, genesisVaults, storageDirectory)).unsafeRunSync
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
@@ -356,7 +356,7 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
               setParentsHashList = List().some,
               setDeploys = b._2.some
             )
-            _ <- dagStore.insert(base, false)
+            _ <- dagStore.insert(base, false, approved = true)
 
             // create children an all other
             baseChildren <- mkTailStates(b._1, n * 2 + 2, (n * 2 + 2).toLong)

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
@@ -387,7 +387,7 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
                         )
                         .map(_.toMap)
 
-            _   <- dagStore.addFinalizedBlockHash(base.blockHash)
+            _   <- dagStore.addFinalizedBlockHashes(List(base.blockHash))
             dag <- dagStore.getRepresentation
             // merge children to get next preStateHash
             v <- DagMerger.merge[Task](

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/MergingBranchMergerSpec.scala
@@ -387,7 +387,7 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
                         )
                         .map(_.toMap)
 
-            _   <- dagStore.addFinalizedBlockHashes(List(base.blockHash))
+            _   <- dagStore.recordDirectlyFinalized(base.blockHash, _ => ().pure[Task])
             dag <- dagStore.getRepresentation
             // merge children to get next preStateHash
             v <- DagMerger.merge[Task](

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -145,6 +145,8 @@ object Resources {
       override def isFinalized(blockHash: BlockHash): F[Boolean] = ???
 
       override def children(vertex: BlockHash): F[Option[Set[BlockHash]]] = ???
+
+      override def lastFinalizedBlock: BlockHash = ???
     }
     CasperSnapshot[F](
       dummyRepresentation,

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -119,6 +119,7 @@ message BlockMetadataInternal {
   int64 blockNum                        = 6;
   int32 seqNum                          = 7;
   bool invalid                          = 8; // whether the block was marked as invalid
+  bool directlyFinalized              = 9;
 }
 
 message HeaderProto {

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -119,7 +119,8 @@ message BlockMetadataInternal {
   int64 blockNum                        = 6;
   int32 seqNum                          = 7;
   bool invalid                          = 8; // whether the block was marked as invalid
-  bool directlyFinalized              = 9;
+  bool directlyFinalized                = 9; // whether the block has been last finalized block (LFB)
+  bool finalized                        = 10;// whether the block is finalized
 }
 
 message HeaderProto {

--- a/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
@@ -13,7 +13,8 @@ final case class BlockMetadata(
     blockNum: Long,
     seqNum: Int,
     invalid: Boolean,
-    directlyFinalized: Boolean
+    directlyFinalized: Boolean,
+    finalized: Boolean
 ) {
   def toByteString = BlockMetadata.typeMapper.toBase(this).toByteString
 }
@@ -29,7 +30,8 @@ object BlockMetadata {
       internal.blockNum,
       internal.seqNum,
       internal.invalid,
-      internal.directlyFinalized
+      internal.directlyFinalized,
+      internal.finalized
     )
   } { metadata =>
     BlockMetadataInternal(
@@ -41,7 +43,8 @@ object BlockMetadata {
       metadata.blockNum,
       metadata.seqNum,
       metadata.invalid,
-      metadata.directlyFinalized
+      metadata.directlyFinalized,
+      metadata.finalized
     )
   }
 
@@ -67,7 +70,8 @@ object BlockMetadata {
   def fromBlock(
       b: BlockMessage,
       invalid: Boolean,
-      directlyFinalized: Boolean = false
+      directlyFinalized: Boolean = false,
+      finalized: Boolean = false
   ): BlockMetadata =
     BlockMetadata(
       b.blockHash,
@@ -79,6 +83,7 @@ object BlockMetadata {
       b.seqNum,
       invalid,
       // this value is not used anywhere down the call pipeline, so its safe to set it to false
-      directlyFinalized
+      directlyFinalized,
+      finalized
     )
 }

--- a/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
@@ -12,7 +12,8 @@ final case class BlockMetadata(
     weightMap: Map[ByteString, Long],
     blockNum: Long,
     seqNum: Int,
-    invalid: Boolean
+    invalid: Boolean,
+    directlyFinalized: Boolean
 ) {
   def toByteString = BlockMetadata.typeMapper.toBase(this).toByteString
 }
@@ -27,7 +28,8 @@ object BlockMetadata {
       internal.bonds.map(b => b.validator -> b.stake).toMap,
       internal.blockNum,
       internal.seqNum,
-      internal.invalid
+      internal.invalid,
+      internal.directlyFinalized
     )
   } { metadata =>
     BlockMetadataInternal(
@@ -38,7 +40,8 @@ object BlockMetadata {
       metadata.weightMap.map { case (validator, stake) => BondProto(validator, stake) }.toList,
       metadata.blockNum,
       metadata.seqNum,
-      metadata.invalid
+      metadata.invalid,
+      metadata.directlyFinalized
     )
   }
 
@@ -61,7 +64,11 @@ object BlockMetadata {
       case Bond(validator, stake) => validator -> stake
     }.toMap
 
-  def fromBlock(b: BlockMessage, invalid: Boolean): BlockMetadata =
+  def fromBlock(
+      b: BlockMessage,
+      invalid: Boolean,
+      directlyFinalized: Boolean = false
+  ): BlockMetadata =
     BlockMetadata(
       b.blockHash,
       b.header.parentsHashList,
@@ -70,6 +77,8 @@ object BlockMetadata {
       weightMap(b.body.state),
       b.body.state.blockNumber,
       b.seqNum,
-      invalid
+      invalid,
+      // this value is not used anywhere down the call pipeline, so its safe to set it to false
+      directlyFinalized
     )
 }

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
@@ -62,10 +62,9 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
   implicit private val logSource: LogSource = LogSource(this.getClass)
 
   /** Configuration */
-  private val dataDir                  = nodeConf.storage.dataDir
-  private val blockstorePath           = dataDir.resolve("blockstore")
-  private val deployStoragePath        = dataDir.resolve("deploystorage")
-  private val lastFinalizedStoragePath = dataDir.resolve("last-finalized-block")
+  private val dataDir           = nodeConf.storage.dataDir
+  private val blockstorePath    = dataDir.resolve("blockstore")
+  private val deployStoragePath = dataDir.resolve("deploystorage")
 
   /**
     * Main node entry. It will:
@@ -172,7 +171,6 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
           blockRetriever,
           nodeConf,
           blockstorePath,
-          lastFinalizedStoragePath,
           eventBus,
           deployStorageConfig
         )

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -125,7 +125,7 @@ object Setup {
 
       // Migrate LastFinalizedStorage to BlockDagStorage
       lfbMigration = Log[F].info("Migrating LastFinalizedStorage to BlockDagStorage.") *>
-        lastFinalizedStorage.migrateLfb(rnodeStoreManager)
+        lastFinalizedStorage.migrateLfb(rnodeStoreManager, blockStore)
       // Check if LFB is already migrated
       lfbRequireMigration <- lastFinalizedStorage.requireMigration
       _                   <- lfbMigration.whenA(lfbRequireMigration)

--- a/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreSyntax.scala
@@ -1,6 +1,6 @@
 package coop.rchain.store
 
-import cats.Functor
+import cats.{Functor, Show}
 import cats.effect.Sync
 import cats.syntax.all._
 
@@ -14,15 +14,20 @@ final class KeyValueTypedStoreOps[F[_], K, V](
     // KeyValueTypedStore extensions / syntax
     private val store: KeyValueTypedStore[F, K, V]
 ) extends AnyVal {
-  def errKVStoreExpectValue = "Error when reading from KeyValueStore: value not found."
+  def errKVStoreExpectValue(hash: String) =
+    s"Error when unsafe reading from KeyValueStore: value for key ${hash} not found."
 
   def get(key: K)(implicit f: Functor[F]): F[Option[V]] = store.get(Seq(key)).map(_.head)
 
-  def getUnsafe(keys: Seq[K])(implicit f: Sync[F]): F[List[V]] =
-    store.get(keys).flatMap(_.toList.traverse(_.liftTo[F](new Exception(errKVStoreExpectValue))))
+  def getUnsafeBatch(keys: Seq[K])(implicit f: Sync[F], show: Show[K]): F[List[V]] =
+    store
+      .get(keys)
+      .flatMap(_.zip(keys).toList.traverse {
+        case (vOpt, key) => vOpt.liftTo[F](new Exception(errKVStoreExpectValue(key.show)))
+      })
 
-  def getUnsafe(key: K)(implicit f: Sync[F]): F[V] =
-    get(key).flatMap(_.liftTo[F](new Exception(errKVStoreExpectValue)))
+  def getUnsafe(key: K)(implicit f: Sync[F], show: Show[K]): F[V] =
+    get(key).flatMap(_.liftTo[F](new Exception(errKVStoreExpectValue(key.show))))
 
   def put(key: K, value: V): F[Unit] = store.put(Seq((key, value)))
 


### PR DESCRIPTION
## Overview
Currently there is a single key value storage for last finalised block. 

Given https://github.com/rchain/rchain/pull/3439, Last Finalised Block is necessary part of DAG representation, therefore it should be stored in BlockMetadata. Also we should record at least two last directly finalised blocks (preferably all of them) to detect when finalised deploy cannot be rejected by merge. 

This PR is part of https://github.com/rchain/rchain/pull/3439 that belongs to dev. 
It introduces migration and deprecates LastFinaizedStorage. In addition, flag `finalized` is introduced for BlockMetadata to mark indirect finalization.

**Migration logic is the following:** 
- read last finalized record from LastFinaizedStorage, update BlockMetadata for this hash. 
- In addition - collect all ancestors and mark them as finalized **and directlyiFinalized** (this is because current networks are single parent, so all blocks are supposed to be finalized directly). This processing is done in chunks - chunk of blocks is read from metadata storage, updated and then put back.

**Performance results**
Full main net DAG storage contains 880155 blocks, size of 7.8 Gb
batch size 1000 => 10 min
```
07:45:46.579 [INFO ] [main                ] [c.rchain.node.runtime.Setup$ ] - Migrating LastFinalizedStorage to BlockDagStorage.
07:46:02.439 [INFO ] [main                ] [.b.d.BlockDagKeyValueStorage$] - Migration of LFB done.
07:46:04.616 [INFO ] [node-runner-30      ] [.b.d.BlockDagKeyValueStorage$] - Finalized blocks recorded: 1000 of 880155.
....
07:56:00.780 [INFO ] [node-runner-31      ] [.b.d.BlockDagKeyValueStorage$] - Finalized blocks recorded: 880155 of 880155.
```

for batch size 10000 => 6 min
```
08:00:30.338 [INFO ] [main                ] [c.rchain.node.runtime.Setup$ ] - Migrating LastFinalizedStorage to BlockDagStorage.
08:00:45.994 [INFO ] [main                ] [.b.d.BlockDagKeyValueStorage$] - Migration of LFB done.
08:00:50.571 [INFO ] [node-runner-29      ] [.b.d.BlockDagKeyValueStorage$] - Finalized blocks recorded: 10000 of 880188.
...
08:07:08.876 [INFO ] [node-runner-30      ] [.b.d.BlockDagKeyValueStorage$] - Finalized blocks recorded: 880188 of 880188.
```

Looks like 10k blocks (about 100MB chunk) is a reasonable size.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
