### PR TITLE
Fix LFS tests and use dequeue with one element in LFS requesters

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Compile
         run: |
-          export SBT_OPTS="$SBT_OPTS -Dsbt.task.timings=true -Xmx2g -Xss2m"
+          export SBT_OPTS="$SBT_OPTS -Dsbt.task.timings=true -Xmx2500m -Xss2m"
           sbt update scalafmtCheckAll compile
 
       - name: Pack Working Tree

--- a/casper/src/main/scala/coop/rchain/casper/engine/LfsBlockRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LfsBlockRequester.scala
@@ -244,7 +244,7 @@ object LfsBlockRequester {
         */
       val requestStream = for {
         // Request queue is a trigger when to check the state
-        resend <- requestQueue.dequeue
+        resend <- requestQueue.dequeueChunk(maxSize = 1)
 
         // Check if stream is finished (no more requests)
         isEnd <- Stream.eval(st.get.map(_.isFinished))

--- a/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
@@ -130,7 +130,7 @@ object LfsTupleSpaceRequester {
         */
       val requestStream = for {
         // Request queue is a trigger when to check the state
-        resend <- requestQueue.dequeue
+        resend <- requestQueue.dequeueChunk(maxSize = 1)
 
         // Check if stream is finished (no more requests)
         isEnd <- Stream.eval(st.get.map(_.isFinished))


### PR DESCRIPTION
## Overview

This PR fixes issues with LFS requester tests that was failing occasionally.

Also raises memory limit for SBT in CI actions to 2.5GB to mitigate this error.
https://github.com/rchain/rchain/runs/3114583867#step:6:961
```
2021-07-20T13:55:13.7900539Z [error] java.lang.NoClassDefFoundError: xsbt/API$FlattenedNames
2021-07-20T13:55:13.7906181Z [error] 	at xsbt.API.$anonfun$registerGeneratedClasses$1(API.scala:140)
2021-07-20T13:55:13.7912395Z [error] 	at xsbt.API.$anonfun$registerGeneratedClasses$1$adapted(API.scala:115)
2021-07-20T13:55:13.7917538Z [error] 	at scala.collection.Iterator.foreach(Iterator.scala:943)
2021-07-20T13:55:13.7922857Z [error] 	at scala.collection.Iterator.foreach$(Iterator.scala:943)
2021-07-20T13:55:13.7928268Z [error] 	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
2021-07-20T13:55:13.7934089Z [error] 	at xsbt.API.registerGeneratedClasses(API.scala:115)
2021-07-20T13:55:13.7939489Z [error] 	at xsbt.API$ApiPhase.run(API.scala:37)
2021-07-20T13:55:13.7970356Z [error] 	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1501)
2021-07-20T13:55:13.7971589Z [error] 	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1485)
...
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
