### PR TITLE
Rejection options compute bug fix + tests

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
@@ -8,6 +8,8 @@ import coop.rchain.rspace.history.HistoryRepository
 import coop.rchain.rspace.merger.{StateChange, _}
 import coop.rchain.rspace.syntax._
 
+import scala.util.Random
+
 final case class DeployIdWithCost(id: ByteString, cost: Long)
 
 /** index of deploys depending on each other inside a single block (state transition) */
@@ -59,4 +61,19 @@ object DeployChainIndex {
       stateChanges
     )
   }
+
+  def random: Iterator[DeployChainIndex] =
+    Iterator.continually[Int](Random.nextInt(10)).map { size =>
+      val deployIds = Range(0, size)
+        .map(
+          _ => ByteString.copyFrom(Array.fill(64)((scala.util.Random.nextInt(256) - 128).toByte))
+        )
+      DeployChainIndex(
+        deployIds.map(id => DeployIdWithCost(id, 0)).toSet,
+        Blake2b256Hash.fromByteArray(new Array[Byte](32)),
+        Blake2b256Hash.fromByteArray(new Array[Byte](32)),
+        EventLogIndex.empty,
+        StateChange.empty
+      )
+    }
 }

--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
@@ -17,7 +17,16 @@ final case class DeployChainIndex(
     postStateHash: Blake2b256Hash,
     eventLogIndex: EventLogIndex,
     stateChanges: StateChange
-)
+) {
+  // equals and hash overrides are required to make conflict resolution faster, particularly rejection options calculation
+  override def equals(obj: Any): Boolean = obj match {
+    case that: DeployChainIndex => that.deploysWithCost.map(_.id) == this.deploysWithCost.map(_.id)
+    case _                      => false
+  }
+
+  override def hashCode(): Int =
+    deploysWithCost.map(_.id).foldLeft(0)((acc, v) => acc + v.hashCode() * 31)
+}
 
 object DeployChainIndex {
 

--- a/casper/src/main/scala/coop/rchain/casper/util/ConstructDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ConstructDeploy.scala
@@ -57,10 +57,9 @@ object ConstructDeploy {
       sec: PrivateKey = defaultSec,
       vabn: Long = 0
   ): F[Signed[DeployData]] =
-    Time[F].currentMillis
-      .map(
-        sourceDeploy(source, _, phloLimit = phloLimit, phloPrice = phloPrice, sec = sec, vabn: Long)
-      )
+    Time[F].nanoTime.map {
+      sourceDeploy(source, _, phloLimit = phloLimit, phloPrice = phloPrice, sec = sec, vabn: Long)
+    }
 
   // TODO: replace usages with basicSendDeployData
   def basicDeployData[F[_]: Monad: Time](

--- a/casper/src/test/scala/coop/rchain/casper/merging/MerginBenchmark.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MerginBenchmark.scala
@@ -21,7 +21,7 @@ class MergingBenchmark extends FlatSpec {
 
       // One third random pairs are conflicting
       val dciConflictingPairs = dciFullPairs.take(dciFullPairs.size / 3)
-      val intConflictingPairs = intFullPairs.take(dciFullPairs.size / 3)
+      val intConflictingPairs = intFullPairs.take(intFullPairs.size / 3)
 
       val (_, dciTime) =
         Stopwatch.profile(computeRejectionOptions(conflictsMap(dciConflictingPairs)))

--- a/casper/src/test/scala/coop/rchain/casper/merging/MerginBenchmark.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MerginBenchmark.scala
@@ -1,0 +1,36 @@
+package coop.rchain.casper.merging
+
+import coop.rchain.rspace.merger.MergingLogic.computeRejectionOptions
+import coop.rchain.shared.Stopwatch
+import org.scalatest.FlatSpec
+
+class MergingBenchmark extends FlatSpec {
+  "rejections option benchmark" should "for DeplyChainIndex" in {
+    def conflictsMap[A](conflictingPairs: Set[List[A]]): Map[A, Set[A]] =
+      conflictingPairs.foldLeft(Map.empty[A, Set[A]]) {
+        case (acc, Seq(l, r)) =>
+          acc +
+            (l -> (acc.getOrElse(l, Set.empty) + r)) +
+            (r -> (acc.getOrElse(r, Set.empty) + l))
+      }
+
+    val conflictSetSizes = Range(5, 100, 5)
+    conflictSetSizes.map { conflictSetSize =>
+      val dciFullPairs = DeployChainIndex.random.take(conflictSetSize).toList.combinations(2).toSet
+      val intFullPairs = (1 to conflictSetSize).toList.combinations(2).toSet
+
+      // One third random pairs are conflicting
+      val dciConflictingPairs = dciFullPairs.take(dciFullPairs.size / 3)
+      val intConflictingPairs = intFullPairs.take(dciFullPairs.size / 3)
+
+      val (_, dciTime) =
+        Stopwatch.profile(computeRejectionOptions(conflictsMap(dciConflictingPairs)))
+      val (_, intTime) =
+        Stopwatch.profile(computeRejectionOptions(conflictsMap(intConflictingPairs)))
+      println(
+        s"Conflict set size ${conflictSetSize}, 1/3 pairs conflicting. " +
+          s"Rejection options computed in: for Int (fastest possible): ${intTime}, for DeployChainIndex: ${dciTime} }"
+      )
+    }
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/merging/MergingLogic.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/merging/MergingLogic.scala
@@ -1,0 +1,58 @@
+package coop.rchain.rspace.merging
+
+import coop.rchain.rspace.merger.MergingLogic._
+import coop.rchain.shared.Stopwatch
+import org.scalatest.{FlatSpec, Matchers}
+
+class MergingLogic extends FlatSpec with Matchers {
+  // some random conflict maps and rejection options, computed manually
+  "rejection options" should "be computed correctly" in {
+    computeRejectionOptions(
+      Map(
+        1 -> Set(2, 3, 4),
+        2 -> Set(1),
+        3 -> Set(1, 2),
+        4 -> Set(1)
+      )
+    ) shouldBe Set(Set(1, 2), Set(2, 3, 4))
+
+    computeRejectionOptions(
+      Map(
+        1 -> Set(2, 3, 4),
+        2 -> Set(1, 3, 4),
+        3 -> Set(1, 2, 4),
+        4 -> Set(1, 2, 3)
+      )
+    ) shouldBe Set(Set(2, 3, 4), Set(1, 3, 4), Set(1, 2, 4), Set(1, 2, 3))
+
+    computeRejectionOptions(
+      Map(
+        1 -> Set(2, 3, 4),
+        2 -> Set(1),
+        3 -> Set(1, 4),
+        4 -> Set(1, 3)
+      )
+    ) shouldBe Set(Set(2, 3, 4), Set(1, 3), Set(1, 4))
+
+    val all         = (1 to 1000) toSet
+    val conflictMap = (1 to 1000).map(i => i -> (all - i)).toMap
+    computeRejectionOptions(conflictMap) shouldBe (1 to 1000).map(all - _).toSet
+  }
+
+  "benchmark" should "" ignore {
+    val conflictSetSizes = Range(10, 100, 5)
+    conflictSetSizes.map { conflictSetSize =>
+      val fullPairs = (1 to conflictSetSize).combinations(2).toSet
+      // One third random pairs are conflicting
+      val conflictingPairs = fullPairs.take(fullPairs.size / 3)
+      val conflictMap = conflictingPairs.foldLeft(Map.empty[Int, Set[Int]]) {
+        case (acc, Seq(l, r)) =>
+          acc +
+            (l -> (acc.getOrElse(l, Set.empty) + r)) +
+            (r -> (acc.getOrElse(r, Set.empty) + l))
+      }
+      val (_, time) = Stopwatch.profile(computeRejectionOptions(conflictMap))
+      println(s"$conflictSetSize in ${time}")
+    }
+  }
+}

--- a/rspace/src/test/scala/coop/rchain/rspace/merging/MergingLogic.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/merging/MergingLogic.scala
@@ -34,25 +34,17 @@ class MergingLogic extends FlatSpec with Matchers {
       )
     ) shouldBe Set(Set(2, 3, 4), Set(1, 3), Set(1, 4))
 
+    computeRejectionOptions(
+      Map(
+        1 -> Set.empty[Int],
+        2 -> Set(3),
+        3 -> Set(2, 4),
+        4 -> Set(3)
+      )
+    ) shouldBe Set(Set(3), Set(2, 4))
+
     val all         = (1 to 1000) toSet
     val conflictMap = (1 to 1000).map(i => i -> (all - i)).toMap
     computeRejectionOptions(conflictMap) shouldBe (1 to 1000).map(all - _).toSet
-  }
-
-  "benchmark" should "" ignore {
-    val conflictSetSizes = Range(10, 100, 5)
-    conflictSetSizes.map { conflictSetSize =>
-      val fullPairs = (1 to conflictSetSize).combinations(2).toSet
-      // One third random pairs are conflicting
-      val conflictingPairs = fullPairs.take(fullPairs.size / 3)
-      val conflictMap = conflictingPairs.foldLeft(Map.empty[Int, Set[Int]]) {
-        case (acc, Seq(l, r)) =>
-          acc +
-            (l -> (acc.getOrElse(l, Set.empty) + r)) +
-            (r -> (acc.getOrElse(r, Set.empty) + l))
-      }
-      val (_, time) = Stopwatch.profile(computeRejectionOptions(conflictMap))
-      println(s"$conflictSetSize in ${time}")
-    }
   }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/merging/MergingLogicSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/merging/MergingLogicSpec.scala
@@ -4,7 +4,7 @@ import coop.rchain.rspace.merger.MergingLogic._
 import coop.rchain.shared.Stopwatch
 import org.scalatest.{FlatSpec, Matchers}
 
-class MergingLogic extends FlatSpec with Matchers {
+class MergingLogicSpec extends FlatSpec with Matchers {
   // some random conflict maps and rejection options, computed manually
   "rejection options" should "be computed correctly" in {
     computeRejectionOptions(


### PR DESCRIPTION
## Overview
This PR introduces bug fix for rejection options calculations. Current rejection options compute logic were not complete and did not account all the cases. Tests also added to check correctness.

Benchmarks revealed that rejection options calculation in real node is slow, it turned out that operating on DeployChainIndex in comparison to, e.g. Integers slows down the code significantly. To overcome this issue, `equals` and `hashCode` overrides added to DeployChainIndex.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
