### PR TITLE
Fix genesis blockhash validation bug

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -436,7 +436,7 @@ object Validate {
 
   // TODO: Double check this validation isn't shadowed by the blockSignature validation
   def blockHash[F[_]: Applicative: Log](b: BlockMessage): F[ValidBlockProcessing] = {
-    val blockHashComputed = ProtoUtil.hashSignedBlock(b)
+    val blockHashComputed = ProtoUtil.hashBlock(b)
     if (b.blockHash == blockHashComputed)
       BlockStatus.valid.asRight[BlockError].pure
     else {

--- a/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ValidatorIdentity.scala
@@ -33,7 +33,7 @@ final case class ValidatorIdentity(
     // Hash should include sigAlgorithm and sender
     val b = block.copy(sigAlgorithm = sigAlgorithm, sender = sender)
 
-    val blockHash = ProtoUtil.hashSignedBlock(b)
+    val blockHash = ProtoUtil.hashBlock(b)
 
     val sig = signature(blockHash.toByteArray).sig
 

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -137,6 +137,7 @@ object BlockCreator {
                 _             <- Span[F].mark("before-packing-block")
                 shardId       = s.onChainState.shardConf.shardName
                 casperVersion = s.onChainState.shardConf.casperVersion
+                // unsignedBlock got blockHash(hashed without signature)
                 unsignedBlock = packageBlock(
                   blockData,
                   parents.map(_.blockHash),
@@ -150,7 +151,9 @@ object BlockCreator {
                   shardId,
                   casperVersion
                 )
-                _           <- Span[F].mark("block-created")
+                _ <- Span[F].mark("block-created")
+                // signedBlock add signature and replace hashed-without-signature
+                // blockHash to hashed-with-signature blockHash
                 signedBlock = validatorIdentity.signBlock(unsignedBlock)
                 _           <- Span[F].mark("block-signed")
               } yield BlockCreatorResult.created(signedBlock)

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -68,7 +68,7 @@ object Genesis {
     )
 
     runtimeManager
-      .computeGenesis(blessedTerms, timestamp)
+      .computeGenesis(blessedTerms, timestamp, genesis.blockNumber)
       .map {
         case (startHash, stateHash, processedDeploys) =>
           createProcessedDeploy(genesis, startHash, stateHash, processedDeploys)

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -278,12 +278,12 @@ object ProtoUtil {
       extraBytes = ByteString.EMPTY
     )
 
-    val hash = hashSignedBlock(block)
+    val hash = hashBlock(block)
 
     block.copy(blockHash = hash)
   }
 
-  def hashSignedBlock(blockMessage: BlockMessage): BlockHash =
+  def hashBlock(blockMessage: BlockMessage): BlockHash =
     ProtoUtil.hashByteArrays(
       blockMessage.header.toProto.toByteArray,
       blockMessage.body.toProto.toByteArray,

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -278,16 +278,9 @@ object ProtoUtil {
       extraBytes = ByteString.EMPTY
     )
 
-    val hash = hashUnsignedBlock(block)
+    val hash = hashSignedBlock(block)
 
     block.copy(blockHash = hash)
-  }
-
-  def hashUnsignedBlock(blockMessage: BlockMessage): BlockHash = {
-    val toHash = blockMessage.header.toProto.toByteArray +: blockMessage.justifications.map(
-      _.toProto.toByteArray
-    )
-    hashByteArrays(toHash: _*)
   }
 
   def hashSignedBlock(blockMessage: BlockMessage): BlockHash =

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/CasperRhoRuntimeSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/CasperRhoRuntimeSyntax.scala
@@ -220,12 +220,13 @@ final class RhoRuntimeOps[F[_]: Sync: Span: Log](
 
   def computeGenesis(
       terms: Seq[Signed[DeployData]],
-      blockTime: Long
+      blockTime: Long,
+      blockNumber: Long
   ): F[(StateHash, StateHash, Seq[ProcessedDeploy])] =
     Span[F].traceI("compute-genesis") {
       for {
         _ <- runtime.setBlockData(
-              BlockData(blockTime, 0, PublicKey(Array[Byte]()), 0)
+              BlockData(blockTime, blockNumber, PublicKey(Array[Byte]()), 0)
             )
         genesisPreStateHash <- emptyStateHash
         evalResult          <- processDeploys(genesisPreStateHash, terms, processDeploy)

--- a/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/rholang/RuntimeManager.scala
@@ -54,7 +54,8 @@ trait RuntimeManager[F[_]] {
   ): F[(StateHash, Seq[ProcessedDeploy], Seq[ProcessedSystemDeploy])]
   def computeGenesis(
       terms: Seq[Signed[DeployData]],
-      blockTime: Long
+      blockTime: Long,
+      blockNumber: Long
   ): F[(StateHash, StateHash, Seq[ProcessedDeploy])]
   def computeBonds(startHash: StateHash): F[Seq[Bond]]
   def getActiveValidators(startHash: StateHash): F[Seq[Validator]]
@@ -123,9 +124,10 @@ final case class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log: Contex
 
   def computeGenesis(
       terms: Seq[Signed[DeployData]],
-      blockTime: Long
+      blockTime: Long,
+      blockNumber: Long
   ): F[(StateHash, StateHash, Seq[ProcessedDeploy])] =
-    spawnRuntime.flatMap(_.computeGenesis(terms, blockTime))
+    spawnRuntime.flatMap(_.computeGenesis(terms, blockTime, blockNumber))
 
   def replayComputeState(startHash: StateHash)(
       terms: Seq[ProcessedDeploy],

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -304,7 +304,7 @@ class ValidateTest
             setBlockNumber = n.some,
             setTimestamp = timestamp.some,
             setParentsHashList = parentHashes.some,
-            hashF = (ProtoUtil.hashUnsignedBlock _).some
+            hashF = (ProtoUtil.hashSignedBlock _).some
           )
 
           _ <- blockStore.put(block.blockHash, block)
@@ -589,7 +589,7 @@ class ValidateTest
         )
         _ <- Validate.blockSummary[Task](
               signedBlock,
-              getRandomBlock(hashF = (ProtoUtil.hashUnsignedBlock _).some),
+              getRandomBlock(hashF = (ProtoUtil.hashSignedBlock _).some),
               mkCasperSnapshot(dag),
               "root",
               Int.MaxValue
@@ -710,7 +710,7 @@ class ValidateTest
         blockWithJustificationRegression = getRandomBlock(
           setValidator = v1.some,
           setJustifications = justificationsWithRegression.some,
-          hashF = (ProtoUtil.hashUnsignedBlock _).some
+          hashF = (ProtoUtil.hashSignedBlock _).some
         )
         dag <- blockDagStorage.getRepresentation
         _ <- Validate.justificationRegressions[Task](

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -304,7 +304,7 @@ class ValidateTest
             setBlockNumber = n.some,
             setTimestamp = timestamp.some,
             setParentsHashList = parentHashes.some,
-            hashF = (ProtoUtil.hashSignedBlock _).some
+            hashF = (ProtoUtil.hashBlock _).some
           )
 
           _ <- blockStore.put(block.blockHash, block)
@@ -589,7 +589,7 @@ class ValidateTest
         )
         _ <- Validate.blockSummary[Task](
               signedBlock,
-              getRandomBlock(hashF = (ProtoUtil.hashSignedBlock _).some),
+              getRandomBlock(hashF = (ProtoUtil.hashBlock _).some),
               mkCasperSnapshot(dag),
               "root",
               Int.MaxValue
@@ -710,7 +710,7 @@ class ValidateTest
         blockWithJustificationRegression = getRandomBlock(
           setValidator = v1.some,
           setJustifications = justificationsWithRegression.some,
-          hashF = (ProtoUtil.hashSignedBlock _).some
+          hashF = (ProtoUtil.hashBlock _).some
         )
         dag <- blockDagStorage.getRepresentation
         _ <- Validate.justificationRegressions[Task](

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockUtil.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockUtil.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.helper
 
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.BlockMessage
-import coop.rchain.casper.util.ProtoUtil.hashSignedBlock
+import coop.rchain.casper.util.ProtoUtil.hashBlock
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.SignaturesAlg
 import coop.rchain.models.BlockHash.BlockHash
@@ -16,7 +16,7 @@ object BlockUtil {
       SignaturesAlg(b.sigAlgorithm).get.sign
 
     val blockHash =
-      hashSignedBlock(b)
+      hashBlock(b)
     val sig = ByteString.copyFrom(signFunction(blockHash.toByteArray, sk))
     b.copy(blockHash = blockHash, sig = sig)
   }


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
After https://github.com/rchain/rchain/pull/3390, if we config genesis with a non-zero block number, the validator who received this genesis block can not validate the block hash because the hashing block detail is different and validator would show the warning below.

```
rnode.readonly | 01:56:12.867 [WARN ] [node-runner-26      ] [coop.rchain.casper.Validate$ ] - Ignoring block b63f133db5... because block hash b63f133db5... does not match to computed value e25b677348....
rnode.readonly | 01:56:12.870 [WARN ] [node-runner-26      ] [c.r.c.e.LfsBlockRequester$   ] - Received Block #10 (b63f133db5...) with empty parents (supposedly genesis) with invalid hash. Ignored block.
```

This pr is intended to make all block hashing consistent and I think we **should not make any difference between hashing signed block and unsigned block**.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
