### PR TITLE
Make updating fork choice tips memory efficient

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -12,6 +12,7 @@ import coop.rchain.casper._
 import coop.rchain.casper.engine.EngineCell.EngineCell
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.syntax._
+import coop.rchain.shared.syntax._
 import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.casper.util.comm.CommUtil
 import coop.rchain.comm.PeerNode
@@ -23,6 +24,7 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.state.{RSpaceExporter, RSpaceStateManager}
 import fs2.concurrent.Queue
 import coop.rchain.shared.{Log, Time}
+import fs2.Stream
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration._
@@ -58,19 +60,29 @@ object Running {
             casper => {
               for {
                 latestMessages <- casper.blockDag.flatMap(
-                                   _.latestMessageHashes.map(_.values.toList)
+                                   _.latestMessageHashes.map(_.values.toSet)
                                  )
-                tips            <- latestMessages.traverse(BlockStore[F].getUnsafe)
-                newestTimestamp = tips.map(_.header.timestamp).max
-                now             <- Time[F].currentMillis
-                expired         = (now - newestTimestamp) > delayThreshold.toMillis
+                now <- Time[F].currentMillis
+                hasRecentLatestMessage = Stream
+                  .fromIterator(latestMessages.iterator)
+                  .evalMap(BlockStore[F].getUnsafe)
+                  // filter only blocks that are recent
+                  .filter { b =>
+                    val blockTimestamp = b.header.timestamp
+                    (now - blockTimestamp) < delayThreshold.toMillis
+                  }
+                  .head
+                  .compile
+                  .last
+                  .map(_.isDefined)
+                stuck <- hasRecentLatestMessage.not
                 requestWithLog = Log[F].info(
                   "Requesting tips update as newest latest message " +
                     s"is more then ${delayThreshold.toString} old. " +
                     s"Might be network is faulty."
                 ) >> CommUtil[F].sendForkChoiceTipRequest
 
-                _ <- (requestWithLog).whenA(expired)
+                _ <- (requestWithLog).whenA(stuck)
               } yield ()
             },
             ().pure[F]
@@ -179,7 +191,7 @@ object Running {
       Log[F].info(
         s"Sending tips ${PrettyPrinter.buildString(tips)} to ${peer.endpoint.host}"
       )
-    val getTips = casper.blockDag.flatMap(_.latestMessageHashes.map(_.values.toList))
+    val getTips = casper.blockDag.flatMap(_.latestMessageHashes.map(_.values.toList.distinct))
     // TODO respond with all tips in a single message
     def respondToPeer(tip: BlockHash) = TransportLayer[F].sendToPeer(peer, HasBlockProto(tip))
 


### PR DESCRIPTION
## Overview
Having big block as latest messages when network is not progressing might lead to exhaustion of memory, as all blocks are loaded into memory.

This PR makes the process memory efficient.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
