### PR TITLE
Make relation predicate to be non directional for merging logic.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
@@ -7,7 +7,7 @@ import coop.rchain.casper.util.EventConverter
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.HistoryRepository
-import coop.rchain.rspace.merger.MergingLogic.computeRelatedSets
+import coop.rchain.rspace.merger.MergingLogic.{computeRelatedSets, depends}
 import coop.rchain.rspace.merger._
 import coop.rchain.rspace.syntax._
 import coop.rchain.rspace.trace.Produce
@@ -21,40 +21,45 @@ object BlockIndex {
   // TODO make proper storage for block indices
   val cache = TrieMap.empty[BlockHash, BlockIndex]
 
+  def createEventLogIndex[F[_]: Concurrent, C, P, A, K](
+      d: ProcessedDeploy,
+      historyRepository: HistoryRepository[F, C, P, A, K],
+      preStateHash: Blake2b256Hash
+  ): F[EventLogIndex] = {
+    implicit val channelStore: HistoryRepository[F, C, P, A, K] = historyRepository
+    val preStateReader =
+      historyRepository.getHistoryReader(preStateHash)
+    val produceExistsInPreState = (p: Produce) =>
+      preStateReader.getDataFromChannelHash(p.channelsHash).map(_.exists(_.source == p))
+    val produceTouchesPreStateJoin = (p: Produce) =>
+      preStateReader.getJoinsFromChannelHash(p.channelsHash).map(_.exists(_.size > 1))
+    EventLogIndex.apply(
+      d.deployLog.map(EventConverter.toRspaceEvent),
+      produceExistsInPreState,
+      produceTouchesPreStateJoin
+    )
+  }
+
   def apply[F[_]: Concurrent, C, P, A, K](
       blockHash: BlockHash,
       processedDeploys: List[ProcessedDeploy],
       preStateHash: Blake2b256Hash,
       postStateHash: Blake2b256Hash,
       historyRepository: HistoryRepository[F, C, P, A, K]
-  ): F[BlockIndex] = {
-    implicit val channelStore: HistoryRepository[F, C, P, A, K] = historyRepository
-
-    val createEventLogIndex = (d: ProcessedDeploy) => {
-      val preStateReader =
-        historyRepository.getHistoryReader(preStateHash)
-      val produceExistsInPreState = (p: Produce) =>
-        preStateReader.getDataFromChannelHash(p.channelsHash).map(_.exists(_.source == p))
-      val produceTouchesPreStateJoin = (p: Produce) =>
-        preStateReader.getJoinsFromChannelHash(p.channelsHash).map(_.exists(_.size > 1))
-      EventLogIndex.apply(
-        d.deployLog.map(EventConverter.toRspaceEvent),
-        produceExistsInPreState,
-        produceTouchesPreStateJoin
-      )
-    }
-
+  ): F[BlockIndex] =
     for {
       deployIndices <- processedDeploys
                         .filterNot(_.isFailed)
-                        .traverse(DeployIndex(_, createEventLogIndex))
+                        .traverse { d =>
+                          DeployIndex(d, createEventLogIndex(_, historyRepository, preStateHash))
+                        }
 
       /** Here deploys from a single block are examined. Atm deploys in block are executed sequentially,
         * so all conflicts are resolved according to order of sequential execution.
         * Therefore there won't be any conflicts between event logs. But there can be dependencies. */
       deployChains = computeRelatedSets[DeployIndex](
         deployIndices.toSet,
-        (t, s) => MergingLogic.depends(t.eventLogIndex, s.eventLogIndex)
+        (l, r) => MergingLogic.depends(l.eventLogIndex, r.eventLogIndex)
       )
       index <- deployChains.toVector
                 .traverse(
@@ -66,5 +71,4 @@ object BlockIndex {
                   )
                 )
     } yield BlockIndex(blockHash, index)
-  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
@@ -20,6 +20,9 @@ final case class DeployChainIndex(
 )
 
 object DeployChainIndex {
+
+  implicit val ord = Ordering.by((_: DeployChainIndex).postStateHash)
+
   def apply[F[_]: Concurrent, C, P, A, K](
       deploys: Set[DeployIndex],
       preStateHash: Blake2b256Hash,

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
@@ -1,0 +1,103 @@
+package coop.rchain.casper.merging
+
+import cats.syntax.all._
+import cats.effect.{Concurrent, Resource}
+import coop.rchain.casper.PrettyPrinter
+import coop.rchain.casper.util.rholang.costacc.CloseBlockDeploy
+import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
+import coop.rchain.casper.util.rholang.{Resources, RuntimeManager, SystemDeployUtil}
+import coop.rchain.metrics.Metrics
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
+import coop.rchain.p2p.EffectsTestInstances.LogicalTime
+import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
+import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.rspace.merger.{EventLogIndex, MergingLogic}
+import coop.rchain.rspace.merger.MergingLogic.computeRelatedSets
+import coop.rchain.shared.{EventLog, Log, Time}
+import coop.rchain.shared.scalatestcontrib.effectTest
+import monix.eval.Task
+import org.scalatest.{FlatSpec, Matchers}
+import monix.execution.Scheduler.Implicits.global
+
+class MergingCases extends FlatSpec with Matchers {
+
+  val genesisContext             = GenesisBuilder.buildGenesis(validatorsNum = 5)
+  val genesis                    = genesisContext.genesisBlock
+  implicit val logEff            = Log.log[Task]
+  implicit val timeF: Time[Task] = new LogicalTime[Task]
+
+  val runtimeManagerResource: Resource[Task, RuntimeManager[Task]] = for {
+    dirs <- Resources.copyStorage[Task](genesisContext.storageDirectory)
+    kvm  <- Resource.liftF(Resources.mkTestRNodeStoreManager[Task](dirs.storageDir))
+    rm   <- Resource.liftF(Resources.mkRuntimeManagerAt[Task](kvm))
+  } yield rm
+
+  /**
+    * Two deploys inside single state transition are using the same PVV for precharge and refund.
+    * So this should be dependent over produce that puts new value into PVV balance in the first deploy.
+    * TODO adjust this once/if there is a solution to make deploys touching the same PVV non dependent
+    */
+  "Two deploys executed inside single state transition" should "be dependent" in effectTest {
+    runtimeManagerResource.use { runtimeManager =>
+      {
+        val baseState              = genesis.body.state.postStateHash
+        val payer1Key              = genesisContext.genesisVaults.head._1
+        val payer2Key              = genesisContext.genesisVaults.tail.head._1
+        val stateTransitionCreator = genesisContext.validatorKeyPairs.head._2
+        val seqNum                 = 1
+        val blockNum               = 1L
+
+        for {
+          d1          <- ConstructDeploy.sourceDeployNowF("Nil", sec = payer1Key)
+          d2          <- ConstructDeploy.sourceDeployNowF("Nil", sec = payer2Key)
+          userDeploys = Seq(d1, d2)
+          systemDeploys = CloseBlockDeploy(
+            SystemDeployUtil
+              .generateCloseDeployRandomSeed(
+                stateTransitionCreator,
+                seqNum
+              )
+          ) :: Nil
+          blockData = BlockData(
+            d1.data.timestamp,
+            blockNum,
+            stateTransitionCreator,
+            seqNum
+          )
+          invalidBlocks = Map.empty[BlockHash, Validator]
+          r <- runtimeManager.computeState(baseState)(
+                userDeploys,
+                systemDeploys,
+                blockData,
+                invalidBlocks
+              )
+          (_, processedDeploys, _) = r
+          _                        = processedDeploys.size shouldBe 2
+          idxs <- processedDeploys.toList.traverse(
+                   BlockIndex.createEventLogIndex(
+                     _,
+                     runtimeManager.getHistoryRepo,
+                     Blake2b256Hash.fromByteString(baseState)
+                   )
+                 )
+          firstDepends  = MergingLogic.depends(idxs.head, idxs(1))
+          secondDepends = MergingLogic.depends(idxs(1), idxs.head)
+          conflicts     = MergingLogic.areConflicting(idxs.head, idxs(1))
+          deployChains = computeRelatedSets[EventLogIndex](
+            idxs.toSet,
+            MergingLogic.depends
+          )
+          // deploys inside one state transition never conflict, as executed in a sequence (for now)
+          _ = conflicts shouldBe false
+          // first deploy does not depend on the second
+          _ = firstDepends shouldBe false
+          // second deploy depends on the first, as it consumes produce put by first one when updating per validator vault balance
+          _ = secondDepends shouldBe true
+          // deploys should be be put in a single deploy chain
+          _ = deployChains.size shouldBe 1
+        } yield ()
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Overview
This PR fixes bug reported by @gsj5 on block merge testnet. `Bug found: refund failed` has been occurring because on block index dependent deploys were separated into different deploy chains, so data effectively has been merged twice.
To see the root cause of the bug ptal at comments.

### Notes
In addition, test is added to expose the issue.


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
