### PR TITLE
Fix length unknown list codec

### DIFF
--- a/node/src/main/scala/coop/rchain/node/web/Transaction.scala
+++ b/node/src/main/scala/coop/rchain/node/web/Transaction.scala
@@ -213,7 +213,7 @@ object Transaction {
 
     val transactionInfo: Codec[TransactionInfo] =
       (transactionCodec :: transactionType).as[TransactionInfo]
-    val transactionResponseCodec: Codec[TransactionResponse] = list(transactionInfo)
+    val transactionResponseCodec: Codec[TransactionResponse] = listOfN(int32, transactionInfo)
       .as[TransactionResponse]
   }
 


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

Fix the newly introduced encoding bug in transaction api. 

`list(transactionInfo)` doesnt show how list length which make the decoding impossible

we need to append the length in front of the codec

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
