### PR TITLE
Change wallets.txt file format/parser to REV address

### DIFF
--- a/integration-tests/test/conftest.py
+++ b/integration-tests/test/conftest.py
@@ -98,7 +98,7 @@ def temporary_bonds_file(validator_bonds_dict: Dict[PrivateKey, int]) -> Generat
 def make_wallets_file_lines(wallet_balance_from_private_key: Dict[PrivateKey, int]) -> List[str]:
     result = []
     for private_key, token_amount in wallet_balance_from_private_key.items():
-        line = '{},{},0'.format(private_key.get_public_key().get_eth_address(), token_amount)
+        line = '{},{},0'.format(private_key.get_public_key().get_rev_address(), token_amount)
         result.append(line)
     return result
 

--- a/integration-tests/test/test_internal.py
+++ b/integration-tests/test/test_internal.py
@@ -21,9 +21,9 @@ def test_make_wallets_file_lines() -> None:
     output = make_wallets_file_lines(wallets_map)
 
     assert output == [
-        '26218db6e5a2eed1901f72cea58fda7ef1f602c6,40,0',
-        '42c828c183163cb50f6ad5207a10899b59aae91c,45,0',
-        '2a11fd494610330f3b522562f7204670f8928133,26,0',
+        '111125MFSfZan5xv4zYqfeoJdbKtPmdhs3rE1SZA1VKQoCZ2j4HZXn,40,0',
+        '11112p4N2mcrBm5rfLVrMFJ87rQjk1b4CdooKi7pkSbipw2VMDM6WG,45,0',
+        '11112DLVVFkm7mU1cW4BJtXabXPMZungbywdoi8zGfPGoCD2UKr4pJ,26,0',
     ]
 
 


### PR DESCRIPTION
## Overview

This PR changes the format of `wallets.txt` file used for initial REV balance (vault state) on a new network.

Format is changed from ETH to REV address and removed third parameter.

New format of wallets file.
```
<REV_address_1>,<balance_1>
<REV_address_2>,<balance_2>
...
``` 

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
