### PR TITLE
Define reasons for propose. Enable attestation messages.

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -49,6 +49,7 @@ trait BlockDagRepresentation[F[_]] {
       latestMessages: Map[Validator, BlockHash],
       findLfb: Map[Validator, BlockHash] => F[BlockHash]
   ): F[BlockDagRepresentation[F]]
+  def reachedAcquiescence: F[Boolean]
 }
 
 trait EquivocationsTracker[F[_]] {

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -12,7 +12,7 @@ import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.rholang._
 import coop.rchain.casper.util.rholang.costacc.{CloseBlockDeploy, SlashDeploy}
-import coop.rchain.casper.{CasperSnapshot, PrettyPrinter, ValidatorIdentity}
+import coop.rchain.casper.{Casper, CasperSnapshot, PrettyPrinter, ValidatorIdentity}
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.codec.Base16
 import coop.rchain.crypto.signatures.Signed
@@ -112,54 +112,50 @@ object BlockCreator {
             .generateCloseDeployRandomSeed(selfId, nextSeqNum)
         )
         deploys = userDeploys -- s.deploysInScope ++ dummyDeploys
-        r <- if (deploys.nonEmpty || slashingDeploys.nonEmpty)
-              for {
-                now           <- Time[F].currentMillis
-                invalidBlocks = s.invalidBlocks
-                blockData     = BlockData(now, nextBlockNum, validatorIdentity.publicKey, nextSeqNum)
-                checkpointData <- InterpreterUtil.computeDeploysCheckpoint(
-                                   parents,
-                                   deploys.toSeq,
-                                   systemDeploys,
-                                   s,
-                                   runtimeManager,
-                                   blockData,
-                                   invalidBlocks
-                                 )
-                (
-                  preStateHash,
-                  postStateHash,
-                  processedDeploys,
-                  rejectedDeploys,
-                  processedSystemDeploys
-                )             = checkpointData
-                newBonds      <- runtimeManager.computeBonds(postStateHash)
-                _             <- Span[F].mark("before-packing-block")
-                shardId       = s.onChainState.shardConf.shardName
-                casperVersion = s.onChainState.shardConf.casperVersion
-                // unsignedBlock got blockHash(hashed without signature)
-                unsignedBlock = packageBlock(
-                  blockData,
-                  parents.map(_.blockHash),
-                  justifications.toSeq,
-                  preStateHash,
-                  postStateHash,
-                  processedDeploys,
-                  rejectedDeploys,
-                  processedSystemDeploys,
-                  newBonds,
-                  shardId,
-                  casperVersion
-                )
-                _ <- Span[F].mark("block-created")
-                // signedBlock add signature and replace hashed-without-signature
-                // blockHash to hashed-with-signature blockHash
-                signedBlock = validatorIdentity.signBlock(unsignedBlock)
-                _           <- Span[F].mark("block-signed")
-              } yield BlockCreatorResult.created(signedBlock)
-            else
-              BlockCreatorResult.noNewDeploys.pure[F]
-      } yield r
+
+        now           <- Time[F].currentMillis
+        invalidBlocks = s.invalidBlocks
+        blockData     = BlockData(now, nextBlockNum, validatorIdentity.publicKey, nextSeqNum)
+        checkpointData <- InterpreterUtil.computeDeploysCheckpoint(
+                           parents,
+                           deploys.toSeq,
+                           systemDeploys,
+                           s,
+                           runtimeManager,
+                           blockData,
+                           invalidBlocks
+                         )
+        (
+          preStateHash,
+          postStateHash,
+          processedDeploys,
+          rejectedDeploys,
+          processedSystemDeploys
+        )             = checkpointData
+        newBonds      <- runtimeManager.computeBonds(postStateHash)
+        _             <- Span[F].mark("before-packing-block")
+        shardId       = s.onChainState.shardConf.shardName
+        casperVersion = s.onChainState.shardConf.casperVersion
+        // unsignedBlock got blockHash(hashed without signature)
+        unsignedBlock = packageBlock(
+          blockData,
+          parents.map(_.blockHash),
+          justifications.toSeq,
+          preStateHash,
+          postStateHash,
+          processedDeploys,
+          rejectedDeploys,
+          processedSystemDeploys,
+          newBonds,
+          shardId,
+          casperVersion
+        )
+        _ <- Span[F].mark("block-created")
+        // signedBlock add signature and replace hashed-without-signature
+        // blockHash to hashed-with-signature blockHash
+        signedBlock = validatorIdentity.signBlock(unsignedBlock)
+        _           <- Span[F].mark("block-signed")
+      } yield BlockCreatorResult.created(signedBlock)
 
       for {
         // Create block and measure duration

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/ProposeResult.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/ProposeResult.scala
@@ -22,12 +22,14 @@ sealed trait CheckProposeConstraintsFailure
 case object NotBonded                  extends CheckProposeConstraintsFailure
 case object NotEnoughNewBlocks         extends CheckProposeConstraintsFailure
 case object TooFarAheadOfLastFinalized extends CheckProposeConstraintsFailure
+case object NoReasonToPropose          extends CheckProposeConstraintsFailure
 
 object CheckProposeConstraintsResult {
   def success: CheckProposeConstraintsResult                    = CheckProposeConstraintsSuccess
   def notBonded: CheckProposeConstraintsResult                  = NotBonded
   def notEnoughNewBlock: CheckProposeConstraintsResult          = NotEnoughNewBlocks
   def tooFarAheadOfLastFinalized: CheckProposeConstraintsResult = TooFarAheadOfLastFinalized
+  def noReasonToPropose: CheckProposeConstraintsResult          = NoReasonToPropose
 }
 
 object ProposeResult {
@@ -35,7 +37,7 @@ object ProposeResult {
   implicit val showProposeResut: Show[ProposeStatus] = new Show[ProposeStatus] {
     def show(result: ProposeStatus): String = result match {
       case ProposeSuccess(r)   => s"Propose succeed: $r"
-      case NoNewDeploys        => s"Proposal failed: NoNewDeploys"
+      case NoReasonToPropose   => s"Proposal failed: NoReasonToPropose"
       case InternalDeployError => s"Proposal failed: internal deploy error"
       case NotBonded           => s"Proposal failed: ReadOnlyMode"
       case NotEnoughNewBlocks  => s"Proposal failed: Must wait for more blocks from other validators"
@@ -45,7 +47,7 @@ object ProposeResult {
     }
   }
 
-  def noNewDeploys: ProposeFailure                   = NoNewDeploys
+  def noReasonToPropose: ProposeResult               = ProposeResult(NoReasonToPropose)
   def internalDeployError: ProposeFailure            = InternalDeployError
   def notBonded: ProposeResult                       = ProposeResult(NotBonded)
   def notEnoughBlocks: ProposeResult                 = ProposeResult(NotEnoughNewBlocks)
@@ -55,9 +57,7 @@ object ProposeResult {
 }
 
 trait BlockCreatorResult
-case object NoNewDeploys                             extends BlockCreatorResult with ProposeFailure
 final case class Created(blockMessage: BlockMessage) extends BlockCreatorResult
 object BlockCreatorResult {
-  def noNewDeploys: BlockCreatorResult             = NoNewDeploys
   def created(b: BlockMessage): BlockCreatorResult = Created(b)
 }

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper._
-import coop.rchain.casper.blocks.proposer.NoNewDeploys
+import coop.rchain.casper.blocks.proposer.NoReasonToPropose
 import coop.rchain.casper._
 import coop.rchain.casper.helper.TestNode._
 import coop.rchain.casper.helper.{BlockUtil, TestNode}
@@ -126,22 +126,23 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
     }
   }
 
-  it should "not allow empty blocks with multiple parents" in effectTest {
-    TestNode.networkEff(genesis, networkSize = 2).use { nodes =>
-      for {
-        deployDatas <- (0 to 1).toList
-                        .traverse[Effect, Signed[DeployData]](
-                          i => ConstructDeploy.basicDeployData[Effect](i)
-                        )
-        _ <- nodes(0).addBlock(deployDatas(0))
-        _ <- nodes(1).addBlock(deployDatas(1))
-        _ <- nodes(1).handleReceive() // receive block1
-        _ <- nodes(0).handleReceive() // receive block2
-
-        status <- nodes(1).createBlock()
-      } yield (assert(status == NoNewDeploys))
-    }
-  }
+  // Test does not make sense given attestation messages
+//  it should "not allow empty blocks with multiple parents" in effectTest {
+//    TestNode.networkEff(genesis, networkSize = 2).use { nodes =>
+//      for {
+//        deployDatas <- (0 to 1).toList
+//                        .traverse[Effect, Signed[DeployData]](
+//                          i => ConstructDeploy.basicDeployData[Effect](i)
+//                        )
+//        _ <- nodes(0).addBlock(deployDatas(0))
+//        _ <- nodes(1).addBlock(deployDatas(1))
+//        _ <- nodes(1).handleReceive() // receive block1
+//        _ <- nodes(0).handleReceive() // receive block2
+//
+//        status <- nodes(1).createBlock()
+//      } yield (assert(status == NoReasonToPropose))
+//    }
+//  }
 
   it should "create valid blocks when peek syntax is present in a deploy" in effectTest {
     TestNode.standaloneEff(genesis).use { node =>

--- a/casper/src/test/scala/coop/rchain/casper/addblock/ProposerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/ProposerSpec.scala
@@ -7,10 +7,11 @@ import cats.syntax.all._
 import coop.rchain.casper._
 import coop.rchain.casper.blocks.proposer._
 import coop.rchain.casper.helper.{BlockDagStorageFixture, NoOpsCasperEffect}
-import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.protocol.{BlockMessage, DeployData}
 import coop.rchain.casper.util.GenesisBuilder.defaultValidatorSks
 import coop.rchain.casper.util.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.util.rholang.{Resources, RuntimeManager}
+import coop.rchain.crypto.signatures.Signed
 import coop.rchain.metrics.Metrics.MetricsNOP
 import coop.rchain.metrics.{NoopSpan, Span}
 import coop.rchain.models.BlockHash.BlockHash
@@ -95,7 +96,8 @@ class ProposerSpec extends FlatSpec with Matchers with BlockDagStorageFixture {
               createBlock = createBlockF,
               validateBlock = alwaysSuccesfullValidation,
               proposeEffect = proposeEffect(0),
-              validator = dummyValidatorIdentity
+              validator = dummyValidatorIdentity,
+              loadDeploys = Set.empty[Signed[DeployData]].pure[Task]
             )
 
             for {
@@ -125,7 +127,8 @@ class ProposerSpec extends FlatSpec with Matchers with BlockDagStorageFixture {
               createBlock = createBlockF,
               validateBlock = alwaysSuccesfullValidation,
               proposeEffect = proposeEffect(0),
-              validator = dummyValidatorIdentity
+              validator = dummyValidatorIdentity,
+              loadDeploys = Set.empty[Signed[DeployData]].pure[Task]
             )
 
             for {
@@ -154,7 +157,8 @@ class ProposerSpec extends FlatSpec with Matchers with BlockDagStorageFixture {
               createBlock = createBlockF,
               validateBlock = alwaysSuccesfullValidation,
               proposeEffect = proposeEffect(0),
-              validator = dummyValidatorIdentity
+              validator = dummyValidatorIdentity,
+              loadDeploys = Set.empty[Signed[DeployData]].pure[Task]
             )
             for {
               d      <- Deferred[Task, ProposerResult]
@@ -182,7 +186,8 @@ class ProposerSpec extends FlatSpec with Matchers with BlockDagStorageFixture {
                 getCasperSnapshot = getCasperSnapshotF,
                 createBlock = createBlockF,
                 proposeEffect = proposeEffect(0),
-                validator = dummyValidatorIdentity
+                validator = dummyValidatorIdentity,
+                loadDeploys = Set.empty[Signed[DeployData]].pure[Task]
               )
 
               for {
@@ -211,7 +216,8 @@ class ProposerSpec extends FlatSpec with Matchers with BlockDagStorageFixture {
               getCasperSnapshot = getCasperSnapshotF,
               createBlock = createBlockF,
               proposeEffect = proposeEffect(10),
-              validator = dummyValidatorIdentity
+              validator = dummyValidatorIdentity,
+              loadDeploys = Set.empty[Signed[DeployData]].pure[Task]
             )
 
             for {

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
@@ -1,6 +1,6 @@
 package coop.rchain.casper.batch1
 
-import coop.rchain.casper.blocks.proposer.{Created, NoNewDeploys}
+import coop.rchain.casper.blocks.proposer.{Created, NoReasonToPropose}
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode._
 import coop.rchain.casper.util.ConstructDeploy
@@ -31,7 +31,7 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
     }
   }
 
-  it should "not create a block with a repeated deploy" in effectTest {
+  it should "not put repeated deploy in a block" in effectTest {
     implicit val timeEff = new LogicalTime[Effect]
     TestNode.networkEff(genesis, networkSize = 2).use { nodes =>
       val List(node0, node1) = nodes.toList
@@ -39,7 +39,8 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
         deploy             <- ConstructDeploy.basicDeployData[Effect](0)
         _                  <- node0.propagateBlock(deploy)(node1)
         createBlockResult2 <- node1.createBlock(deploy)
-      } yield (createBlockResult2 should be(NoNewDeploys))
+        Created(b)         = createBlockResult2
+      } yield (b.body.deploys.size shouldBe 0)
     }
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -97,9 +97,10 @@ object Resources {
 
       override def latestMessageHash(validator: Validator): F[Option[BlockHash]] = ???
 
-      override def latestMessageHashes: F[Map[Validator, BlockHash]] = ???
+      override def latestMessageHashes: F[Map[Validator, BlockHash]] =
+        Map.empty[Validator, BlockHash].pure[F]
 
-      override def invalidBlocks: F[Set[BlockMetadata]] = ???
+      override def invalidBlocks: F[Set[BlockMetadata]] = Set.empty[BlockMetadata].pure[F]
 
       override def latestBlockNumber: F[Long] = ???
 

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -122,6 +122,8 @@ object Resources {
           latestMessages: Map[Validator, BlockHash],
           findLfb: Map[Validator, BlockHash] => F[BlockHash]
       ): F[BlockDagRepresentation[F]] = ???
+
+      override def reachedAcquiescence: F[Boolean] = false.pure[F]
     }
     CasperSnapshot[F](
       dummyRepresentation,

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -121,6 +121,7 @@ message BlockMetadataInternal {
   bool invalid                          = 8; // whether the block was marked as invalid
   bool directlyFinalized                = 9; // whether the block has been last finalized block (LFB)
   bool finalized                        = 10;// whether the block is finalized
+  bytes postStateHash                    = 11;// whether the block is finalized
 }
 
 message HeaderProto {

--- a/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadata.scala
@@ -6,6 +6,7 @@ import scalapb.TypeMapper
 
 final case class BlockMetadata(
     blockHash: ByteString,
+    postStateHash: ByteString,
     parents: List[ByteString],
     sender: ByteString,
     justifications: List[Justification],
@@ -23,6 +24,7 @@ object BlockMetadata {
   implicit val typeMapper = TypeMapper[BlockMetadataInternal, BlockMetadata] { internal =>
     BlockMetadata(
       internal.blockHash,
+      internal.postStateHash,
       internal.parents,
       internal.sender,
       internal.justifications.map(Justification.from),
@@ -44,7 +46,8 @@ object BlockMetadata {
       metadata.seqNum,
       metadata.invalid,
       metadata.directlyFinalized,
-      metadata.finalized
+      metadata.finalized,
+      metadata.postStateHash
     )
   }
 
@@ -75,6 +78,7 @@ object BlockMetadata {
   ): BlockMetadata =
     BlockMetadata(
       b.blockHash,
+      b.body.state.postStateHash,
       b.header.parentsHashList,
       b.sender,
       b.justifications,


### PR DESCRIPTION
## Overview
Define reasons for block creation.
Another approach to https://github.com/rchain/rchain/pull/3506 and https://github.com/rchain/rchain/pull/3452.


Motivation for this PR is upcoming block merge PR, which, given current bock producing logic, leads to high resource requirements. At the moment all blocks should contain some state transition, so include precharge and refund, which are costly until efficient REV vault inside History is implemented (as planned for HF3). 

Another motivation is making network lean, so not spending resources unless it serves the purpose of blockchain - maintaining state that network is agree on. Block merge release emphasises this issue.

Another point to add is that block merge not only motivated this solution, but also made it possible.

Attestation messages logic boils down to allowing proposing messages without user deploy and defining cases where this is appropriate. This replaces requirements for attestation messages and difficulties tied to using synchrony constraint. it looks like more elegant and straightforward solution.

**Please find description of proposed solution below.**

Casper messages serve only two purposes:
1. offering state transitions for validation by the network, and
2. participating in finalization of past state transitions.

Therefore message producing makes sense and should be allowed only if it is justified by these reasons.

Given said above here are rules for detecting if propose is justified:
1. State transition is offered (reason to create `STM` from from https://github.com/rchain/rchain/pull/3452).
   **a. there is a user deploy to be included in a block, or
   b. parents have different post state, so merge block should be issued.**
   Both of these rules can be validated, so offence an be detected.
2. Finalization of user deploys (reaching acquiescence) is not done. (reason to create AM from https://github.com/rchain/rchain/pull/3452.)
   **There are non finalized messages which do not share post state with some finalized message. So basically, if there are non finalized states known.**
   This rule also can be validated and offence detected.
   *TODO this might be narrowed down to "if sender already propagated its weight down to all states known", not finalization requirement*

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
