### PR TITLE
Populate channels map in batch

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/channelStore/ChannelStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/channelStore/ChannelStore.scala
@@ -19,7 +19,9 @@ final case class ContinuationHash(hash: Blake2b256Hash) extends ChannelHash
 
 trait ChannelStore[F[_], C] {
   def putChannelHash(channel: C): F[Unit]
+  def putChannelHashes(channels: Seq[C]): F[Unit]
   def putContinuationHash(channels: Seq[C]): F[Unit]
+  def putContinuationHashes(conts: Seq[Seq[C]]): F[Unit]
   def getChannelHash(hash: Blake2b256Hash): F[Option[ChannelHash]]
 
   def continuationKey(channels: Seq[Blake2b256Hash]): Blake2b256Hash =

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
@@ -206,6 +206,10 @@ trait InMemoryHistoryRepositoryTestBase extends InMemoryHistoryTestBase {
     override def putChannelHash(channel: String): Task[Unit] = ().pure[Task]
 
     override def putContinuationHash(channels: Seq[String]): Task[Unit] = ().pure[Task]
+
+    override def putChannelHashes(channels: Seq[String]): Task[Unit] = ().pure[Task]
+
+    override def putContinuationHashes(conts: Seq[Seq[String]]): Task[Unit] = ().pure[Task]
   }
   def inmemRootsStore =
     new RootsStore[Task] {


### PR DESCRIPTION
## Overview
Channels map population is taking long time because each hash is committed separately.
This PR introduces batch write. Preliminary results show that it significantly reduces replay time. (15sec -> 9 sec)


### Notes
This is needed just for transitional period before channels map is removed completely.


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
