### PR TITLE
Increase TreeHashMap depth in PoS used for rewards map

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -105,7 +105,7 @@ in {
           pickActiveValidators!($$initialBonds$$, {}, *initialActiveCh) |
           // Initializes pending rewards TreeHashMap.
           // - each key in pending rewards state is Map[PublicKey, Int] accumulated by calling "refundDeploy".
-          TreeHashMap!("init", 1, *pendingRewardsMapCh) |
+          TreeHashMap!("init", 4, *pendingRewardsMapCh) |
           for (@(true, posVault)  <- posVaultCh;
                @initialActive     <- initialActiveCh;
                @pendingRewardsMap <- pendingRewardsMapCh) {


### PR DESCRIPTION
## Overview

This PR changes depth parameter for TreeHashMap used in PoS to store validator rewards. It's required for block-merge release if released before Hard Fork 2.

Currently depth `1` can easily create conflict with the hash generated from THM keys, especially when there are more then ~20 validators.
Depth is increased to `4` which makes conflicts very unlikely, it's tested with existing validators public keys. Full solution will be part on the Hard Fork 2.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
