### PR TITLE
Use DAG to find BlockMessage by truncated hash string to increase performance

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -8,14 +8,6 @@ import coop.rchain.models.BlockHash.BlockHash
 trait BlockStore[F[_]] {
   def get(blockHash: BlockHash): F[Option[BlockMessage]]
 
-  /**
-    * Iterates over BlockStore and loads first n blocks according to predicate
-    * @param p predicate
-    * @param n limit for number of blocks to load
-    * @return Sequence of [(BlockHash, BlockMessage)]
-    */
-  def find(p: BlockHash => Boolean, n: Int = 10000): F[Seq[(BlockHash, BlockMessage)]]
-
   def put(f: => (BlockHash, BlockMessage)): F[Unit]
 
   def contains(blockHash: BlockHash)(implicit applicativeF: Applicative[F]): F[Boolean] =

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -13,6 +13,7 @@ import coop.rchain.blockstorage.syntax._
 import coop.rchain.blockstorage.util.BlockMessageUtil._
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.crypto.codec.Base16
 import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.{Metrics, MetricsSemaphore}
 import coop.rchain.models.BlockHash.BlockHash
@@ -74,6 +75,10 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
 
     def isFinalized(blockHash: BlockHash): F[Boolean] =
       finalizedBlocksSet.contains(blockHash).pure[F]
+
+    override def find(truncatedHash: String): F[Option[BlockHash]] = Sync[F].delay {
+      dagSet.find(hash => Base16.encode(hash.toByteArray).startsWith(truncatedHash))
+    }
 
     def topoSort(
         startBlockNumber: Long,

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -77,7 +77,8 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
       finalizedBlocksSet.contains(blockHash).pure[F]
 
     override def find(truncatedHash: String): F[Option[BlockHash]] = Sync[F].delay {
-      dagSet.find(hash => Base16.encode(hash.toByteArray).startsWith(truncatedHash))
+      val truncatedByteString = ByteString.copyFrom(Base16.unsafeDecode(truncatedHash))
+      dagSet.find(hash => hash.startsWith(truncatedByteString))
     }
 
     def topoSort(

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -44,6 +44,7 @@ trait BlockDagRepresentation[F[_]] {
   // DAG representation has to have finalized block, or it does not make sense
   def lastFinalizedBlock: BlockHash
   def isFinalized(blockHash: BlockHash): F[Boolean]
+  def find(truncatedHash: String): F[Option[BlockHash]]
 }
 
 trait EquivocationsTracker[F[_]] {

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -105,6 +105,8 @@ object Resources {
 
       override def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] = ???
 
+      override def find(truncatedHash: String): F[Option[BlockHash]] = ???
+
       override def topoSort(
           startBlockNumber: Long,
           maybeEndBlockNumber: Option[Long]


### PR DESCRIPTION
## Overview

Solution uses hash lookups from `BlockDagRepresentation`. A `find` method has been added in `BlockDagRepresentation` and implemented in `KeyValueDagRepresentation`, which takes a truncated hash and returns an optional `BlockHash`

### Performance results
| node | find block request time | factor |
|---|---|---|
| Main net, node0 | ~10.2s | 102x |
| Main net, observer-us | ~100ms | 1x |

bors r+
bors try
bors delegate+