### PR TITLE
Fix edge case no user deploy log bug in transaction api

### DIFF
--- a/node/src/test/scala/coop/rchain/node/TransactionAPISpec.scala
+++ b/node/src/test/scala/coop/rchain/node/TransactionAPISpec.scala
@@ -6,6 +6,7 @@ import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.GenesisBuilder.{buildGenesis, GenesisContext}
 import coop.rchain.casper.util.rholang.Resources
+import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.models.Par
 import coop.rchain.node.web.{PreCharge, Refund, Transaction, UserDeploy}
@@ -15,43 +16,24 @@ import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 import monix.execution.Scheduler.Implicits.global
-
+import org.scalatest._
 class TransactionAPISpec extends FlatSpec with Matchers with Inspectors {
   val genesis: GenesisContext = buildGenesis()
 
-  "transfer rev" should "be gotten in transaction api" in {
-    TestNode.standaloneEff(genesis).use { node =>
-      val fromSk    = genesis.genesisVaultsSks.head
-      val fromAddr  = RevAddress.fromPublicKey(Secp256k1.toPublic(fromSk)).get.toBase58
-      val toPk      = genesis.genesisVaultsSks.last
-      val toAddr    = RevAddress.fromPublicKey(Secp256k1.toPublic(toPk)).get.toBase58
-      val amount    = 1L
-      val phloPrice = 1L
-      val phloLimit = 3000000L
-      import node._
-      def transferRho(fromAddr: String, toAddr: String, amount: Long) = s"""
-                          #new rl(`rho:registry:lookup`), RevVaultCh, vaultCh, toVaultCh, deployerId(`rho:rchain:deployerId`), revVaultKeyCh, resultCh in {
-                          #  rl!(`rho:rchain:revVault`, *RevVaultCh) |
-                          #  for (@(_, RevVault) <- RevVaultCh) {
-                          #    @RevVault!("findOrCreate", "$fromAddr", *vaultCh) |
-                          #    @RevVault!("findOrCreate", "$toAddr", *toVaultCh) |
-                          #    @RevVault!("deployerAuthKey", *deployerId, *revVaultKeyCh) |
-                          #    for (@(true, vault) <- vaultCh; key <- revVaultKeyCh; @(true, toVault) <- toVaultCh) {
-                          #      @vault!("transfer", "$toAddr", $amount, *key, *resultCh) |
-                          #      for (_ <- resultCh) { Nil }
-                          #    }
-                          #  }
-                          #}""".stripMargin('#')
+  def checkTransactionAPI(term: String, phloLimit: Long, phloPrice: Long, deployKey: PrivateKey) =
+    TestNode.networkEff(genesis, networkSize = 1, withReadOnlySize = 1).use { nodes =>
+      val validator = nodes(0)
+      val readonly  = nodes(1)
+      import readonly._
       for {
-        kvm             <- Resources.mkTestRNodeStoreManager[Task](node.dataDir)
+        kvm             <- Resources.mkTestRNodeStoreManager[Task](readonly.dataDir)
         rspaceStore     <- kvm.rSpaceStores
         reportingCasper = ReportingCasper.rhoReporter[Task](rspaceStore)
         reportingStore  <- ReportStore.store[Task](kvm)
         blockReportAPI  = BlockReportAPI[Task](reportingCasper, reportingStore)
-        term            = transferRho(fromAddr, toAddr, amount)
         deploy <- ConstructDeploy.sourceDeployNowF(
                    term,
-                   sec = fromSk,
+                   sec = deployKey,
                    phloLimit = phloLimit,
                    phloPrice = phloPrice
                  )
@@ -59,35 +41,112 @@ class TransactionAPISpec extends FlatSpec with Matchers with Inspectors {
           blockReportAPI,
           Par(unforgeables = Seq(Transaction.transferUnforgeable))
         )
-        transferBlock <- node.addBlock(deploy)
+        transferBlock <- validator.addBlock(deploy)
+        _             <- readonly.processBlock(transferBlock)
         transactions <- transactionAPI
                          .getTransaction(Blake2b256Hash.fromByteString(transferBlock.blockHash))
-        _ = transactions.length should be(3)
-        _ = transactions.foreach { t =>
-          t.transactionType match {
-            case UserDeploy(_) =>
-              t.transaction.fromAddr should be(fromAddr)
-              t.transaction.toAddr should be(toAddr)
-              t.transaction.amount should be(amount)
-              t.transaction.failReason should be(None)
 
-            case PreCharge(_) =>
-              t.transaction.fromAddr should be(fromAddr)
-              t.transaction.amount should be(phloLimit * phloPrice)
-              t.transaction.failReason should be(None)
-
-            case Refund(_) =>
-              t.transaction.toAddr should be(fromAddr)
-              t.transaction.amount should be(
-                phloLimit * phloPrice - transferBlock.body.deploys.head.cost.cost
-              )
-              t.transaction.failReason should be(None)
-            case _ => ()
-          }
-        }
-
-      } yield ()
+      } yield (transactions, transferBlock)
     }
+
+  "transfer rev" should "be gotten in transaction api" in {
+    val fromSk      = genesis.genesisVaultsSks.head
+    val fromAddr    = RevAddress.fromPublicKey(Secp256k1.toPublic(fromSk)).get.toBase58
+    val toPk        = genesis.genesisVaultsSks.last
+    val toAddr      = RevAddress.fromPublicKey(Secp256k1.toPublic(toPk)).get.toBase58
+    val amount      = 1L
+    val phloPrice   = 1L
+    val phloLimit   = 3000000L
+    val transferRho = s"""
+         #new rl(`rho:registry:lookup`), RevVaultCh, vaultCh, toVaultCh, deployerId(`rho:rchain:deployerId`), revVaultKeyCh, resultCh in {
+         #  rl!(`rho:rchain:revVault`, *RevVaultCh) |
+         #  for (@(_, RevVault) <- RevVaultCh) {
+         #    @RevVault!("findOrCreate", "$fromAddr", *vaultCh) |
+         #    @RevVault!("findOrCreate", "$toAddr", *toVaultCh) |
+         #    @RevVault!("deployerAuthKey", *deployerId, *revVaultKeyCh) |
+         #    for (@(true, vault) <- vaultCh; key <- revVaultKeyCh; @(true, toVault) <- toVaultCh) {
+         #      @vault!("transfer", "$toAddr", $amount, *key, *resultCh) |
+         #      for (_ <- resultCh) { Nil }
+         #    }
+         #  }
+         #}""".stripMargin('#')
+    (for {
+      result                        <- checkTransactionAPI(transferRho, phloLimit, phloPrice, fromSk)
+      (transactions, transferBlock) = result
+      _                             = transactions.length should be(3)
+      _ = transactions.foreach { t =>
+        t.transactionType match {
+          case UserDeploy(_) =>
+            t.transaction.fromAddr should be(fromAddr)
+            t.transaction.toAddr should be(toAddr)
+            t.transaction.amount should be(amount)
+            t.transaction.failReason should be(None)
+
+          case PreCharge(_) =>
+            t.transaction.fromAddr should be(fromAddr)
+            t.transaction.amount should be(phloLimit * phloPrice)
+            t.transaction.failReason should be(None)
+
+          case Refund(_) =>
+            t.transaction.toAddr should be(fromAddr)
+            t.transaction.amount should be(
+              phloLimit * phloPrice - transferBlock.body.deploys.head.cost.cost
+            )
+            t.transaction.failReason should be(None)
+          case _ => ()
+        }
+      }
+    } yield ()).runSyncUnsafe()
   }
 
+  "no user deploy log" should "return only precharge and refund transaction" in {
+    val fromSk    = genesis.genesisVaultsSks.head
+    val fromAddr  = RevAddress.fromPublicKey(Secp256k1.toPublic(fromSk)).get.toBase58
+    val phloPrice = 1L
+    val phloLimit = 3000000L
+    val deployRho = s"""new a in {}"""
+    (for {
+      result                <- checkTransactionAPI(deployRho, phloLimit, phloPrice, fromSk)
+      (transactions, block) = result
+      _                     = transactions.length should be(2)
+      _ = transactions.foreach { t =>
+        t.transactionType match {
+          case PreCharge(_) =>
+            t.transaction.fromAddr should be(fromAddr)
+            t.transaction.amount should be(phloLimit * phloPrice)
+            t.transaction.failReason should be(None)
+
+          case Refund(_) =>
+            t.transaction.toAddr should be(fromAddr)
+            t.transaction.amount should be(
+              phloLimit * phloPrice - block.body.deploys.head.cost.cost
+            )
+            t.transaction.failReason should be(None)
+          case _ => ()
+        }
+      }
+
+    } yield ()).runSyncUnsafe()
+  }
+
+  "preCharge failed case" should "return 1 preCharge transaction" in {
+    val fromSk    = genesis.genesisVaultsSks.head
+    val fromAddr  = RevAddress.fromPublicKey(Secp256k1.toPublic(fromSk)).get.toBase58
+    val phloPrice = 1L
+    val phloLimit = 300000000000L
+    val deployRho = s"""new a in {}"""
+    val (transaction, block) = (for {
+      result                <- checkTransactionAPI(deployRho, phloLimit, phloPrice, fromSk)
+      (transactions, block) = result
+      _                     = transactions.length should be(1)
+      t                     = transactions.head
+
+      _ = t.transaction.failReason should be(Some("Insufficient funds"))
+
+    } yield (t, block)).runSyncUnsafe()
+    transaction.transactionType shouldBe a[PreCharge]
+    transaction.transaction.fromAddr shouldBe fromAddr
+    transaction.transaction.amount shouldBe phloLimit * phloPrice - block.body.deploys.head.cost.cost
+    transaction.transaction.failReason shouldBe Some("Insufficient funds")
+  }
 }


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

Currently if the user deploy rholang like `new a in {}` which doesn't generate any event log in the block . The transaction api would recognize the `refund` deploy as `userDeploy`.

The pr is intended to fix the error.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
