### PR TITLE
Use only unique changes for merging random generators

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
@@ -100,8 +100,8 @@ object RholangMergingLogic {
       initNum = initValOpt getOrElse 0L
       newVal  = initNum + diff
 
-      // Calculate merged random generator
-      newRnd = if (changes.added.size == 1) {
+      // Calculate merged random generator (use only unique changes as input)
+      newRnd = if (changes.added.toSet.size == 1) {
         // Single branch, just use available random generator
         decodeRnd(changes.added.head)
       } else {


### PR DESCRIPTION
## Overview
Merging of REV balances uses merging of random generators. 
For that purpose random generators from datas to be added to channels are read. 
The case when there are multiple identical datas is not handled, so node is failing with 
```
java.lang.AssertionError: assertion failed: Blake2b512Random should have at least 2 inputs to merge, received 1.
```
But this can happen due to peek or if the same deploy is sent to multiple validators.

This PR makes a small change to only use unique datas added to merge random generators.


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
