### PR TITLE
Require latest messages justifications for LFS

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockRetriever.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockRetriever.scala
@@ -198,7 +198,7 @@ object BlockRetriever {
           _ <- result.status match {
                 case NewSourcePeerAddedToRequest =>
                   Log[F]
-                    .info(
+                    .debug(
                       s"Adding ${peer.get.endpoint.host} to waiting list of ${PrettyPrinter
                         .buildString(hash)} request. " +
                         s"Reason: $admitHashReason"


### PR DESCRIPTION
## Overview
Current version of LFS does not pull enough blocks that are required for validation. 
This PR makes sure all latest messages self justifications are pulled as part of LFS state.
Closing https://github.com/rchain/rchain/issues/3483

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
