### PR TITLE
Mark branches with duplicated deploys as conflicting

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
@@ -63,11 +63,11 @@ object BlockIndex {
       sysDeploysData = sysProcessedDeploys.toVector
         .collect {
           case Succeeded(log, SlashSystemDeployData(_, _)) =>
-            (SYS_SLASH_DEPLOY_ID, SYS_SLASH_DEPLOY_COST, log)
+            (blockHash.concat(SYS_SLASH_DEPLOY_ID), SYS_SLASH_DEPLOY_COST, log)
           case Succeeded(log, CloseBlockSystemDeployData) =>
-            (SYS_CLOSE_BLOCK_DEPLOY_ID, SYS_CLOSE_BLOCK_DEPLOY_COST, log)
+            (blockHash.concat(SYS_CLOSE_BLOCK_DEPLOY_ID), SYS_CLOSE_BLOCK_DEPLOY_COST, log)
           case Succeeded(log, Empty) =>
-            (SYS_EMPTY_DEPLOY_ID, SYS_EMPTY_DEPLOY_COST, log)
+            (blockHash.concat(SYS_EMPTY_DEPLOY_ID), SYS_EMPTY_DEPLOY_COST, log)
         }
       sysDeployIndices <- sysDeploysData.traverse {
                            case (sig, cost, log) =>

--- a/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
@@ -39,10 +39,11 @@ object DagMerger {
       lateSet <- lateBlocks.toList.traverse(index).map(_.flatten.toSet)
 
       branchesAreConflicting = (as: Set[DeployChainIndex], bs: Set[DeployChainIndex]) =>
-        MergingLogic.areConflicting(
-          as.map(_.eventLogIndex).toList.combineAll,
-          bs.map(_.eventLogIndex).toList.combineAll
-        )
+        (as.flatMap(_.deploysWithCost.map(_.id)) intersect bs.flatMap(_.deploysWithCost.map(_.id))).nonEmpty ||
+          MergingLogic.areConflicting(
+            as.map(_.eventLogIndex).toList.combineAll,
+            bs.map(_.eventLogIndex).toList.combineAll
+          )
 
       computeTrieActions = (baseState: Blake2b256Hash, changes: StateChange) => {
         val baseReader = historyRepository.getHistoryReader(baseState).readerBinary

--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployIndex.scala
@@ -20,9 +20,9 @@ object DeployIndex {
   val SYS_CLOSE_BLOCK_DEPLOY_COST = 0L
   val SYS_EMPTY_DEPLOY_COST       = 0L
   // These are to be put in rejected set in blocks, so prefix format is defined for identification purposes.
-  val SYS_SLASH_DEPLOY_ID       = ByteString.copyFrom(64.toByte +: new Array[Byte](31))  // 1000000xxx
-  val SYS_CLOSE_BLOCK_DEPLOY_ID = ByteString.copyFrom(96.toByte +: new Array[Byte](31))  // 1100000xxx
-  val SYS_EMPTY_DEPLOY_ID       = ByteString.copyFrom(112.toByte +: new Array[Byte](31)) // 1110000xxx
+  val SYS_SLASH_DEPLOY_ID       = ByteString.copyFrom(Array(1.toByte))
+  val SYS_CLOSE_BLOCK_DEPLOY_ID = ByteString.copyFrom(Array(2.toByte))
+  val SYS_EMPTY_DEPLOY_ID       = ByteString.copyFrom(Array(3.toByte))
 
   def apply[F[_]: Concurrent](
       sig: ByteString,


### PR DESCRIPTION
## Overview
As the same deploys can be submitted to multiple validators, there might be the the same deploy included in different instances of `DeployChainIndex` inside merging scope. And the same deploy be part of multiple branches that are merged. 
This PR ensures two branches are conflicting if they contain duplicated deploys.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
