### PR TITLE
Benchmarks: concurrency + leaderful simulation

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -292,19 +292,7 @@ in {
                                       match transferResult {
                                         (true, _) => {
                                           new newRewardsCh, pendingUpdatedCh in {
-                                            distributeRewards!(
-                                              initialPaymentAmount - refundAmount,
-                                              state.get("activeValidators"),
-                                              state.get("allBonds"),
-                                              *newRewardsCh
-                                            ) |
-                                            for (@newRewards <- newRewardsCh) {
-                                              // Add new pending rewards to validator pending rewards state
-                                              PendingRewards!("append", sender, newRewards, *pendingUpdatedCh) |
-                                              for (_ <- pendingUpdatedCh) {
-                                                return!((true, Nil))
-                                              }
-                                            }
+                                            return!((true, Nil))
                                           }
                                         }
                                         (_, errorMessage) => {

--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployIndex.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper.merging
 import cats.effect.Concurrent
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.protocol.Event
+import coop.rchain.casper.protocol.{BlockMessage, Event}
 import coop.rchain.rspace.merger.EventLogIndex
 
 /** index of a single deploy */
@@ -23,6 +23,10 @@ object DeployIndex {
   val SYS_SLASH_DEPLOY_ID       = ByteString.copyFrom(Array(1.toByte))
   val SYS_CLOSE_BLOCK_DEPLOY_ID = ByteString.copyFrom(Array(2.toByte))
   val SYS_EMPTY_DEPLOY_ID       = ByteString.copyFrom(Array(3.toByte))
+
+  def sysSlashId(b: BlockMessage)      = b.blockHash.concat(SYS_SLASH_DEPLOY_ID)
+  def sysCloseBlockId(b: BlockMessage) = b.blockHash.concat(SYS_CLOSE_BLOCK_DEPLOY_ID)
+  def sysEmptyId(b: BlockMessage)      = b.blockHash.concat(SYS_EMPTY_DEPLOY_ID)
 
   def apply[F[_]: Concurrent](
       sig: ByteString,

--- a/models/src/test/scala/coop/rchain/models/blockImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/blockImplicits.scala
@@ -127,6 +127,8 @@ object blockImplicits {
       setParentsHashList: Option[Seq[BlockHash]] = None,
       setJustifications: Option[Seq[Justification]] = None,
       setDeploys: Option[Seq[ProcessedDeploy]] = None,
+      setSysDeploys: Option[Seq[ProcessedSystemDeploy]] = None,
+      setRejDeploys: Option[Seq[RejectedDeploy]] = None,
       setBonds: Option[Seq[Bond]] = None,
       setShardId: Option[String] = None,
       hashF: Option[BlockMessage => BlockHash] = None
@@ -147,6 +149,10 @@ object blockImplicits {
       deploys <- if (setDeploys.isEmpty)
                   arbitrary[Seq[ProcessedDeploy]](arbitraryProcessedDeploys)
                 else Gen.const(setDeploys.get)
+      sysDeploys <- if (setSysDeploys.isEmpty) Gen.const(List.empty)
+                   else Gen.const(setSysDeploys.get)
+      rejDeploys <- if (setRejDeploys.isEmpty) Gen.const(List.empty)
+                   else Gen.const(setRejDeploys.get)
       // 10 random validators in bonds list
       bonds <- if (setBonds.isEmpty) Gen.containerOfN[List, Bond](10, bondGen)
               else Gen.const(setBonds.get)
@@ -174,8 +180,8 @@ object blockImplicits {
             blockNumber = setBlockNumber.get
           ),
           deploys = deploys.toList,
-          systemDeploys = List.empty,
-          rejectedDeploys = List.empty
+          systemDeploys = sysDeploys.toList,
+          rejectedDeploys = rejDeploys.toList
         ),
         justifications = justifications.toList,
         sender = validator,
@@ -221,6 +227,8 @@ object blockImplicits {
       setParentsHashList: Option[Seq[BlockHash]] = None,
       setJustifications: Option[Seq[Justification]] = None,
       setDeploys: Option[Seq[ProcessedDeploy]] = None,
+      setSysDeploys: Option[Seq[ProcessedSystemDeploy]] = None,
+      setRejDeploys: Option[Seq[RejectedDeploy]] = None,
       setBonds: Option[Seq[Bond]] = None,
       setShardId: Option[String] = None,
       hashF: Option[BlockMessage => BlockHash] = None
@@ -236,6 +244,8 @@ object blockImplicits {
       setParentsHashList,
       setJustifications,
       setDeploys,
+      setSysDeploys,
+      setRejDeploys,
       setBonds,
       setShardId,
       hashF

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -12,7 +12,7 @@ import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.{Secp256k1, SignaturesAlg}
 import coop.rchain.crypto.util.KeyUtil
 import coop.rchain.monix.Monixable
-import coop.rchain.node.benchmark.ConcurrencyBench
+import coop.rchain.node.benchmark.{ConcurrentReplayBench, LeaderfulHardening}
 import coop.rchain.node.configuration.Configuration.Profile
 import coop.rchain.node.configuration._
 import coop.rchain.node.effects._
@@ -77,7 +77,15 @@ object Main {
   )(implicit scheduler: Scheduler): F[Unit] = {
     implicit val time: Time[F] = effects.time
     if (options.subcommands.contains(options.bench.concurrency))
-      ConcurrencyBench.go(options.bench.concurrency.maxConcurrentTx(), options.bench.dataDir())
+      ConcurrentReplayBench.go(options.bench.concurrency.maxConcurrentTx(), options.bench.dataDir())
+    else if (options.subcommands.contains(options.bench.leaderful))
+      LeaderfulHardening.run(
+        options.bench.dataDir(),
+        options.bench.leaderful.validatorsNum(),
+        options.bench.leaderful.usersNum(),
+        options.bench.leaderful.maxTxPerBlock(),
+        options.bench.leaderful.epochLength()
+      )
     else new Exception(s"Please select benchmark mode").raiseError
   }
 

--- a/node/src/main/scala/coop/rchain/node/benchmark/ConcurrentReplayBench.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/ConcurrentReplayBench.scala
@@ -1,0 +1,170 @@
+package coop.rchain.node.benchmark
+
+import cats.Parallel
+import cats.effect.concurrent.Ref
+import cats.effect.{Blocker, Concurrent, ContextShift, Resource}
+import cats.syntax.all._
+import coop.rchain.casper.genesis.Genesis
+import coop.rchain.casper.genesis.contracts.Validator
+import coop.rchain.casper.protocol.{CommEvent, ConsumeEvent, ProduceEvent}
+import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.metrics.Metrics.Source
+import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.node.benchmark.utils.GenesisParams.genesisParameters
+import coop.rchain.node.benchmark.utils.LeaderfulDagBuilder.ValidatorWithPayments
+import coop.rchain.node.benchmark.utils.{Payment, StateTransition, User}
+import coop.rchain.rspace.syntax._
+import coop.rchain.shared.syntax._
+import coop.rchain.shared.{Log, Stopwatch, Time}
+import coop.rchain.store.InMemoryStoreManager
+import fs2.Stream
+import io.circe.syntax._
+import monix.execution.Scheduler
+
+import java.nio.file.Path
+import scala.collection.Seq
+import scala.concurrent.duration.{FiniteDuration, NANOSECONDS}
+
+/** Benchmark for concurrent state transitions. This is equivalent to concurrent block validation. */
+object ConcurrentReplayBench {
+
+  def go[F[_]: Concurrent: Parallel: Time: Log: ContextShift](
+      stateTransitionsMax: Int,
+      dataDir: Path
+  )(implicit scheduler: Scheduler): F[Unit] = {
+    implicit val m = new Metrics.MetricsNOP[F]
+
+    // run everything in memory
+    val rnodeStoreManager = new InMemoryStoreManager
+
+    for {
+      rSpaceStores <- rnodeStoreManager.rSpaceStores
+      // extract all performance data gathered by Span trait usage across codebase
+      statsRef <- Ref.of[F, Map[String, (Long, Int)]](Map.empty)
+      profiler = new Span[F] {
+        override def trace[A](source: Source)(block: F[A]): F[A] =
+          for {
+            v         <- Stopwatch.durationNano(block)
+            (r, time) = v
+            _ <- statsRef.update { s =>
+                  val (currTimeAcc, currCallsAcc) = s.getOrElse(source, (0L, 0))
+                  val newV                        = (currTimeAcc + time, currCallsAcc + 1)
+                  s.updated(source, newV)
+                }
+          } yield r
+
+        // do not need these one
+        override def mark(name: String): F[Unit]                    = ().pure[F]
+        override def withMarks[A](label: String)(block: F[A]): F[A] = block
+      }
+      runtimeManager <- {
+        implicit val span = profiler
+        RuntimeManager(rSpaceStores)
+      }
+
+      _     <- Log[F].info(s"Preparing genesis block...")
+      users = User.random.take(stateTransitionsMax).toList
+      validatorsKeys = (1 to stateTransitionsMax)
+        .map(_ => Secp256k1.newKeyPair)
+        .map { case (_, pk) => pk }
+        .toList
+      genesisVaults = users.map(_.pk)
+      bondedValidators = validatorsKeys.zipWithIndex.map {
+        case (v, i) => Validator(v, (2L * i.toLong + 1L))
+      }
+      genesis <- Genesis.createGenesisBlock(
+                  runtimeManager,
+                  genesisParameters(bondedValidators, genesisVaults)
+                )
+      _ <- Log[F].info(s"Genesis done.")
+
+      r <- {
+        implicit val rm = runtimeManager
+        implicit val blocker =
+          Blocker.liftExecutionContext(scala.concurrent.ExecutionContext.global)
+
+        // first is a warm up for JVM
+        (Stream(1, 1, 2, 3, 4, 5, 7) ++ Stream.range(10, stateTransitionsMax + 5, 5))
+          .evalMap { networkSize =>
+            val validators = validatorsKeys.take(networkSize)
+            val payments   = Payment.random(users, 1, 10).take(networkSize).toList
+            val transitions = validators
+              .zip(payments)
+              .map { case (v, p) => ValidatorWithPayments(v, Seq(p)) }
+
+            val test = Stream
+              .emits(transitions)
+              .parEvalMapProcBounded { v =>
+                StateTransition.make(
+                  genesis.body.state.postStateHash,
+                  v.validator,
+                  0,
+                  1,
+                  v.payments.toList
+                )
+              }
+              .compile
+              .toList
+
+            for {
+              _               <- Log[F].info(s"Running ${transitions.size} concurrent STs.")
+              r               <- Stopwatch.durationNano(test)
+              (results, time) = r
+              timeStr         = Stopwatch.showTime(FiniteDuration(time, NANOSECONDS))
+              avgDeploysPerST = results.flatMap(_.processedDeploys).size.toFloat / results.size
+              ps = results
+                .flatMap(_.processedDeploys.flatMap(_.deployLog))
+                .collect { case c: ProduceEvent => c }
+                .size
+              cs = results
+                .flatMap(_.processedDeploys.flatMap(_.deployLog))
+                .collect { case c: ConsumeEvent => c }
+                .size
+              comms = results
+                .flatMap(_.processedDeploys.flatMap(_.deployLog))
+                .collect { case c: CommEvent => c }
+                .size
+              psSys = results
+                .flatMap(_.processedSysDeploys.flatMap(_.eventList))
+                .collect { case c: ProduceEvent => c }
+                .size
+              csSys = results
+                .flatMap(_.processedSysDeploys.flatMap(_.eventList))
+                .collect { case c: ConsumeEvent => c }
+                .size
+              commsSys = results
+                .flatMap(_.processedSysDeploys.flatMap(_.eventList))
+                .collect { case c: CommEvent => c }
+                .size
+              cps   = comms.toFloat / time * 1e9
+              stats <- statsRef.get
+              logMsg = stats.toList
+                .sortBy { case (_, (v, _)) => v }
+                .reverse
+                .foldLeft(
+                  s"\nDONE: ${results.size} State transitions (avg $avgDeploysPerST TX per ST), " +
+                    s"user events: $ps P, $cs C $comms COMM, " +
+                    s"sys events : $psSys P, $csSys C $commsSys COMM, " +
+                    s"time: ${timeStr}. COMMS per sec: ${cps}"
+                ) {
+                  case (acc, (metric, (totalTime, totalCalls))) =>
+                    val timeS = totalTime.toFloat / 1e9
+                    acc + f"\n$metric%60s: avg ${timeS / totalCalls}%.7f s, total $timeS%.7f s, calls ${totalCalls}, "
+                }
+              _ <- Log[F].info(logMsg)
+              _ <- statsRef.set(Map.empty) //reset stats
+              r = stats.map {
+                case (metric, (total, qty)) =>
+                  metric -> ("size" -> networkSize, "total" -> total, "calls" -> qty)
+              }.asJson
+            } yield r
+          }
+          .flatMap(v => Stream.fromIterator(v.show.getBytes.iterator))
+          .through(fs2.io.file.writeAll(dataDir.resolve("out.json"), blocker))
+          .compile
+          .lastOrError
+      }
+    } yield ()
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/benchmark/ConcurrentReplayBench.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/ConcurrentReplayBench.scala
@@ -12,7 +12,7 @@ import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.node.benchmark.utils.GenesisParams.genesisParameters
-import coop.rchain.node.benchmark.utils.LeaderfulDagBuilder.ValidatorWithPayments
+import coop.rchain.node.benchmark.utils.LeaderfulSimulation.ValidatorWithPayments
 import coop.rchain.node.benchmark.utils.{Payment, StateTransition, User}
 import coop.rchain.rspace.syntax._
 import coop.rchain.shared.syntax._

--- a/node/src/main/scala/coop/rchain/node/benchmark/LeaderfulHardening.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/LeaderfulHardening.scala
@@ -1,0 +1,100 @@
+package coop.rchain.node.benchmark
+
+import cats.Parallel
+import cats.effect.{Concurrent, ContextShift}
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.KeyValueBlockStore
+import coop.rchain.blockstorage.dag.BlockDagKeyValueStorage
+import coop.rchain.casper.genesis.Genesis
+import coop.rchain.casper.genesis.contracts.Validator
+import coop.rchain.casper.merging.DeployIndex.sysCloseBlockId
+import coop.rchain.casper.storage.RNodeKeyValueStoreManager
+import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.node.benchmark.utils.GenesisParams.genesisParameters
+import coop.rchain.node.benchmark.utils.LeaderfulSimulation.ValidatorWithPayments
+import coop.rchain.node.benchmark.utils.{LeaderfulSimulation, Payment, User}
+import coop.rchain.rspace.syntax._
+import coop.rchain.shared.{Log, Time}
+import monix.execution.Scheduler
+
+import java.nio.file.Path
+import scala.collection.Seq
+
+object LeaderfulHardening {
+
+  def run[F[_]: Concurrent: Log: Parallel: ContextShift: Time](
+      storageDirectory: Path,
+      nValidators: Int,
+      nUsers: Int,
+      maxTxPerBlock: Int,
+      epochLength: Int = 10
+  )(implicit scheduler: Scheduler): F[Unit] = {
+    implicit val m = new Metrics.MetricsNOP[F]
+    implicit val s = new NoopSpan[F]
+
+    val users = User.random.take(nUsers).toList
+    val validatorsKeys = (1 to nValidators)
+      .map(_ => Secp256k1.newKeyPair)
+      .map { case (_, pk) => pk }
+      .toList
+
+    for {
+      rnodeStoreManager <- RNodeKeyValueStoreManager(storageDirectory)
+      rSpaceStores      <- rnodeStoreManager.rSpaceStores
+      runtimeManager    <- RuntimeManager(rSpaceStores)
+      blockStore        <- KeyValueBlockStore(rnodeStoreManager)
+      blockDagStorage   <- BlockDagKeyValueStorage.create(rnodeStoreManager)
+
+      _ <- Log[F].info(s"Preparing genesis block...")
+      genesis <- {
+        val genesisVaults = users.map(_.pk)
+        val bondedValidators = validatorsKeys.zipWithIndex
+          .map { case (v, i) => Validator(v, (2L * i.toLong + 1L)) }
+        Genesis.createGenesisBlock(
+          runtimeManager,
+          genesisParameters(bondedValidators, genesisVaults, epochLength)
+        )
+      }
+      _ <- Log[F].info(s"Done.")
+      _ <- blockStore.put(genesis.blockHash, genesis)
+      _ <- blockDagStorage.insert(genesis, invalid = false, approved = true)
+      layers = {
+        implicit val rm  = runtimeManager
+        implicit val bds = blockDagStorage
+
+        val payments = Payment.randomBatches(users, 1, 10, maxTxPerBlock)
+
+        val validatorsWithPayments = Iterator
+          .continually(validatorsKeys)
+          .flatten
+          .zip(payments)
+          .map(ValidatorWithPayments.tupled)
+          .grouped(validatorsKeys.size)
+
+        val initUserBalances = users.map {
+          case User(_, pk, _) =>
+            (users.find(_.pk == pk).get, (900000000L, Seq.empty[Payment]))
+        }.toMap
+        val validatorUsers = validatorsKeys.map { pk =>
+          User(PrivateKey(ByteString.EMPTY), pk, Base16.encode(pk.bytes))
+        }
+        val initValidatorBalances = validatorUsers.map(_ -> (0L, List.empty)).toMap
+        val initBalances          = initUserBalances ++ initValidatorBalances
+
+        LeaderfulSimulation.go(
+          genesis,
+          validatorsWithPayments,
+          initBalances,
+          epochLength,
+          Int.MaxValue
+        )
+      }
+      _ <- layers.compile.lastOrError
+    } yield ()
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/benchmark/utils/GenesisParams.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/utils/GenesisParams.scala
@@ -1,0 +1,47 @@
+package coop.rchain.node.benchmark.utils
+
+import cats.syntax.all._
+import coop.rchain.casper.genesis.Genesis
+import coop.rchain.casper.genesis.contracts.{ProofOfStake, Validator, Vault}
+import coop.rchain.crypto.PublicKey
+import coop.rchain.rholang.interpreter.util.RevAddress
+
+import scala.collection.Seq
+
+object GenesisParams {
+
+  val predefinedVaultsAmt = 900000000L
+
+  def genesisParameters(
+      bondedValidators: Seq[Validator],
+      genesisVaults: List[PublicKey]
+  ): Genesis = {
+    def predefinedVault(pub: PublicKey): Vault =
+      Vault(RevAddress.fromPublicKey(pub).get, predefinedVaultsAmt)
+
+    Genesis(
+      shardId = "root",
+      timestamp = 0L,
+      proofOfStake = ProofOfStake(
+        minimumBond = 0L,
+        maximumBond = Long.MaxValue,
+        // Epoch length is set to large number to prevent trigger of epoch change
+        // in PoS close block method, which causes block merge conflicts
+        // - epoch change can be set as a parameter in Rholang tests (e.g. PoSSpec)
+        epochLength = 1000,
+        quarantineLength = 50000,
+        numberOfActiveValidators = 100,
+        validators = bondedValidators
+      ),
+      vaults = genesisVaults.map(predefinedVault) ++
+        bondedValidators.toList.map {
+          case Validator(pk, _) =>
+            // Initial validator vaults contain 0 Rev
+            RevAddress.fromPublicKey(pk).map(Vault(_, 0))
+        }.flattenOption,
+      supply = Long.MaxValue,
+      blockNumber = 0
+    )
+  }
+
+}

--- a/node/src/main/scala/coop/rchain/node/benchmark/utils/GenesisParams.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/utils/GenesisParams.scala
@@ -14,7 +14,8 @@ object GenesisParams {
 
   def genesisParameters(
       bondedValidators: Seq[Validator],
-      genesisVaults: List[PublicKey]
+      genesisVaults: List[PublicKey],
+      epochLength: Int = 1000
   ): Genesis = {
     def predefinedVault(pub: PublicKey): Vault =
       Vault(RevAddress.fromPublicKey(pub).get, predefinedVaultsAmt)
@@ -28,7 +29,7 @@ object GenesisParams {
         // Epoch length is set to large number to prevent trigger of epoch change
         // in PoS close block method, which causes block merge conflicts
         // - epoch change can be set as a parameter in Rholang tests (e.g. PoSSpec)
-        epochLength = 1000,
+        epochLength = epochLength,
         quarantineLength = 50000,
         numberOfActiveValidators = 100,
         validators = bondedValidators

--- a/node/src/main/scala/coop/rchain/node/benchmark/utils/LeaderfulSimulation.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/utils/LeaderfulSimulation.scala
@@ -1,0 +1,456 @@
+package coop.rchain.node.benchmark.utils
+
+import cats.effect.Concurrent
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.dag.BlockDagStorage
+import coop.rchain.casper.merging.DeployIndex.sysCloseBlockId
+import coop.rchain.casper.merging.{BlockIndex, DagMerger, DeployIndex}
+import coop.rchain.casper.protocol.{
+  BlockMessage,
+  Body,
+  Bond,
+  CommEvent,
+  Header,
+  ProcessedDeploy,
+  ProcessedSystemDeploy,
+  RChainState,
+  RejectedDeploy
+}
+import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.crypto.PublicKey
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.metrics.Metrics
+import coop.rchain.models.block.StateHash.StateHash
+import coop.rchain.node.benchmark.utils.Payment.{
+  conflictsPresent,
+  verifyBalances,
+  BalanceSheet,
+  BlockWithPayments
+}
+import coop.rchain.node.benchmark.utils.StateTransition.StateTransitionResult
+import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.shared.syntax._
+import coop.rchain.shared.{Log, Stopwatch, Time}
+import fs2.Stream
+
+import scala.collection.Seq
+import scala.concurrent.duration.{FiniteDuration, NANOSECONDS}
+
+object LeaderfulSimulation {
+
+  def mkBlocks[F[_]: Concurrent: Time](
+      validatorsWithPayments: List[ValidatorWithPayments],
+      preStateHash: StateHash,
+      seqNum: Int,
+      blockNum: Long,
+      deploysToReject: Seq[ByteString] = List.empty
+  )(
+      implicit runtimeManager: RuntimeManager[F]
+  ): List[Stream[F, (BlockMessage, Seq[Charged[PaymentDeploy]])]] = {
+    def packBlock(
+        sender: PublicKey,
+        postStateHash: StateHash,
+        processed: Seq[ProcessedDeploy],
+        processedSystem: Seq[ProcessedSystemDeploy]
+    ): BlockMessage = BlockMessage(
+      blockHash = ByteString.copyFrom(Array.fill(32)((scala.util.Random.nextInt(256) - 128).toByte)),
+      header = Header(
+        parentsHashList = List.empty,
+        timestamp = processed.head.deploy.data.timestamp,
+        version = 1
+      ),
+      body = Body(
+        state = RChainState(
+          preStateHash = preStateHash,
+          postStateHash = postStateHash,
+          bonds = validatorsWithPayments
+            .map(_.validator)
+            .map(pk => Bond(ByteString.copyFrom(pk.bytes), 1)),
+          blockNumber = blockNum
+        ),
+        deploys = processed.toList,
+        systemDeploys = processedSystem.toList,
+        rejectedDeploys = deploysToReject.map(RejectedDeploy(_)).toList
+      ),
+      justifications = List.empty,
+      sender = ByteString.copyFrom(sender.bytes),
+      seqNum = seqNum,
+      sig = ByteString.copyFrom(Array.fill(32)((scala.util.Random.nextInt(256) - 128).toByte)),
+      sigAlgorithm = "",
+      shardId = "shardId"
+    )
+
+    validatorsWithPayments.map {
+      case ValidatorWithPayments(validatorPk, payments) =>
+        Stream
+          .eval(
+            StateTransition
+              .make(
+                preStateHash,
+                validatorPk,
+                seqNum,
+                blockNum,
+                payments.toList
+              )
+          )
+          .map {
+            case StateTransitionResult(
+                postStateHash,
+                chargedDeploysWithMeta,
+                processedDeploys,
+                processedSystem
+                ) =>
+              (
+                packBlock(validatorPk, postStateHash, processedDeploys, processedSystem),
+                chargedDeploysWithMeta
+              )
+          }
+    }
+  }
+
+  final case class LayerResult(
+      mergeBlock: BlockWithPayments,
+      mergedBlocks: List[BlockWithPayments],
+      rejected: List[RejectedDeploy],
+      commsAccepted: Long,
+      commsrejected: Long,
+      mergeTime: String
+  )
+  def mkLayer[F[_]: Concurrent: Time: Log](
+      validatorsWithPayments: List[ValidatorWithPayments],
+      baseBlock: BlockMessage,
+      dagStore: BlockDagStorage[F]
+  )(
+      implicit runtimeManager: RuntimeManager[F]
+  ): F[LayerResult] = {
+
+    val baseState        = baseBlock.body.state.postStateHash
+    val seqNum           = baseBlock.seqNum + 1
+    val mergingBlocksNum = (baseBlock.body.state.blockNumber + 1).toLong
+    val mergerBlockNum   = (baseBlock.body.state.blockNumber + 2).toLong
+    val validatorsNum    = validatorsWithPayments.size
+
+    val mkBlocksToMerge =
+      Log[F].info(s"${validatorsNum - 1} validators create blocks concurrently.") *>
+        Stream
+          .emits(
+            mkBlocks[F](validatorsWithPayments, baseState, seqNum, mergingBlocksNum).dropRight(1)
+          )
+          .parJoinProcBounded
+          .map {
+            case (b, payment) =>
+              (
+                b.copy(header = b.header.copy(parentsHashList = List(baseBlock.blockHash))),
+                payment
+              )
+          }
+          .evalTap { case (b, _) => dagStore.insert(b, false) }
+          .compile
+          .toList
+
+    for {
+      // create children blocks
+      v                            <- Stopwatch.duration(mkBlocksToMerge)
+      (t, tailStateTransitionTime) = v
+
+      _                         <- Log[F].info(s"Done in ${tailStateTransitionTime}")
+      (toMerge, mergedPayments) = t.unzip
+
+      _ <- Log[F].info("Indexing blocks...")
+      // merge children blocks
+      indices <- (baseBlock +: toMerge)
+                  .traverse(
+                    b =>
+                      BlockIndex(
+                        b.blockHash,
+                        b.body.deploys,
+                        b.body.systemDeploys,
+                        Blake2b256Hash.fromByteString(b.body.state.preStateHash),
+                        Blake2b256Hash.fromByteString(b.body.state.postStateHash),
+                        runtimeManager.getHistoryRepo
+                      ).map(b.blockHash -> _)
+                  )
+                  .map(_.toMap)
+      dag <- dagStore.getRepresentation
+
+      _ <- Log[F].info("Preparing merged state...")
+      v <- Stopwatch.duration(
+            DagMerger.merge[F](
+              dag,
+              baseBlock.blockHash,
+              Blake2b256Hash.fromByteString(baseState),
+              indices(_).deployChains.pure,
+              runtimeManager.getHistoryRepo,
+              DagMerger.costOptimalRejectionAlg
+            )
+          )
+      ((postState, rejectedDeploys), mergeTime) = v
+      mergedState                               = ByteString.copyFrom(postState.bytes.toArray)
+
+      // create next base block (merge block)
+      _ <- Log[F].info("Creating merge block...")
+      r <- mkBlocks[F](
+            validatorsWithPayments,
+            mergedState,
+            seqNum,
+            mergerBlockNum,
+            rejectedDeploys
+          ).last
+            .map {
+              case (b, balancesDiff) =>
+                (
+                  b.copy(header = b.header.copy(parentsHashList = toMerge.map(_.blockHash))),
+                  balancesDiff
+                )
+            }
+            .compile
+            .lastOrError
+      (nextBaseBlock, leaderPayments) = r
+      _                               <- dagStore.insert(nextBaseBlock, false)
+      _                               <- dagStore.recordDirectlyFinalized(nextBaseBlock.blockHash, _ => ().pure[F])
+      (rejectedLogs, acceptedLogs) = (nextBaseBlock +: toMerge)
+        .flatMap(_.body.deploys)
+        .map(d => (d, rejectedDeploys.contains(d.deploy.sig)))
+        .partition { case (_, rejected) => rejected }
+      commsAccepted = acceptedLogs
+        .flatMap(_._1.deployLog)
+        .collect { case c: CommEvent => c }
+        .size
+        .toLong
+      commsRejected = rejectedLogs
+        .flatMap(_._1.deployLog)
+        .collect { case c: CommEvent => c }
+        .size
+        .toLong
+    } yield LayerResult(
+      BlockWithPayments(nextBaseBlock, leaderPayments),
+      toMerge.zip(mergedPayments).map(BlockWithPayments.tupled),
+      rejectedDeploys.map(RejectedDeploy(_)).toList,
+      commsAccepted,
+      commsRejected,
+      mergeTime
+    )
+  }
+
+  final case class ValidatorWithPayments(validator: PublicKey, payments: Seq[Payment])
+  def go[F[_]: Concurrent: Time: RuntimeManager: BlockDagStorage: Log: Metrics](
+      genesis: BlockMessage,
+      layers: Iterator[Seq[ValidatorWithPayments]],
+      initBalances: BalanceSheet,
+      epochLength: Int,
+      mergesNum: Int = 1
+  ): Stream[F, (List[BlockMessage], BlockMessage)] = {
+    val usersToTrack = initBalances
+      .filterNot {
+        // do not check per validator vaults
+        case (User(_, pk, _), _) =>
+          layers.next().map(_.validator).contains(pk)
+      }
+
+    def newLayer(
+        validatorsWithPayments: Seq[ValidatorWithPayments],
+        baseBlock: BlockMessage,
+        balanceSheetAcc: BalanceSheet,
+        acceptedCommsAcc: Long,
+        rejectedCommsAcc: Long,
+        durAcc: Long,
+        layerNum: Int
+    ): F[(BlockMessage, List[BlockMessage], Int, BalanceSheet, Long, Long, Long)] =
+      for {
+        v <- Stopwatch.durationNano(
+              mkLayer(validatorsWithPayments.toList, baseBlock, BlockDagStorage[F])
+            )
+        (
+          LayerResult(
+            mergeBlockWithPayments,
+            mergedBlocksWithPayments,
+            rejectedOnMerge,
+            commsAccepted,
+            commsRejected,
+            mergeTime
+          ),
+          dur
+        ) = v
+
+        // 1. initial check
+        _ <- new Exception("State is not changed.").raiseError.whenA(
+              baseBlock.body.state.postStateHash == mergeBlockWithPayments.b.body.state.postStateHash
+            )
+        isEpochMerge           = mergedBlocksWithPayments.head.b.body.state.blockNumber % epochLength == 0
+        paymentsOfferedToMerge = mergedBlocksWithPayments.map(_.payments)
+        conflictingPaymentsPresent = conflictsPresent(
+          paymentsOfferedToMerge.map(_.map(_.v.payment))
+        )
+        closeBlocksOfferedToMerge = mergedBlocksWithPayments
+          .map(_.b)
+          .map(DeployIndex.sysCloseBlockId)
+        rejections = rejectedOnMerge.map(_.sig)
+        // a. when merging epoch all but one closeBlocks should be rejected
+        badEpochMerge = isEpochMerge && (closeBlocksOfferedToMerge diff rejections).size != 1
+        _ <- new Exception(
+              "More then one close block left unrejected when merging blocks with epoch change"
+            ).raiseError.whenA(badEpochMerge)
+        // b. if conflicting payments present - there have to be rejected deploys
+        // this check for epoch merge is problematic because close block on epoch depends on all payments
+        // so all deploys are rejected
+        wrongPaymentRejection = !isEpochMerge && rejectedOnMerge.nonEmpty != conflictingPaymentsPresent
+        _ <- new Exception(
+              "Transfers are conflicting but no rejections or vice versa."
+            ).raiseError.whenA(wrongPaymentRejection)
+
+        // 2. balances check
+        paymentsMerged = paymentsOfferedToMerge.flatten.map { dwp =>
+          if (rejectedOnMerge.map(_.sig).contains(dwp.v.d.sig)) {
+            dwp.copy(
+              charge = dwp.charge.copy(rejected = true),
+              v = dwp.v.copy(payment = dwp.v.payment.copy(rejected = true))
+            )
+          } else dwp
+        }
+        paymentsInMerge = mergeBlockWithPayments.payments
+        newBalanceSheet = (paymentsInMerge ++ paymentsMerged)
+          .flatMap { dwp =>
+            val v = List(dwp.charge, dwp.v.payment)
+            assert(
+              dwp.charge.rejected == dwp.v.payment.rejected,
+              s"charge rejected ${dwp.charge.rejected}, payment rejected: ${dwp.v.payment.rejected}"
+            )
+            v
+          }
+          .foldLeft(balanceSheetAcc) {
+            case (acc, p) =>
+              acc +
+                (p.source -> {
+                  val (currB, currPs) =
+                    acc.getOrElse(p.source, (0L, List.empty[Payment]))
+                  (
+                    if (p.rejected || p.source == p.dest) currB
+                    else currB - p.amt,
+                    p +: currPs
+                  )
+                }) +
+                (p.dest -> {
+                  val (currB, currPs) =
+                    acc.getOrElse(p.dest, (0L, List.empty[Payment]))
+                  (
+                    if (p.rejected || p.source == p.dest) currB
+                    else currB + p.amt,
+                    p +: currPs
+                  )
+                })
+          }
+        // a. verify new balance sheet - each tx has charge so number of TX should be even
+        paymentsRejected = newBalanceSheet.flatMap(_._2._2).toSet.count(_.rejected)
+        paymentsIn       = newBalanceSheet.flatMap(_._2._2).toSet.count(v => !v.rejected)
+        _ <- new Exception(
+              s"Rejected payments number is odd ($paymentsRejected) (are you including charge?)"
+            ).raiseError.whenA(paymentsRejected % 2 != 0)
+        _ <- new Exception(
+              s"Accepted payments number is odd ($paymentsIn) (are you including charge?)"
+            ).raiseError.whenA(paymentsIn % 2 != 0)
+        // b. verify state balances
+        toVerify    = newBalanceSheet.filterKeys(usersToTrack.contains)
+        usersMadeTx = toVerify.filter { case (_, (_, txs)) => txs.nonEmpty }
+        _ <- Log[F].info(s"Verifying ${toVerify.size} vaults balances at state ${Base16
+              .encode(mergeBlockWithPayments.b.body.state.postStateHash.toByteArray)}")
+        _ <- verifyBalances(
+              toVerify.iterator,
+              mergeBlockWithPayments.b.body.state.postStateHash
+            )
+
+        // Log
+        txRejected          = paymentsRejected / 2
+        txIn                = paymentsIn / 2
+        txTotal             = txIn + txRejected
+        newAcceptedCommsAcc = acceptedCommsAcc + commsAccepted
+        newRejectedCommsAcc = rejectedCommsAcc + commsRejected
+        newDurAcc           = durAcc + dur
+        nextLayerNum        = layerNum + 1
+
+        _ <- Log[F].info(
+              s"""
+           |Layer ${nextLayerNum} accomplished. Layer stats:
+           | Time spent: ${Stopwatch.showTime(FiniteDuration(dur, NANOSECONDS))}
+           | Time spent on merge: $mergeTime
+           | COMM events accepted: ${commsAccepted}
+           | COMM events rejected: ${commsRejected}
+           |Network stats:
+           | Validators num: ${validatorsWithPayments.size}
+           | Users total: ${newBalanceSheet.size - validatorsWithPayments.size}
+           | Users involved in TX: ${usersMadeTx.size}
+           | Payments accepted: ${txIn} (${txIn.toFloat / txTotal * 100} %)
+           | Payments rejected: ${txRejected} (${txRejected.toFloat / txTotal * 100} %)
+           | Avg payments per block: ${txTotal.toFloat / nextLayerNum / validatorsWithPayments.size}
+           | COMMs accepted total: $newAcceptedCommsAcc
+           | COMMs rejected total: $newRejectedCommsAcc
+           | Time spent: ${Stopwatch
+                   .showTime(FiniteDuration(newDurAcc, NANOSECONDS))} $newDurAcc
+           | COMM EVENTS PER SEC (include rejected): ${(newAcceptedCommsAcc + newRejectedCommsAcc)
+                   .floatValue() / (newDurAcc.floatValue() / 1e9)}
+           | COMM EVENTS PER SEC (real):  ${newAcceptedCommsAcc
+                   .floatValue() / (newDurAcc.floatValue() / 1e9)}
+           |""".stripMargin
+            )
+      } yield (
+        mergeBlockWithPayments.b,
+        mergedBlocksWithPayments.map(_.b),
+        nextLayerNum,
+        newBalanceSheet,
+        newAcceptedCommsAcc,
+        newRejectedCommsAcc,
+        newDurAcc
+      )
+
+    Stream
+      .unfoldLoopEval((genesis, 0, initBalances, 0L, 0L, 0L)) {
+        case (
+            baseBlock,
+            layerNum,
+            balanceSheetAcc,
+            acceptedCommsAcc,
+            rejectedCommsAcc,
+            durAcc
+            ) =>
+          val validatorsWithPayments = layers.next()
+
+          for {
+            _ <- Log[F].info("Verifying vaults balances at genesis...")
+            _ <- verifyBalances(
+                  initBalances.filterKeys(usersToTrack.contains).iterator,
+                  genesis.body.state.postStateHash
+                ).whenA(layerNum == 0)
+            _ <- Log[F].info(s"Done. OK for ${usersToTrack.size} vaults at state ${Base16
+                  .encode(genesis.body.state.postStateHash.toByteArray)}.")
+            r <- newLayer(
+                  validatorsWithPayments,
+                  baseBlock,
+                  balanceSheetAcc,
+                  acceptedCommsAcc,
+                  rejectedCommsAcc,
+                  durAcc,
+                  layerNum
+                )
+            (
+              b,
+              merged,
+              nextLayerNum,
+              newBalanceSheet,
+              newAcceptedCommsAcc,
+              newRejectedCommsAcc,
+              newDurAcc
+            ) = r
+
+            out = (merged, b)
+            next = (
+              b,
+              nextLayerNum,
+              newBalanceSheet,
+              newAcceptedCommsAcc,
+              newRejectedCommsAcc,
+              newDurAcc
+            )
+          } yield (out, (nextLayerNum < mergesNum).guard[Option].as(next))
+      }
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/benchmark/utils/Payment.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/utils/Payment.scala
@@ -1,0 +1,156 @@
+package coop.rchain.node.benchmark.utils
+
+import cats.Functor
+import cats.effect.Concurrent
+import cats.syntax.all._
+import coop.rchain.casper.protocol.DeployData
+import coop.rchain.casper.util.ConstructDeploy
+import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.signatures.Signed
+import coop.rchain.node.benchmark.utils
+import coop.rchain.node.revvaultexport.VaultBalanceGetter
+import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.shared.Time
+import coop.rchain.shared.syntax._
+import fs2.Stream
+
+import scala.collection.Seq
+import scala.util.Random
+
+final case class Payment(
+    source: User,
+    dest: User,
+    amt: Long,
+    rejected: Boolean = false
+)
+final case class PaymentDeploy(d: Signed[DeployData], payment: Payment)
+final case class Charged[A](v: A, charge: Payment)
+
+object Payment {
+
+  type BalanceSheet = Map[User, (Long, Seq[Payment])]
+
+  val rnd = new Random(System.currentTimeMillis())
+
+  def random(users: Seq[User], minTxAmt: Int, maxTxAmt: Int): Iterator[Payment] =
+    Iterator.continually({
+      val s   = users(rnd.nextInt(users.length))
+      val t   = users(rnd.nextInt(users.length))
+      val amt = minTxAmt + rnd.nextInt((maxTxAmt - minTxAmt) + 1).toLong
+      utils.Payment(s, t, amt)
+    })
+
+  def randomBatches(
+      users: Seq[User],
+      minTxAmt: Int,
+      maxTxAmt: Int,
+      maxSize: Int
+  ): Iterator[Seq[Payment]] = {
+    require(maxSize > 0, "randomBatches accepts only positive maxSize")
+    random(users, minTxAmt, maxTxAmt)
+      .grouped(maxSize)
+      .map(l => l.take(1 + rnd.nextInt(l.size)))
+  }
+
+  def conflictsPresent(payments: List[Seq[Payment]]): Boolean =
+    payments
+      .combinations(2)
+      .filter {
+        case List(l, r) =>
+          // conflict present if the same sources or destinations are used
+          ((l.map(v => v.dest) ++ l.map(v => v.source)) intersect (r.map(v => v.dest) ++ r.map(
+            v => v.source
+          ))).nonEmpty
+      }
+      .take(1)
+      .nonEmpty
+
+  def mkTxDeploy[F[_]: Functor: Time](
+      payment: Payment,
+      printDebug: Boolean = true
+  ): F[PaymentDeploy] = {
+    def txRho(payer: String, payee: String, amt: Long) = {
+      val tx =
+        if (printDebug) s"""@vault!("transfer", to, amount, *key, *resultCh) |
+                          | for (@r <- resultCh) {
+                          |   stdout!(("${payer} -> ${payee}", "${amt}", sender, r))
+                          | }
+                          |"""
+        else s"""@vault!("transfer", to, amount, *key, *resultCh)"""
+
+      s"""
+         |new
+         |  rl(`rho:registry:lookup`), stdout(`rho:io:stdout`),  revVaultCh, log, getBlockData(`rho:block:data`), blockDataCh
+         |in {
+         |  rl!(`rho:rchain:revVault`, *revVaultCh) |
+         |  getBlockData!(*blockDataCh) |
+         |  for (@(_, revVault) <- revVaultCh; _, _, @sender <- blockDataCh) {
+         |    match ("${payer}", "${payee}", ${amt}) {
+         |      (from, to, amount) => {
+         |        new vaultCh, revVaultKeyCh, deployerId(`rho:rchain:deployerId`) in {
+         |          @revVault!("findOrCreate", from, *vaultCh) |
+         |          @revVault!("deployerAuthKey", *deployerId, *revVaultKeyCh) |
+         |          for (@(true, vault) <- vaultCh; key <- revVaultKeyCh) {
+         |            new resultCh, r in { 
+         |              ${tx}
+         |            }
+         |          }
+         |        }
+         |      }
+         |    }
+         |  }
+         |}""".stripMargin
+    }
+
+    val payerKey  = payment.source.sk
+    val payerAddr = payment.source.addr
+    val payeeAddr = payment.dest.addr
+    val amt       = payment.amt
+    ConstructDeploy
+      .sourceDeployNowF[F](txRho(payerAddr, payeeAddr, amt), sec = payerKey)
+      .map(PaymentDeploy(_, payment))
+  }
+
+  def verifyBalances[F[_]: Concurrent](
+      balances: Iterator[(User, (Long, Seq[Payment]))],
+      state: StateHash
+  )(
+      implicit runtimeManager: RuntimeManager[F]
+  ): F[Unit] = {
+
+    def getVault(addr: String): String =
+      s"""new return, rl(`rho:registry:lookup`), RevVaultCh, vaultCh, balanceCh in {
+         |  rl!(`rho:rchain:revVault`, *RevVaultCh) |
+         |  for (@(_, RevVault) <- RevVaultCh) {
+         |    @RevVault!("findOrCreate", "${addr}", *vaultCh) |
+         |    for (@(true, vault) <- vaultCh) {
+         |      return!(vault)
+         |    }
+         |  }
+         |}
+         |""".stripMargin
+
+    Stream
+      .fromIterator(balances)
+      .parEvalMapProcBounded {
+        case (User(_, _, addr), (paperBalance, txs)) =>
+          for {
+            vaultPar    <- runtimeManager.playExploratoryDeploy(getVault(addr), state)
+            runtime     <- runtimeManager.spawnRuntime
+            _           <- runtime.reset(Blake2b256Hash.fromByteString(state))
+            realBalance <- VaultBalanceGetter.getBalanceFromVaultPar(vaultPar.head, runtime)
+            errMsg      = s"""
+               |Balance verification for ${addr} failed.               
+               |State balance = ${realBalance.get} (${Base16.encode(state.toByteArray)} ), paper balance = $paperBalance.              
+               |Transfers list: 
+               |${txs.mkString("\n")}
+               |""".stripMargin
+            _           <- new Exception(errMsg).raiseError.unlessA(realBalance.contains(paperBalance))
+          } yield ()
+      }
+      .compile
+      .lastOrError
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/benchmark/utils/Payment.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/utils/Payment.scala
@@ -3,7 +3,7 @@ package coop.rchain.node.benchmark.utils
 import cats.Functor
 import cats.effect.Concurrent
 import cats.syntax.all._
-import coop.rchain.casper.protocol.DeployData
+import coop.rchain.casper.protocol.{BlockMessage, DeployData}
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
@@ -23,12 +23,15 @@ final case class Payment(
     source: User,
     dest: User,
     amt: Long,
-    rejected: Boolean = false
+    rejected: Boolean = false,
+    timestamp: Long = Random.nextLong() // this is to make all payments different
 )
 final case class PaymentDeploy(d: Signed[DeployData], payment: Payment)
 final case class Charged[A](v: A, charge: Payment)
 
 object Payment {
+
+  final case class BlockWithPayments(b: BlockMessage, payments: Seq[Charged[PaymentDeploy]])
 
   type BalanceSheet = Map[User, (Long, Seq[Payment])]
 

--- a/node/src/main/scala/coop/rchain/node/benchmark/utils/StateTransition.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/utils/StateTransition.scala
@@ -1,0 +1,78 @@
+package coop.rchain.node.benchmark.utils
+
+import cats.effect.Concurrent
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol.{DeployData, ProcessedDeploy, ProcessedSystemDeploy}
+import coop.rchain.casper.util.rholang.costacc.CloseBlockDeploy
+import coop.rchain.casper.util.rholang.{RuntimeManager, SystemDeployUtil}
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.signatures.Signed
+import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
+import coop.rchain.models.block.StateHash.StateHash
+import coop.rchain.node.benchmark.utils
+import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
+import coop.rchain.rholang.interpreter.util.RevAddress
+import coop.rchain.shared.Time
+
+import scala.collection.Seq
+
+object StateTransition {
+
+  final case class StateTransitionResult(
+      finalState: StateHash,
+      paymentsDone: Seq[Charged[PaymentDeploy]],
+      processedDeploys: Seq[ProcessedDeploy],
+      processedSysDeploys: Seq[ProcessedSystemDeploy]
+  )
+
+  /** Make state transition */
+  def make[F[_]: Concurrent: RuntimeManager: Time](
+      baseState: StateHash,
+      validator: PublicKey,
+      seqNum: Int,
+      blockNum: Long,
+      payments: List[Payment]
+  ): F[StateTransitionResult] = {
+    val perValidatorVault =
+      User(PrivateKey(ByteString.EMPTY), validator, Base16.encode(validator.bytes))
+
+    def computeState(
+        userDeploys: Seq[Signed[DeployData]]
+    ): F[(StateHash, Seq[ProcessedDeploy], Seq[ProcessedSystemDeploy])] = {
+      val cbRandomSeed = SystemDeployUtil.generateCloseDeployRandomSeed(validator, seqNum)
+      assert(userDeploys.nonEmpty, "Attempting to compute state without user deploys.")
+      RuntimeManager[F]
+        .computeState(baseState)(
+          terms = userDeploys.distinct,
+          systemDeploys = CloseBlockDeploy(cbRandomSeed) :: Nil,
+          blockData = BlockData(userDeploys.head.data.timestamp, blockNum, validator, seqNum),
+          invalidBlocks = Map.empty[BlockHash, Validator]
+        )
+    }
+    for {
+      paymentDeploys <- payments.traverse(Payment.mkTxDeploy(_, printDebug = false))
+      r <- computeState(paymentDeploys.map(_.d)).map {
+            case (s, processedDeploys, sp) =>
+              assert(
+                !processedDeploys.exists(_.isFailed),
+                "Failed deploys found. Check if you users have enough REV to continue payments."
+              )
+              val charged =
+                processedDeploys.map { d =>
+                  val payerAddr = RevAddress.fromPublicKey(d.deploy.pk).get.address.toBase58
+                  val charge = utils.Payment(
+                    // TODO key not avail here, but not needed actually
+                    User(PrivateKey(ByteString.EMPTY), d.deploy.pk, payerAddr),
+                    perValidatorVault,
+                    d.cost.cost
+                  )
+                  Charged(paymentDeploys.find(_.d.sig == d.deploy.sig).get, charge)
+                }
+              StateTransitionResult(s, charged, processedDeploys, sp)
+          }
+    } yield r
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/benchmark/utils/User.scala
+++ b/node/src/main/scala/coop/rchain/node/benchmark/utils/User.scala
@@ -1,0 +1,20 @@
+package coop.rchain.node.benchmark.utils
+
+import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.rholang.interpreter.util.RevAddress
+
+final case class User(sk: PrivateKey, pk: PublicKey, addr: String) {
+  override def equals(obj: Any): Boolean = obj match {
+    case User(_, _, a) => a == addr
+    case _             => false
+  }
+  override def hashCode(): Int = addr.hashCode()
+}
+
+object User {
+  def random: Iterator[User] =
+    Iterator.continually(Secp256k1.newKeyPair).map {
+      case (sk, pk) => User(sk, pk, RevAddress.fromPublicKey(pk).get.address.toBase58)
+    }
+}

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -546,6 +546,15 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       val maxConcurrentTx = opt[Int](default = Some(40))
     }
     addSubcommand(concurrency)
+
+    val leaderful = new Subcommand("leaderful") {
+      helpWidth(width)
+      val validatorsNum = opt[Int](default = Some(5), name = "validators-num")
+      val usersNum      = opt[Int](default = Some(10), name = "users-num")
+      val maxTxPerBlock = opt[Int](default = Some(5), name = "max-block-tx")
+      val epochLength   = opt[Int](default = Some(10), name = "epoch-length")
+    }
+    addSubcommand(leaderful)
   }
   addSubcommand(bench)
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -534,6 +534,21 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(run)
 
+  val bench = new Subcommand("bench") {
+    descr("benchmark")
+
+    val dataDir = opt[Path](
+      default = Some(Path.of("~/.rnode")),
+      name = "data-dir"
+    )
+
+    val concurrency = new Subcommand("concurrency") {
+      val maxConcurrentTx = opt[Int](default = Some(40))
+    }
+    addSubcommand(concurrency)
+  }
+  addSubcommand(bench)
+
   val keygen = new Subcommand("keygen") {
     descr(
       "Generates a public/private key pair. Files created are: \n" +

--- a/node/src/test/scala/coop/rchain/node/hardening/Hardening.scala
+++ b/node/src/test/scala/coop/rchain/node/hardening/Hardening.scala
@@ -1,0 +1,120 @@
+package coop.rchain.node.hardening
+
+import cats.Monad
+import cats.effect.Concurrent
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.KeyValueBlockStore
+import coop.rchain.blockstorage.dag.BlockDagKeyValueStorage
+import coop.rchain.casper.genesis.Genesis
+import coop.rchain.casper.genesis.contracts.Validator
+import coop.rchain.casper.merging.DeployIndex._
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.crypto.codec.Base16
+import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.metrics.{Metrics, NoopSpan}
+import coop.rchain.node.benchmark.utils.GenesisParams.genesisParameters
+import coop.rchain.node.benchmark.utils.LeaderfulSimulation.ValidatorWithPayments
+import coop.rchain.node.benchmark.utils.Payment.BalanceSheet
+import coop.rchain.node.benchmark.utils.{LeaderfulSimulation, Payment, User}
+import coop.rchain.node.effects
+import coop.rchain.rspace.syntax._
+import coop.rchain.shared.scalatestcontrib.effectTest
+import coop.rchain.shared.{Log, Time}
+import coop.rchain.store.InMemoryStoreManager
+import fs2.Pipe
+import fs2.Stream
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.collection.Seq
+
+class Hardening extends FlatSpec with Matchers {
+
+  "leaderful DAG" should "be ok" in effectTest {
+
+    val nUsers        = 20
+    val nValidators   = 4
+    val maxTxPerBlock = 1
+
+    val users = User.random.take(nUsers).toList
+    val validators = (1 to nValidators)
+      .map(_ => Secp256k1.newKeyPair)
+      .map { case (_, pk) => pk }
+      .toList
+    val payments = Payment.randomBatches(users, 1, 10, maxTxPerBlock)
+
+    val epochLength = 3
+
+    /**
+      *    * 10 -> 2 of 3 closeBlock should be rejected
+      * ***  9  -> epoch change
+      *    * 8
+      * ***  7
+      *    * 6  -> epoch change, no closeBlock should be rejected
+      * ***  5
+      *    * 4  -> 2 of 3 closeBlock should be rejected
+      * ***  3  -> epoch change
+      *    * 2  -> no closeBlock should be rejected
+      * ***  1
+      * GGGG 0
+      */
+    val validatorsWithPayments = Iterator
+      .continually(validators)
+      .flatten
+      .zip(payments)
+      .map(ValidatorWithPayments.tupled)
+      .grouped(validators.size)
+
+    implicit val c                                 = Concurrent[Task]
+    implicit val metrics: Metrics.MetricsNOP[Task] = new Metrics.MetricsNOP
+    implicit val logEff                            = Log.log[Task]
+    implicit val time: Time[Task]                  = effects.time
+    implicit val span                              = new NoopSpan[Task]
+
+    // run everything in memory
+    val rnodeStoreManager = new InMemoryStoreManager
+
+    for {
+      rSpaceStores    <- rnodeStoreManager.rSpaceStores
+      runtimeManager  <- RuntimeManager(rSpaceStores)
+      blockStore      <- KeyValueBlockStore(rnodeStoreManager)
+      blockDagStorage <- BlockDagKeyValueStorage.create(rnodeStoreManager)
+      r <- {
+        val genesisVaults = users.map(_.pk)
+        val bondedValidators = validators.zipWithIndex
+          .map { case (v, i) => Validator(v, (2L * i.toLong + 1L)) }
+
+        Genesis
+          .createGenesisBlock(
+            runtimeManager,
+            genesisParameters(bondedValidators, genesisVaults, epochLength = epochLength)
+          )
+          .map((_, users, validators))
+      }
+      (genesis, users, validators) = r
+      _                            <- blockStore.put(genesis.blockHash, genesis)
+      _                            <- blockDagStorage.insert(genesis, invalid = false, approved = true)
+      layers = {
+        implicit val rm  = runtimeManager
+        implicit val bds = blockDagStorage
+
+        val initUserBalances = users.map {
+          case User(_, pk, _) =>
+            (users.find(_.pk == pk).get, (900000000L, Seq.empty[Payment]))
+        }.toMap
+        val validatorUsers = validators.map { pk =>
+          User(PrivateKey(ByteString.EMPTY), pk, Base16.encode(pk.bytes))
+        }
+        val initValidatorBalances = validatorUsers.map(_ -> (0L, List.empty)).toMap
+        val initBalances          = initUserBalances ++ initValidatorBalances
+
+        LeaderfulSimulation
+          .go(genesis, validatorsWithPayments, initBalances, 3, 5)
+      }
+      _ <- layers.compile.lastOrError
+    } yield ()
+  }
+}

--- a/shared/src/main/scala/coop/rchain/shared/Stopwatch.scala
+++ b/shared/src/main/scala/coop/rchain/shared/Stopwatch.scala
@@ -25,6 +25,14 @@ object Stopwatch {
       m  = Duration.fromNanos(t1 - t0)
     } yield (a, showTime(m))
 
+  def durationNano[F[_]: Sync, A](block: => F[A]): F[(A, Long)] =
+    for {
+      t0 <- Sync[F].delay(System.nanoTime)
+      a  <- block
+      t1 = System.nanoTime
+      m  = t1 - t0
+    } yield (a, m)
+
   def profile[A](block: => A): (A, String) = {
     val t0 = System.nanoTime
     val a  = block


### PR DESCRIPTION
## Overview
This PR introduces two benchmarks:

1) **Node is following leaderful network**. Behaviour is identical, without networking layer. Given N validators, N-1 block added concurrently, then merged block added.  This pattern repeats. For hardening purposes, REV transfers are simulated in the network, and balances are verified after each new layer created.
```rnode bench leaderful --validators-num 30 --users-num 1000 --max-block-tx 1 --epoch-length 10000```
It is useful to test scaling. By adjusting `--validators-num` from 1 to X scaling ability can be estimated. In this case better to set epochLength to big value so it does not happen in test, because epoch change block takes longer to process. In addition `--max-block-tx 1` should be used, so each block is created with the same number of deploys.
The difference of this benchmark from real network is that each block creation in benchmark is play+replay+validation in real network, and networking overhead (which should not be big) is not accounted for.

2) **Scaling of concurrent block validation**. More simple test which just emulate concurrent block processing, without logic to harder merging (multiple transfers in block, balances validation).
```rnode bench concurrency --max-concurrent-tx 100```

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
