### PR TITLE
Hotstore rewrite (tuple space hash mismatch fix)

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/Checkpoint.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/Checkpoint.scala
@@ -4,7 +4,7 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.trace.Produce
 
 final case class SoftCheckpoint[C, P, A, K](
-    cacheSnapshot: Snapshot[C, P, A, K],
+    cacheSnapshot: HotStoreState[C, P, A, K],
     log: trace.Log,
     produceCounter: Map[Produce, Int]
 )

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -31,13 +31,11 @@ trait HotStore[F[_], C, P, A, K] {
 }
 
 final case class HotStoreState[C, P, A, K](
-    continuations: Map[Seq[C], Seq[WaitingContinuation[P, K]]] =
-      Map.empty[Seq[C], Seq[WaitingContinuation[P, K]]],
-    installedContinuations: Map[Seq[C], WaitingContinuation[P, K]] =
-      Map.empty[Seq[C], WaitingContinuation[P, K]],
-    data: Map[C, Seq[Datum[A]]] = Map.empty[C, Seq[Datum[A]]],
-    joins: Map[C, Seq[Seq[C]]] = Map.empty[C, Seq[Seq[C]]],
-    installedJoins: Map[C, Seq[Seq[C]]] = Map.empty[C, Seq[Seq[C]]]
+    continuations: Map[Seq[C], Seq[WaitingContinuation[P, K]]],
+    installedContinuations: Map[Seq[C], WaitingContinuation[P, K]],
+    data: Map[C, Seq[Datum[A]]],
+    joins: Map[C, Seq[Seq[C]]],
+    installedJoins: Map[C, Seq[Seq[C]]]
 ) {
   def snapshot(): Snapshot[C, P, A, K] =
     Snapshot(
@@ -48,6 +46,17 @@ final case class HotStoreState[C, P, A, K](
         joins = this.joins,
         installedJoins = this.installedJoins
       )
+    )
+}
+
+object HotStoreState {
+  def apply[C, P, A, K](): HotStoreState[C, P, A, K] =
+    HotStoreState[C, P, A, K](
+      Map.empty[Seq[C], Seq[WaitingContinuation[P, K]]],
+      Map.empty[Seq[C], WaitingContinuation[P, K]],
+      Map.empty[C, Seq[Datum[A]]],
+      Map.empty[C, Seq[Seq[C]]],
+      Map.empty[C, Seq[Seq[C]]]
     )
 }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -287,7 +287,7 @@ private class InMemHotStore[F[_]: Concurrent, C, P, A, K](
                   (state, state.installedContinuations.get(join) ++: continuations)
               })._2
 
-              val index       = state.joins.getOrElse(channel, Seq.empty).indexOf(join)
+              val index       = curJoins.indexOf(join)
               val outOfBounds = !curJoins.isDefinedAt(index)
 
               // TODO should attimpting to remove join with non empty contnuation lead to error as well?
@@ -297,7 +297,7 @@ private class InMemHotStore[F[_]: Concurrent, C, P, A, K](
                 if (outOfBounds)
                   (state.copy(joins = state.joins.updated(channel, curJoins)), true)
                 else {
-                  val newVal = removeIndex(state.joins.getOrElse(channel, Seq.empty), index)
+                  val newVal = removeIndex(curJoins, index)
                   (state.copy(joins = state.joins.updated(channel, newVal)), false)
                 }
               } else (state.copy(joins = state.joins.updated(channel, curJoins)), false)

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -1,15 +1,11 @@
 package coop.rchain.rspace
 
-import cats._
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect._
 import cats.effect.concurrent.{Deferred, Ref}
 import coop.rchain.rspace.history.HistoryReaderBase
-import coop.rchain.shared.Language._
 import coop.rchain.shared.MapOps._
 import coop.rchain.rspace.internal._
-import coop.rchain.shared.Serialize._
-import scodec.Codec
 
 final case class Snapshot[C, P, A, K](private[rspace] val cache: HotStoreState[C, P, A, K])
 import scala.collection.immutable.Map

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -1,16 +1,18 @@
 package coop.rchain.rspace
 
-import cats.effect.Concurrent
-import cats.effect.concurrent.Ref
-import cats.syntax.all._
+import cats._
+import cats.implicits._
+import cats.effect._
+import cats.effect.concurrent.{Deferred, Ref}
 import coop.rchain.rspace.history.HistoryReaderBase
-import coop.rchain.rspace.internal._
 import coop.rchain.shared.Language._
 import coop.rchain.shared.MapOps._
+import coop.rchain.rspace.internal._
+import coop.rchain.shared.Serialize._
+import scodec.Codec
 
-import scala.collection.concurrent.TrieMap
-
-final case class Snapshot[C, P, A, K](private[rspace] val cache: Cache[C, P, A, K])
+final case class Snapshot[C, P, A, K](private[rspace] val cache: HotStoreState[C, P, A, K])
+import scala.collection.immutable.Map
 
 trait HotStore[F[_], C, P, A, K] {
   def getContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]]
@@ -32,261 +34,391 @@ trait HotStore[F[_], C, P, A, K] {
   def snapshot(): F[Snapshot[C, P, A, K]]
 }
 
-final case class Cache[C, P, A, K](
-    continuations: TrieMap[Seq[C], Seq[WaitingContinuation[P, K]]] =
-      TrieMap.empty[Seq[C], Seq[WaitingContinuation[P, K]]],
-    installedContinuations: TrieMap[Seq[C], WaitingContinuation[P, K]] =
-      TrieMap.empty[Seq[C], WaitingContinuation[P, K]],
-    data: TrieMap[C, Seq[Datum[A]]] = TrieMap.empty[C, Seq[Datum[A]]],
-    joins: TrieMap[C, Seq[Seq[C]]] = TrieMap.empty[C, Seq[Seq[C]]],
-    installedJoins: TrieMap[C, Seq[Seq[C]]] = TrieMap.empty[C, Seq[Seq[C]]]
+final case class HotStoreState[C, P, A, K](
+    continuations: Map[Seq[C], Seq[WaitingContinuation[P, K]]] =
+      Map.empty[Seq[C], Seq[WaitingContinuation[P, K]]],
+    installedContinuations: Map[Seq[C], WaitingContinuation[P, K]] =
+      Map.empty[Seq[C], WaitingContinuation[P, K]],
+    data: Map[C, Seq[Datum[A]]] = Map.empty[C, Seq[Datum[A]]],
+    joins: Map[C, Seq[Seq[C]]] = Map.empty[C, Seq[Seq[C]]],
+    installedJoins: Map[C, Seq[Seq[C]]] = Map.empty[C, Seq[Seq[C]]]
 ) {
   def snapshot(): Snapshot[C, P, A, K] =
     Snapshot(
       this.copy(
-        continuations = this.continuations.snapshot(),
-        installedContinuations = this.installedContinuations.snapshot(),
-        data = this.data.snapshot(),
-        joins = this.joins.snapshot(),
-        installedJoins = this.installedJoins.snapshot()
+        continuations = this.continuations,
+        installedContinuations = this.installedContinuations,
+        data = this.data,
+        joins = this.joins,
+        installedJoins = this.installedJoins
       )
     )
 }
 
+private final case class HistoryStoreCache[F[_], C, P, A, K](
+    continuations: Map[Seq[C], Deferred[F, Seq[WaitingContinuation[P, K]]]],
+    datums: Map[C, Deferred[F, Seq[Datum[A]]]],
+    joins: Map[C, Deferred[F, Seq[Seq[C]]]]
+)
+
 private class InMemHotStore[F[_]: Concurrent, C, P, A, K](
-    cacheRef: Ref[F, Cache[C, P, A, K]],
-    historyReader: HistoryReaderBase[F, C, P, A, K]
+    hotStoreState: Ref[F, HotStoreState[C, P, A, K]],
+    // this is what is inside history store, lazily populated. Starting data for HotStoreState
+    historyStoreCache: Ref[F, HistoryStoreCache[F, C, P, A, K]]
+)(
+    implicit HR: HistoryReaderBase[F, C, P, A, K]
 ) extends HotStore[F, C, P, A, K] {
 
-  def snapshot(): F[Snapshot[C, P, A, K]] = cacheRef.get.map(_.snapshot())
+  def snapshot(): F[Snapshot[C, P, A, K]] = hotStoreState.get.map(_.snapshot())
+
+  // Continuations
 
   def getContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
     for {
-      cached <- internalGetContinuations(channels)
-      state  <- cacheRef.get
-      result = state.installedContinuations.get(channels) ++: cached
+      fromHistoryStore <- getContFromHistoryStore(channels)
+      result <- hotStoreState.modify[Seq[WaitingContinuation[P, K]]](state => {
+                 state.continuations.get(channels) match {
+                   // update with what is in historyStore and return the same
+                   case None =>
+                     (
+                       state.copy(
+                         continuations = state.continuations.updated(channels, fromHistoryStore)
+                       ),
+                       state.installedContinuations.get(channels) ++: fromHistoryStore
+                     )
+                   // just return what is in hot store already
+                   case Some(continuations) =>
+                     (state, state.installedContinuations.get(channels) ++: continuations)
+                 }
+               })
     } yield result
-
-  private[this] def internalGetContinuations(channels: Seq[C]): F[Seq[WaitingContinuation[P, K]]] =
-    for {
-      state <- cacheRef.get
-      res <- state.continuations.get(channels) match {
-              case None =>
-                for {
-                  historyContinuations <- historyReader.getContinuations(channels)
-                  _ <- cacheRef.update { cache =>
-                        ignore(cache.continuations.putIfAbsent(channels, historyContinuations))
-                        cache
-                      }
-                } yield historyContinuations
-              case Some(continuations) => continuations.pure[F]
-            }
-    } yield (res)
 
   def putContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit] =
     for {
-      continuations <- internalGetContinuations(channels)
-      _ <- cacheRef.update { cache =>
-            ignore(cache.continuations.put(channels, wc +: continuations))
-            cache
+      fromHistoryStore <- getContFromHistoryStore(channels)
+      _ <- hotStoreState.update { state =>
+            val curVal = state.continuations.getOrElse(channels, fromHistoryStore)
+            val newVal = wc +: curVal
+            state.copy(continuations = state.continuations.updated(channels, newVal))
           }
     } yield ()
 
   def installContinuation(channels: Seq[C], wc: WaitingContinuation[P, K]): F[Unit] =
-    cacheRef.update { cache =>
-      ignore(cache.installedContinuations.put(channels, wc))
-      cache
+    hotStoreState.update { cache =>
+      cache.copy(installedContinuations = cache.installedContinuations.updated(channels, wc))
     }
 
   def removeContinuation(channels: Seq[C], index: Int): F[Unit] =
     for {
-      continuations <- getContinuations(channels)
-      cache         <- cacheRef.get
-      installed     = cache.installedContinuations.get(channels)
-      _ <- if (installed.isDefined && index == 0) {
-            new IllegalArgumentException("Attempted to remove an installed continuation").raiseError
-          } else
-            checkIndex(continuations, index) >> cacheRef.update { cache =>
-              val updated = removeIndex(
-                continuations,
-                index
-              )
-              ignore(installed match {
-                case Some(_) => cache.continuations.put(channels, updated tail)
-                case None    => cache.continuations.put(channels, updated)
-              })
-              cache
+      fromHistoryStore <- getContFromHistoryStore(channels)
+      r <- hotStoreState.modify[(Boolean, Boolean)](state => {
+            val curVal      = state.continuations.getOrElse(channels, fromHistoryStore)
+            val isInstalled = state.installedContinuations.contains(channels)
+
+            val removingInstalled = (isInstalled && index == 0)
+            val outOfBounds       = !curVal.isDefinedAt(index)
+
+            if (removingInstalled || outOfBounds)
+              (state, (removingInstalled, outOfBounds))
+            else {
+              val newVal = removeIndex(curVal, index)
+              // TODO Logic behind this isInstalled check is uncertain
+              if (isInstalled)
+                (
+                  state.copy(continuations = state.continuations.updated(channels, newVal.tail)),
+                  (false, false)
+                )
+              else
+                (
+                  state.copy(continuations = state.continuations.updated(channels, newVal)),
+                  (false, false)
+                )
             }
+
+          })
+      (removingInstalled, invalidIndex) = r
+      _ <- Sync[F]
+            .raiseError {
+              new IllegalArgumentException("Attempted to remove an installed continuation")
+            }
+            .whenA(removingInstalled)
+      _ <- Sync[F]
+            .raiseError(
+              new IndexOutOfBoundsException(
+                s"Index ${index} out of bounds when removing continuation"
+              )
+            )
+            .whenA(invalidIndex)
     } yield ()
+
+  // Data
 
   def getData(channel: C): F[Seq[Datum[A]]] =
     for {
-      state <- cacheRef.get
-      res <- state.data.get(channel) match {
-              case None =>
-                for {
-                  historyData <- historyReader.getData(channel)
-                  _ <- cacheRef.update { cache =>
-                        ignore(cache.data.putIfAbsent(channel, historyData))
-                        cache
-                      }
-                } yield (historyData)
-              case Some(data) => data.pure[F]
-            }
-    } yield (res)
+      fromHistoryStore <- getDataFromHistoryStore(channel)
+      result <- hotStoreState.modify[Seq[Datum[A]]](state => {
+                 state.data.get(channel) match {
+                   // update with what is in historyStore and return the same
+                   case None =>
+                     (
+                       state.copy(
+                         data = state.data.updated(channel, fromHistoryStore)
+                       ),
+                       fromHistoryStore
+                     )
+                   // just return what is in hot store already
+                   case Some(data) => (state, data)
+                 }
+               })
+    } yield (result)
 
   def putDatum(channel: C, datum: Datum[A]): F[Unit] =
     for {
-      data <- getData(channel)
-      _ <- cacheRef.update { cache =>
-            ignore(cache.data.put(channel, datum +: data))
-            cache
+      fromHistoryStore <- getDataFromHistoryStore(channel)
+      _ <- hotStoreState.update { state =>
+            state.copy(
+              data = state.data
+              // if continuation list is empty, add what there is in history store as well
+                .updated(
+                  channel,
+                  datum +: state.data.getOrElse(channel, fromHistoryStore)
+                )
+            )
           }
     } yield ()
 
   def removeDatum(channel: C, index: Int): F[Unit] =
     for {
-      data <- getData(channel)
-      s    <- cacheRef.get
-      _    <- checkIndex(s.data(channel), index)
-      _ <- cacheRef.update { cache =>
-            val updated = removeIndex(cache.data(channel), index)
-            ignore(cache.data.put(channel, updated))
-            cache
+      fromHistoryStore <- getDataFromHistoryStore(channel)
+      err <- hotStoreState.modify[Boolean](state => {
+              val curVal      = state.data.getOrElse(channel, fromHistoryStore)
+              val outOfBounds = !curVal.isDefinedAt(index)
 
-          }
+              if (outOfBounds)
+                (state, outOfBounds)
+              else {
+                val updated = removeIndex(curVal, index)
+                (state.copy(data = state.data.updated(channel, updated)), false)
+              }
+            })
+      _ <- Sync[F]
+            .raiseError(
+              new IndexOutOfBoundsException(
+                s"Index ${index} out of bounds when removing datum"
+              )
+            )
+            .whenA(err)
     } yield ()
+
+  // Joins
 
   def getJoins(channel: C): F[Seq[Seq[C]]] =
     for {
-      cached <- internalGetJoins(channel)
-      state  <- cacheRef.get
-    } yield state.installedJoins.getOrElse(channel, Seq.empty) ++: cached
+      fromHistoryStore <- getJoinsFromHistoryStore(channel)
+      result <- hotStoreState.modify[Seq[Seq[C]]](state => {
+                 state.joins.get(channel) match {
+                   // update with what is in historyStore and return the same
+                   case None =>
+                     (
+                       state.copy(
+                         joins = state.joins.updated(channel, fromHistoryStore)
+                       ),
+                       state.installedJoins.getOrElse(channel, Seq.empty) ++: fromHistoryStore
+                     )
+                   // just return what is in hot store already
+                   case Some(joins) =>
+                     (state, state.installedJoins.getOrElse(channel, Seq.empty) ++: joins)
+                 }
+               })
 
-  private[this] def internalGetJoins(channel: C): F[Seq[Seq[C]]] =
-    for {
-      state <- cacheRef.get
-      res <- state.joins.get(channel) match {
-              case None =>
-                for {
-                  historyJoins <- historyReader.getJoins(channel)
-                  _ <- cacheRef.update { cache =>
-                        ignore(cache.joins.putIfAbsent(channel, historyJoins))
-                        cache
-                      }
-                } yield (historyJoins)
-              case Some(joins) => joins.pure[F]
-            }
-    } yield res
+    } yield result
 
   def putJoin(channel: C, join: Seq[C]): F[Unit] =
     for {
-      joins <- getJoins(channel)
-      _ <- cacheRef
-            .update { cache =>
-              ignore(cache.joins.put(channel, join +: joins))
-              cache
+      fromHistoryStore <- getJoinsFromHistoryStore(channel)
+      _ <- hotStoreState.update { state =>
+            val curJoins = state.joins.getOrElse(channel, fromHistoryStore)
+            if (curJoins.contains(join))
+              state
+            else {
+              val newVal = join +: curJoins
+              state.copy(joins = state.joins.updated(channel, newVal))
             }
-            .whenA(!joins.contains(join))
+          }
     } yield ()
 
-  def installJoin(channel: C, join: Seq[C]): F[Unit] = cacheRef.update { cache =>
-    ignore {
-      val installed = cache.installedJoins.getOrElse(channel, Seq.empty)
-
-      if (!installed.contains(join))
-        cache.installedJoins
-          .put(channel, join +: installed)
-    }
-    cache
+  def installJoin(channel: C, join: Seq[C]): F[Unit] = hotStoreState.update { state =>
+    val curInstalled = state.installedJoins.getOrElse(channel, Seq.empty)
+    if (!curInstalled.contains(join)) {
+      val newVal = join +: curInstalled
+      state.copy(installedJoins = state.installedJoins.updated(channel, newVal))
+    } else
+      state
   }
 
   def removeJoin(channel: C, join: Seq[C]): F[Unit] =
     for {
-      joins         <- internalGetJoins(channel)
-      continuations <- getContinuations(join)
-      s             <- cacheRef.get
-      index         = s.joins(channel).indexOf(join)
-      _ <- if (continuations.isEmpty && index != -1)
-            checkIndex(s.joins(channel), index) >>
-              cacheRef.update { cache =>
-                val updated =
-                  removeIndex(
-                    cache.joins(
-                      channel
+      joinsInHistoryStore <- getJoinsFromHistoryStore(channel)
+      contsInHistoryStore <- getContFromHistoryStore(join)
+      err <- hotStoreState.modify[Boolean](state => {
+
+              val curJoins = (state.joins.get(channel) match {
+                // update with what is in historyStore and return the same
+                case None =>
+                  (
+                    state.copy(
+                      joins = state.joins.updated(channel, joinsInHistoryStore)
                     ),
-                    index
+                    joinsInHistoryStore
                   )
-                ignore(
-                  cache.joins.put(
-                    channel,
-                    updated
+                // just return what is in hot store already
+                case Some(joins) =>
+                  (state, joins)
+              })._2
+
+              val curConts = (state.continuations.get(join) match {
+                // update with what is in historyStore and return the same
+                case None =>
+                  (
+                    state.copy(
+                      continuations = state.continuations.updated(join, contsInHistoryStore)
+                    ),
+                    state.installedContinuations.get(join) ++: contsInHistoryStore
                   )
-                )
-                cache
-              } else ().pure[F]
+                // just return what is in hot store already
+                case Some(continuations) =>
+                  (state, state.installedContinuations.get(join) ++: continuations)
+              })._2
+
+              val index       = state.joins(channel).indexOf(join)
+              val outOfBounds = !curJoins.isDefinedAt(index)
+
+              // TODO should attimpting to remove join with non empty contnuation lead to error as well?
+              val doRemove = curConts.isEmpty
+
+              if (doRemove) {
+                if (outOfBounds)
+                  (state, true)
+                else {
+                  val newVal = removeIndex(state.joins(channel), index)
+                  (state.copy(joins = state.joins.updated(channel, newVal)), false)
+                }
+              } else (state, false)
+            })
+      _ <- Sync[F]
+            .raiseError(
+              new IndexOutOfBoundsException(
+                s"Index out of bounds when removing join"
+              )
+            )
+            .whenA(err)
+
     } yield ()
 
   def changes(): F[Seq[HotStoreAction]] =
     for {
-      cache <- cacheRef.get
-      continuations = (cache.continuations
-        .readOnlySnapshot()
-        .map {
-          case (k, v) if (v.isEmpty) => DeleteContinuations(k)
-          case (k, v)                => InsertContinuations(k, v)
-        })
-        .toVector
-      data = (cache.data
-        .readOnlySnapshot()
-        .map {
-          case (k, v) if (v.isEmpty) => DeleteData(k)
-          case (k, v)                => InsertData(k, v)
-        })
-        .toVector
-      joins = (cache.joins
-        .readOnlySnapshot()
-        .map {
-          case (k, v) if (v.isEmpty) => DeleteJoins(k)
-          case (k, v)                => InsertJoins(k, v)
-        })
-        .toVector
-    } yield continuations ++ data ++ joins
+      cache <- hotStoreState.get
+      continuations = (cache.continuations.map {
+        case (k, v) if (v.isEmpty) => DeleteContinuations(k)
+        case (k, v)                => InsertContinuations(k, v)
+      }).toVector
+      data = (cache.data.map {
+        case (k, v) if (v.isEmpty) => DeleteData(k)
+        case (k, v)                => InsertData(k, v)
+      }).toVector
+      joins = (cache.joins.map {
+        case (k, v) if (v.isEmpty) => DeleteJoins(k)
+        case (k, v)                => InsertJoins(k, v)
+      }).toVector
+    } yield (continuations ++ data ++ joins)
 
-  private def checkIndex[E](col: Seq[E], index: Int): F[Unit] =
-    new IndexOutOfBoundsException(
-      s"Tried to remove index ${index} from a Vector of size ${col.size}"
-    ).raiseError.unlessA(col.isDefinedAt(index))
+  private def removeIndex[E](col: Seq[E], index: Int): Seq[E] = {
+    val (l1, l2) = col splitAt index
+    (l1 ++ (l2 tail))
+  }
 
   def toMap: F[Map[Seq[C], Row[P, A, K]]] =
     for {
-      cache         <- cacheRef.get
-      data          = cache.data.readOnlySnapshot().map(_.leftMap(Seq(_))).toMap
+      cache         <- hotStoreState.get
+      data          = cache.data.map(_.leftMap(Seq(_))).toMap
       continuations = (cache.continuations ++ cache.installedContinuations.mapValues(Seq(_))).toMap
       zipped        = zip(data, continuations, Seq.empty[Datum[A]], Seq.empty[WaitingContinuation[P, K]])
       mapped        = zipped.mapValues { case (d, k) => Row(d, k) }
     } yield mapped.filter { case (_, v) => !(v.data.isEmpty && v.wks.isEmpty) }
+
+  private def getContFromHistoryStore(channels: Seq[C]) =
+    for {
+      d <- Deferred[F, Seq[WaitingContinuation[P, K]]]
+      r <- historyStoreCache
+            .modify[(Deferred[F, Seq[WaitingContinuation[P, K]]], Boolean)](cache => {
+              cache.continuations.get(channels) match {
+                case Some(v) => (cache, (v, true))
+                case None =>
+                  (cache.copy(continuations = cache.continuations + (channels -> d)), (d, false))
+              }
+            })
+      (deferred, isComplete) = r
+      _                      <- (HR.getContinuations(channels) >>= deferred.complete).whenA(!isComplete)
+      contInHistoryStore     <- deferred.get
+    } yield contInHistoryStore
+
+  private def getDataFromHistoryStore(channel: C) =
+    for {
+      d <- Deferred[F, Seq[Datum[A]]]
+      r <- historyStoreCache
+            .modify[(Deferred[F, Seq[Datum[A]]], Boolean)](cache => {
+              cache.datums.get(channel) match {
+                case Some(v) => (cache, (v, true))
+                case None    => (cache.copy(datums = cache.datums + (channel -> d)), (d, false))
+              }
+            })
+      (deferred, isComplete) = r
+      _                      <- (HR.getData(channel) >>= deferred.complete).whenA(!isComplete)
+      dataInHistoryStore     <- deferred.get
+    } yield dataInHistoryStore
+
+  private def getJoinsFromHistoryStore(channel: C) =
+    for {
+      d <- Deferred[F, Seq[Seq[C]]]
+      r <- historyStoreCache
+            .modify[(Deferred[F, Seq[Seq[C]]], Boolean)](cache => {
+              cache.joins.get(channel) match {
+                case Some(v) => (cache, (v, true))
+                case None    => (cache.copy(joins = cache.joins + (channel -> d)), (d, false))
+              }
+            })
+      (deferred, isComplete) = r
+      _                      <- (HR.getJoins(channel) >>= deferred.complete).whenA(!isComplete)
+      joinsInHistoryStore    <- deferred.get
+    } yield joinsInHistoryStore
 }
 
 object HotStore {
 
   def inMem[F[_]: Concurrent, C, P, A, K](
-      cache: Ref[F, Cache[C, P, A, K]],
-      historyReader: HistoryReaderBase[F, C, P, A, K]
-  ): HotStore[F, C, P, A, K] =
-    new InMemHotStore[F, C, P, A, K](cache, historyReader)
+      hotStoreStateRef: Ref[F, HotStoreState[C, P, A, K]],
+      HR: HistoryReaderBase[F, C, P, A, K]
+  ): F[HotStore[F, C, P, A, K]] = {
+    implicit val h = HR
+    Ref
+      .of[F, HistoryStoreCache[F, C, P, A, K]](
+        HistoryStoreCache(Map.empty, Map.empty, Map.empty)
+      )
+      .map(new InMemHotStore[F, C, P, A, K](hotStoreStateRef, _))
+  }
 
   def from[F[_]: Concurrent, C, P, A, K](
-      cache: Cache[C, P, A, K],
+      cache: HotStoreState[C, P, A, K],
       historyReader: HistoryReaderBase[F, C, P, A, K]
   ): F[HotStore[F, C, P, A, K]] =
     for {
-      cache <- Ref.of[F, Cache[C, P, A, K]](cache)
-      store = HotStore.inMem(cache, historyReader)
+      cache <- Ref.of[F, HotStoreState[C, P, A, K]](cache)
+      store <- HotStore.inMem(cache, historyReader)
     } yield store
 
   def empty[F[_]: Concurrent, C, P, A, K](
       historyReader: HistoryReaderBase[F, C, P, A, K]
-  ): F[HotStore[F, C, P, A, K]] = from(Cache(), historyReader)
+  ): F[HotStore[F, C, P, A, K]] =
+    from(HotStoreState(), historyReader)
 
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -109,8 +109,15 @@ private class InMemHotStore[F[_]: Concurrent, C, P, A, K](
             val isInstalled  = installedCon.nonEmpty
 
             val removingInstalled = (isInstalled && index == 0)
-            val removedIndex      = if (isInstalled) index - 1 else index
-            val outOfBounds       = !curVal.isDefinedAt(removedIndex)
+            // why -1 here
+            // from users who use `HotStore` trait perspective
+            // the users need to call getContinuations first to retrieve the continuation of the channels
+            // then find which index of the continuation users want to remove
+            // while getContinuations would return results like `Vector(installedContinuation, normalcontinuations, ...)`
+            // The first one would be always `installedContinuation` if it exist which need the
+            // index to -1 to exclude installedContinuation
+            val removedIndex = if (isInstalled) index - 1 else index
+            val outOfBounds  = !curVal.isDefinedAt(removedIndex)
 
             if (removingInstalled || outOfBounds)
               (

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -262,7 +262,8 @@ private class InMemHotStore[F[_]: Concurrent, C, P, A, K](
               val index       = curJoins.indexOf(join)
               val outOfBounds = !curJoins.isDefinedAt(index)
 
-              // TODO should attimpting to remove join with non empty contnuation lead to error as well?
+              // Remove join is called when continuation is removed, so it can be called when
+              // continuations are present in which case we just want to skip removal.
               val doRemove = curConts.isEmpty
 
               if (doRemove) {
@@ -274,14 +275,6 @@ private class InMemHotStore[F[_]: Concurrent, C, P, A, K](
                 }
               } else (state.copy(joins = state.joins.updated(channel, curJoins)), false)
             })
-//      _ <- Sync[F]
-//            .raiseError(
-//              new IndexOutOfBoundsException(
-//                s"Index out of bounds when removing join"
-//              )
-//            )
-//            .whenA(err)
-
     } yield ()
 
   def changes(): F[Seq[HotStoreAction]] =

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -359,12 +359,15 @@ abstract class RSpaceOps[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, 
       val history = historyRepositoryAtom.get()
       for {
         historyReader <- history.getHistoryReader(history.root)
-        hotStore      <- HotStore.from(checkpoint.cacheSnapshot.cache, historyReader.base)
-        _             = storeAtom.set(hotStore)
-        _             = eventLog.take()
-        _             = eventLog.put(checkpoint.log)
-        _             = produceCounter.take()
-        _             = produceCounter.put(checkpoint.produceCounter)
+        hotStore <- HotStore.from(
+                     checkpoint.cacheSnapshot,
+                     historyReader.base
+                   )
+        _ = storeAtom.set(hotStore)
+        _ = eventLog.take()
+        _ = eventLog.put(checkpoint.log)
+        _ = produceCounter.take()
+        _ = produceCounter.put(checkpoint.produceCounter)
       } yield ()
     }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -116,7 +116,11 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                       HotStoreState(
                         continuations = Map(
                           channels -> cachedContinuations
-                        )
+                        ),
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map.empty,
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -146,7 +150,11 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                       HotStoreState(
                         continuations = Map(
                           channels -> cachedContinuations
-                        )
+                        ),
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map.empty,
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -200,7 +208,11 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                       HotStoreState(
                         continuations = Map(
                           channels -> cachedContinuations
-                        )
+                        ),
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map.empty,
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -233,7 +245,11 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                         HotStoreState(
                           continuations = Map(
                             channels -> cachedContinuations
-                          )
+                          ),
+                          installedContinuations = Map.empty,
+                          data = Map.empty,
+                          joins = Map.empty,
+                          installedJoins = Map.empty
                         ),
                         ()
                       )
@@ -295,7 +311,11 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                       HotStoreState(
                         continuations = Map(
                           channels -> cachedContinuations
-                        )
+                        ),
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map.empty,
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -332,7 +352,10 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                         ),
                         installedContinuations = Map(
                           channels -> installedContinuation
-                        )
+                        ),
+                        data = Map.empty,
+                        joins = Map.empty,
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -387,9 +410,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   _ =>
                     (
                       HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
                         data = Map(
                           channel -> cachedData
-                        )
+                        ),
+                        joins = Map.empty,
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -436,9 +463,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   _ =>
                     (
                       HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
                         data = Map(
                           channel -> cachedData
-                        )
+                        ),
+                        joins = Map.empty,
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -489,9 +520,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   _ =>
                     (
                       HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
                         data = Map(
                           channel -> cachedData
-                        )
+                        ),
+                        joins = Map.empty,
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -533,9 +568,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   _ =>
                     (
                       HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
                         joins = Map(
                           channel -> cachedJoins
-                        )
+                        ),
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -585,9 +624,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                     _ =>
                       (
                         HotStoreState(
+                          continuations = Map.empty,
+                          installedContinuations = Map.empty,
+                          data = Map.empty,
                           joins = Map(
                             channel -> cachedJoins
-                          )
+                          ),
+                          installedJoins = Map.empty
                         ),
                         ()
                       )
@@ -616,9 +659,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   _ =>
                     (
                       HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
                         joins = Map(
                           channel -> cachedJoins
-                        )
+                        ),
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -651,9 +698,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                     _ =>
                       (
                         HotStoreState(
+                          continuations = Map.empty,
+                          installedContinuations = Map.empty,
+                          data = Map.empty,
                           joins = Map(
                             channel -> cachedJoins
-                          )
+                          ),
+                          installedJoins = Map.empty
                         ),
                         ()
                       )
@@ -691,9 +742,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   _ =>
                     (
                       HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
                         joins = Map(
                           channel -> cachedJoins
-                        )
+                        ),
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -753,9 +808,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                     _ =>
                       (
                         HotStoreState(
+                          continuations = Map.empty,
+                          installedContinuations = Map.empty,
+                          data = Map.empty,
                           joins = Map(
                             channel -> cachedJoins
-                          )
+                          ),
+                          installedJoins = Map.empty
                         ),
                         ()
                       )
@@ -783,6 +842,9 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                     _ =>
                       (
                         HotStoreState(
+                          continuations = Map.empty,
+                          installedContinuations = Map.empty,
+                          data = Map.empty,
                           joins = Map(
                             channel -> cachedJoins
                           ),
@@ -831,9 +893,13 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                   _ =>
                     (
                       HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
                         joins = Map(
                           channel -> cachedJoins
-                        )
+                        ),
+                        installedJoins = Map.empty
                       ),
                       ()
                     )
@@ -879,7 +945,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
                         ),
                         joins = Map(
                           channel -> joins
-                        )
+                        ),
+                        installedJoins = Map.empty
                       ),
                       ()
                     )

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -19,7 +19,7 @@ import org.scalatest.prop._
 import scodec.bits.ByteVector
 
 import scala.collection.SortedSet
-import scala.collection.concurrent.TrieMap
+import scala.collection.concurrent.{Map, TrieMap}
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -39,35 +39,45 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
 
   implicit val arbitraryJoins = distinctListOf[Join].map(_.toVector)
 
-  implicit def arbitraryCache: Arbitrary[Cache[String, Pattern, String, StringsCaptor]] = Arbitrary(
-    for {
-      continuations <- Arbitrary.arbitrary[TrieMap[Seq[String], Seq[
-                        WaitingContinuation[Pattern, StringsCaptor]
-                      ]]]
-      installedContinuations <- Arbitrary.arbitrary[
-                                 TrieMap[Seq[String], WaitingContinuation[Pattern, StringsCaptor]]
-                               ]
-      data           <- Arbitrary.arbitrary[TrieMap[String, Seq[Datum[String]]]]
-      joins          <- Arbitrary.arbitrary[TrieMap[String, Seq[Seq[String]]]]
-      installedJoins <- Arbitrary.arbitrary[TrieMap[String, Seq[Seq[String]]]]
-    } yield Cache(
-      continuations,
-      installedContinuations,
-      data,
-      joins,
-      installedJoins
+  implicit def arbitraryHotStoreState
+      : Arbitrary[HotStoreState[String, Pattern, String, StringsCaptor]] =
+    Arbitrary(
+      for {
+
+        continuations <- Arbitrary
+                          .arbitrary[TrieMap[Seq[String], Seq[
+                            WaitingContinuation[Pattern, StringsCaptor]
+                          ]]]
+                          .map(_.toMap)
+        installedContinuations <- Arbitrary
+                                   .arbitrary[
+                                     TrieMap[
+                                       Seq[String],
+                                       WaitingContinuation[Pattern, StringsCaptor]
+                                     ]
+                                   ]
+                                   .map(_.toMap)
+        data           <- Arbitrary.arbitrary[TrieMap[String, Seq[Datum[String]]]].map(_.toMap)
+        joins          <- Arbitrary.arbitrary[TrieMap[String, Seq[Seq[String]]]].map(_.toMap)
+        installedJoins <- Arbitrary.arbitrary[TrieMap[String, Seq[Seq[String]]]].map(_.toMap)
+      } yield HotStoreState(
+        continuations,
+        installedContinuations,
+        data,
+        joins,
+        installedJoins
+      )
     )
-  )
 
   def fixture(
       f: (
-          Ref[F, Cache[String, Pattern, String, StringsCaptor]],
+          Ref[F, HotStoreState[String, Pattern, String, StringsCaptor]],
           History[F, String, Pattern, String, StringsCaptor],
           HotStore[F, String, Pattern, String, StringsCaptor]
       ) => F[Unit]
   ): Unit
 
-  def fixture(cache: Cache[String, Pattern, String, StringsCaptor])(
+  def fixture(cache: HotStoreState[String, Pattern, String, StringsCaptor])(
       f: (
           HotStore[F, String, Pattern, String, StringsCaptor]
       ) => F[Unit]
@@ -101,8 +111,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        continuations = TrieMap(
+                      HotStoreState(
+                        continuations = Map(
                           channels -> cachedContinuations
                         )
                       ),
@@ -131,8 +141,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        continuations = TrieMap(
+                      HotStoreState(
+                        continuations = Map(
                           channels -> cachedContinuations
                         )
                       ),
@@ -185,8 +195,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        continuations = TrieMap(
+                      HotStoreState(
+                        continuations = Map(
                           channels -> cachedContinuations
                         )
                       ),
@@ -218,8 +228,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
               _ <- state.modify(
                     _ =>
                       (
-                        Cache(
-                          continuations = TrieMap(
+                        HotStoreState(
+                          continuations = Map(
                             channels -> cachedContinuations
                           )
                         ),
@@ -280,8 +290,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        continuations = TrieMap(
+                      HotStoreState(
+                        continuations = Map(
                           channels -> cachedContinuations
                         )
                       ),
@@ -314,11 +324,11 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        continuations = TrieMap(
+                      HotStoreState(
+                        continuations = Map(
                           channels -> cachedContinuations
                         ),
-                        installedContinuations = TrieMap(
+                        installedContinuations = Map(
                           channels -> installedContinuation
                         )
                       ),
@@ -374,8 +384,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        data = TrieMap(
+                      HotStoreState(
+                        data = Map(
                           channel -> cachedData
                         )
                       ),
@@ -423,8 +433,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        data = TrieMap(
+                      HotStoreState(
+                        data = Map(
                           channel -> cachedData
                         )
                       ),
@@ -471,8 +481,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        data = TrieMap(
+                      HotStoreState(
+                        data = Map(
                           channel -> cachedData
                         )
                       ),
@@ -515,8 +525,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        joins = TrieMap(
+                      HotStoreState(
+                        joins = Map(
                           channel -> cachedJoins
                         )
                       ),
@@ -567,8 +577,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
               _ <- state.modify(
                     _ =>
                       (
-                        Cache(
-                          joins = TrieMap(
+                        HotStoreState(
+                          joins = Map(
                             channel -> cachedJoins
                           )
                         ),
@@ -598,8 +608,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        joins = TrieMap(
+                      HotStoreState(
+                        joins = Map(
                           channel -> cachedJoins
                         )
                       ),
@@ -633,8 +643,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
               _ <- state.modify(
                     _ =>
                       (
-                        Cache(
-                          joins = TrieMap(
+                        HotStoreState(
+                          joins = Map(
                             channel -> cachedJoins
                           )
                         ),
@@ -673,8 +683,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        joins = TrieMap(
+                      HotStoreState(
+                        joins = Map(
                           channel -> cachedJoins
                         )
                       ),
@@ -735,8 +745,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
               _ <- state.modify(
                     _ =>
                       (
-                        Cache(
-                          joins = TrieMap(
+                        HotStoreState(
+                          joins = Map(
                             channel -> cachedJoins
                           )
                         ),
@@ -765,11 +775,11 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
               _ <- state.modify(
                     _ =>
                       (
-                        Cache(
-                          joins = TrieMap(
+                        HotStoreState(
+                          joins = Map(
                             channel -> cachedJoins
                           ),
-                          installedJoins = TrieMap(
+                          installedJoins = Map(
                             channel -> installedJoins
                           )
                         ),
@@ -813,8 +823,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        joins = TrieMap(
+                      HotStoreState(
+                        joins = Map(
                           channel -> cachedJoins
                         )
                       ),
@@ -850,17 +860,17 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _ <- state.modify(
                   _ =>
                     (
-                      Cache(
-                        continuations = TrieMap(
+                      HotStoreState(
+                        continuations = Map(
                           channels -> continuations
                         ),
-                        installedContinuations = TrieMap(
+                        installedContinuations = Map(
                           channels -> installedContinuation
                         ),
-                        data = TrieMap(
+                        data = Map(
                           channel -> data
                         ),
-                        joins = TrieMap(
+                        joins = Map(
                           channel -> joins
                         )
                       ),
@@ -1153,7 +1163,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
     }
 
   "snapshot" should "create a copy of the cache" in forAll {
-    (cache: Cache[String, Pattern, String, StringsCaptor]) =>
+    (cache: HotStoreState[String, Pattern, String, StringsCaptor]) =>
       fixture(cache) { store =>
         for {
           snapshot <- store.snapshot()
@@ -1251,19 +1261,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
   }
 }
 
-class History[F[_]: Sync, C, P, A, K](implicit R: Ref[F, Cache[C, P, A, K]])
+class History[F[_]: Sync, C, P, A, K](implicit R: Ref[F, HotStoreState[C, P, A, K]])
     extends HistoryReaderBase[F, C, P, A, K] {
+
   override def getJoins(channel: C): F[Seq[Seq[C]]] =
     R.get.map(_.joins.get(channel).toSeq.flatten)
   def putJoins(channel: C, joins: Seq[Seq[C]]): F[Unit] = R.modify { prev =>
-    ignore(prev.joins.put(channel, joins))
+    ignore(prev.joins.updated(channel, joins))
     (prev, ())
   }
 
   override def getData(channel: C): F[Seq[Datum[A]]] =
     R.get.map(_.data.get(channel).toSeq.flatten)
   def putData(channel: C, data: Seq[Datum[A]]): F[Unit] = R.modify { prev =>
-    ignore(prev.data.put(channel, data))
+    ignore(prev.data.updated(channel, data))
     (prev, ())
   }
 
@@ -1275,7 +1286,7 @@ class History[F[_]: Sync, C, P, A, K](implicit R: Ref[F, Cache[C, P, A, K]])
       channels: Seq[C],
       continuations: Seq[WaitingContinuation[P, K]]
   ): F[Unit] = R.modify { prev =>
-    ignore(prev.continuations.put(channels, continuations))
+    ignore(prev.continuations.updated(channels, continuations))
     (prev, ())
   }
 
@@ -1293,51 +1304,51 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task, Task.Par] {
   implicit override val S: Sync[F]        = implicitly[Concurrent[Task]]
   implicit override val P: Parallel[Task] = Task.catsParallel
   def C(
-      c: Cache[String, Pattern, String, StringsCaptor] = Cache()
-  ): F[Ref[F, Cache[String, Pattern, String, StringsCaptor]]]
+      c: HotStoreState[String, Pattern, String, StringsCaptor] = HotStoreState()
+  ): F[Ref[F, HotStoreState[String, Pattern, String, StringsCaptor]]]
 
   override def fixture(
       f: (
-          Ref[F, Cache[String, Pattern, String, StringsCaptor]],
+          Ref[F, HotStoreState[String, Pattern, String, StringsCaptor]],
           History[F, String, Pattern, String, StringsCaptor],
           HotStore[F, String, Pattern, String, StringsCaptor]
       ) => F[Unit]
   ) =
     (for {
-      historyState <- Ref.of[F, Cache[String, Pattern, String, StringsCaptor]](
-                       Cache[String, Pattern, String, StringsCaptor]()
+      historyState <- Ref.of[F, HotStoreState[String, Pattern, String, StringsCaptor]](
+                       HotStoreState[String, Pattern, String, StringsCaptor]()
                      )
       history = {
         implicit val hs = historyState
         new History[F, String, Pattern, String, StringsCaptor]
       }
       cache    <- C()
-      hotStore = HotStore.inMem[F, String, Pattern, String, StringsCaptor](cache, history)
+      hotStore <- HotStore.inMem[F, String, Pattern, String, StringsCaptor](cache, history)
       res      <- f(cache, history, hotStore)
     } yield res).runSyncUnsafe(1.second)
 
-  override def fixture(cache: Cache[String, Pattern, String, StringsCaptor])(
+  override def fixture(cache: HotStoreState[String, Pattern, String, StringsCaptor])(
       f: HotStore[F, String, Pattern, String, StringsCaptor] => F[Unit]
   ) =
     (for {
-      historyState <- Ref.of[F, Cache[String, Pattern, String, StringsCaptor]](
-                       Cache[String, Pattern, String, StringsCaptor]()
+      historyState <- Ref.of[F, HotStoreState[String, Pattern, String, StringsCaptor]](
+                       HotStoreState[String, Pattern, String, StringsCaptor]()
                      )
       history = {
         implicit val hs = historyState
         new History[F, String, Pattern, String, StringsCaptor]
       }
       cache    <- C(cache)
-      hotStore = HotStore.inMem[F, String, Pattern, String, StringsCaptor](cache, history)
+      hotStore <- HotStore.inMem[F, String, Pattern, String, StringsCaptor](cache, history)
       res      <- f(hotStore)
     } yield res).runSyncUnsafe(1.second)
 
 }
 
-class RefCachedInMemHotStoreSpec extends InMemHotStoreSpec {
+class RefHotStoreStatedInMemHotStoreSpec extends InMemHotStoreSpec {
   implicit override def C(
-      cache: Cache[String, Pattern, String, StringsCaptor]
-  ): F[Ref[F, Cache[String, Pattern, String, StringsCaptor]]] =
-    Ref.of[F, Cache[String, Pattern, String, StringsCaptor]](cache)
+      cache: HotStoreState[String, Pattern, String, StringsCaptor]
+  ): F[Ref[F, HotStoreState[String, Pattern, String, StringsCaptor]]] =
+    Ref.of[F, HotStoreState[String, Pattern, String, StringsCaptor]](cache)
 
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -1241,7 +1241,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       fixture(cache) { store =>
         for {
           snapshot <- store.snapshot()
-        } yield (snapshot.cache shouldBe cache)
+        } yield (snapshot shouldBe cache)
       }
   }
 
@@ -1257,8 +1257,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _        <- store.putContinuation(channels, continuation1)
             snapshot <- store.snapshot()
             _        <- store.putContinuation(channels, continuation2)
-            _        = snapshot.cache.continuations(channels) should contain(continuation1)
-          } yield (snapshot.cache.continuations(channels) should not contain (continuation2))
+            _        = snapshot.continuations(channels) should contain(continuation1)
+          } yield (snapshot.continuations(channels) should not contain (continuation2))
         }
       }
   }
@@ -1275,7 +1275,7 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _        <- store.installContinuation(channels, continuation1)
             snapshot <- store.snapshot()
             _        <- store.installContinuation(channels, continuation2)
-          } yield (snapshot.cache.installedContinuations(channels) shouldBe (continuation1))
+          } yield (snapshot.installedContinuations(channels) shouldBe (continuation1))
         }
       }
   }
@@ -1292,8 +1292,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _        <- store.putDatum(channel, data1)
             snapshot <- store.snapshot()
             _        <- store.putDatum(channel, data2)
-            _        = snapshot.cache.data(channel) should contain(data1)
-          } yield (snapshot.cache.data(channel) should not contain (data2))
+            _        = snapshot.data(channel) should contain(data1)
+          } yield (snapshot.data(channel) should not contain (data2))
         }
       }
   }
@@ -1310,8 +1310,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _        <- store.putJoin(channel, join1)
             snapshot <- store.snapshot()
             _        <- store.putJoin(channel, join2)
-            _        = snapshot.cache.joins(channel) should contain(join1)
-          } yield (snapshot.cache.joins(channel) should not contain (join2))
+            _        = snapshot.joins(channel) should contain(join1)
+          } yield (snapshot.joins(channel) should not contain (join2))
         }
       }
   }
@@ -1328,8 +1328,8 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             _        <- store.installJoin(channel, join1)
             snapshot <- store.snapshot()
             _        <- store.installJoin(channel, join2)
-            _        = snapshot.cache.installedJoins(channel) should contain(join1)
-          } yield (snapshot.cache.installedJoins(channel) should not contain (join2))
+            _        = snapshot.installedJoins(channel) should contain(join1)
+          } yield (snapshot.installedJoins(channel) should not contain (join2))
         }
       }
   }

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -6,13 +6,10 @@ import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import coop.rchain.rspace.examples.StringExamples.{StringsCaptor, _}
 import coop.rchain.rspace.examples.StringExamples.implicits._
-import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.HistoryReaderBase
 import coop.rchain.rspace.internal._
 import coop.rchain.rspace.test.ArbitraryInstances._
-import coop.rchain.rspace.trace.{Consume, Produce}
 import coop.rchain.shared.GeneratorUtils._
-import coop.rchain.shared.Language._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.{Arbitrary, Gen}
@@ -21,7 +18,6 @@ import org.scalatest.prop._
 import scodec.bits.ByteVector
 
 import scala.collection.SortedSet
-import scala.collection.concurrent.{Map, TrieMap}
 import scala.concurrent.duration._
 import scala.util.Random
 
@@ -47,21 +43,16 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       for {
 
         continuations <- Arbitrary
-                          .arbitrary[TrieMap[Seq[String], Seq[
+                          .arbitrary[Map[Seq[String], Seq[
                             WaitingContinuation[Pattern, StringsCaptor]
                           ]]]
-                          .map(_.toMap)
         installedContinuations <- Arbitrary
                                    .arbitrary[
-                                     TrieMap[
-                                       Seq[String],
-                                       WaitingContinuation[Pattern, StringsCaptor]
-                                     ]
+                                     Map[Seq[String], WaitingContinuation[Pattern, StringsCaptor]]
                                    ]
-                                   .map(_.toMap)
-        data           <- Arbitrary.arbitrary[TrieMap[String, Seq[Datum[String]]]].map(_.toMap)
-        joins          <- Arbitrary.arbitrary[TrieMap[String, Seq[Seq[String]]]].map(_.toMap)
-        installedJoins <- Arbitrary.arbitrary[TrieMap[String, Seq[Seq[String]]]].map(_.toMap)
+        data           <- Arbitrary.arbitrary[Map[String, Seq[Datum[String]]]]
+        joins          <- Arbitrary.arbitrary[Map[String, Seq[Seq[String]]]]
+        installedJoins <- Arbitrary.arbitrary[Map[String, Seq[Seq[String]]]]
       } yield HotStoreState(
         continuations,
         installedContinuations,

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -3,6 +3,8 @@ package coop.rchain.rspace
 import cats.Functor
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
+import cats.effect._
+import cats.effect.concurrent.{Ref, Semaphore}
 import com.typesafe.scalalogging.Logger
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.ski._
@@ -1286,20 +1288,21 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
                             history,
                             channels
                           )
-      cache         <- Ref.of[Task, Cache[C, P, A, K]](Cache[C, P, A, K]())
+      cache         <- Ref.of[Task, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
       historyReader <- historyRepository.getHistoryReader(historyRepository.root)
-      store = {
+      store <- {
         val hr = historyReader.base
-        AtomicAny(HotStore.inMem[Task, C, P, A, K](cache, hr))
+        HotStore.inMem[Task, C, P, A, K](cache, hr).map(AtomicAny(_))
       }
+
       space = new RSpace[Task, C, P, A, K](
         historyRepository,
         store
       )
-      historyCache <- Ref.of[Task, Cache[C, P, A, K]](Cache[C, P, A, K]())
-      replayStore = {
+      historyCache <- Ref.of[Task, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
+      replayStore <- {
         val hr = historyReader.base
-        AtomicAny(HotStore.inMem[Task, C, P, A, K](historyCache, hr))
+        HotStore.inMem[Task, C, P, A, K](historyCache, hr).map(AtomicAny(_))
       }
       replaySpace = new ReplayRSpace[Task, C, P, A, K](
         historyRepository,

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -1132,58 +1132,58 @@ trait StorageActionsTests[F[_]]
     } yield ()
   }
 
-//  "revertToSoftCheckpoint" should "revert the state of the store to the given checkpoint" in fixture {
-//    (_, storeAtom, space) =>
-//      val channel      = "ch1"
-//      val channels     = List(channel)
-//      val patterns     = List(Wildcard)
-//      val continuation = new StringsCaptor
-//
-//      for {
-//        // create an initial soft checkpoint
-//        s1 <- space.createSoftCheckpoint()
-//        // do an operation
-//        _ <- space.consume(channels, patterns, continuation, persist = false)
-//        changes <- storeAtom
-//                    .get()
-//                    .changes()
-//                    .map(
-//                      collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-//                    )
-//        // the operation should be on the list of changes
-//        _ = changes should not be empty
-//        _ <- space.revertToSoftCheckpoint(s1)
-//        changes <- storeAtom
-//                    .get()
-//                    .changes()
-//                    .map(
-//                      collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-//                    )
-//        // after reverting to the initial soft checkpoint the operation is no longer present in the hot store
-//        _ = changes shouldBe empty
-//      } yield ()
-//  }
+  "revertToSoftCheckpoint" should "revert the state of the store to the given checkpoint" in fixture {
+    (_, storeAtom, space) =>
+      val channel      = "ch1"
+      val channels     = List(channel)
+      val patterns     = List(Wildcard)
+      val continuation = new StringsCaptor
 
-//  it should "inject the event log" in fixture { (_, storeAtom, space) =>
-//    val channel      = "ch1"
-//    val channels     = List(channel)
-//    val patterns     = List(Wildcard)
-//    val continuation = new StringsCaptor
-//
-//    for {
-//      // do an operation
-//      _ <- space.consume(channels, patterns, continuation, persist = false)
-//      // create a soft checkpoint
-//      s1 <- space.createSoftCheckpoint()
-//      // do some other operation
-//      _  <- space.consume(channels, patterns, continuation, persist = true)
-//      s2 <- space.createSoftCheckpoint()
-//      _  = s2.log should not be s1.log
-//      _  <- space.revertToSoftCheckpoint(s1)
-//      s3 <- space.createSoftCheckpoint()
-//      _  = s3.log shouldBe s1.log
-//    } yield ()
-//  }
+      for {
+        // create an initial soft checkpoint
+        s1 <- space.createSoftCheckpoint()
+        // do an operation
+        _ <- space.consume(channels, patterns, continuation, persist = false)
+        changes <- storeAtom
+                    .get()
+                    .changes()
+                    .map(
+                      collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
+                    )
+        // the operation should be on the list of changes
+        _ = changes should not be empty
+        _ <- space.revertToSoftCheckpoint(s1)
+        changes <- storeAtom
+                    .get()
+                    .changes()
+                    .map(
+                      collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
+                    )
+        // after reverting to the initial soft checkpoint the operation is no longer present in the hot store
+        _ = changes shouldBe empty
+      } yield ()
+  }
+
+  it should "inject the event log" in fixture { (_, storeAtom, space) =>
+    val channel      = "ch1"
+    val channels     = List(channel)
+    val patterns     = List(Wildcard)
+    val continuation = new StringsCaptor
+
+    for {
+      // do an operation
+      _ <- space.consume(channels, patterns, continuation, persist = false)
+      // create a soft checkpoint
+      s1 <- space.createSoftCheckpoint()
+      // do some other operation
+      _  <- space.consume(channels, patterns, continuation, persist = true)
+      s2 <- space.createSoftCheckpoint()
+      _  = s2.log should not be s1.log
+      _  <- space.revertToSoftCheckpoint(s1)
+      s3 <- space.createSoftCheckpoint()
+      _  = s3.log shouldBe s1.log
+    } yield ()
+  }
 }
 
 class InMemoryHotStoreStorageActionsTests

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -1067,11 +1067,11 @@ trait StorageActionsTests[F[_]]
         // create a soft checkpoint
         s <- space.createSoftCheckpoint()
         // assert that the snapshot contains the continuation
-        _ = s.cacheSnapshot.cache.continuations.values should contain only expectedContinuation
+        _ = s.cacheSnapshot.continuations.values should contain only expectedContinuation
         // consume again
         _ <- space.consume(channels, patterns, continuation, persist = false)
         // assert that the snapshot contains only the first continuation
-        _ = s.cacheSnapshot.cache.continuations.values should contain only expectedContinuation
+        _ = s.cacheSnapshot.continuations.values should contain only expectedContinuation
       } yield ()
   }
 
@@ -1097,13 +1097,13 @@ trait StorageActionsTests[F[_]]
       // create a soft checkpoint
       s1 <- space.createSoftCheckpoint()
       // assert that the snapshot contains the continuation
-      _ = s1.cacheSnapshot.cache.continuations.values should contain only Seq(expectedContinuation)
+      _ = s1.cacheSnapshot.continuations.values should contain only Seq(expectedContinuation)
       // produce thus removing the continuation
       _  <- space.produce(channel, datum, persist = false)
       s2 <- space.createSoftCheckpoint()
       // assert that the first snapshot still contains the first continuation
-      _ = s1.cacheSnapshot.cache.continuations.values should contain only Seq(expectedContinuation)
-      _ = s2.cacheSnapshot.cache.continuations(channels) shouldBe empty
+      _ = s1.cacheSnapshot.continuations.values should contain only Seq(expectedContinuation)
+      _ = s2.cacheSnapshot.continuations(channels) shouldBe empty
     } yield ()
   }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -1132,58 +1132,58 @@ trait StorageActionsTests[F[_]]
     } yield ()
   }
 
-  "revertToSoftCheckpoint" should "revert the state of the store to the given checkpoint" in fixture {
-    (_, storeAtom, space) =>
-      val channel      = "ch1"
-      val channels     = List(channel)
-      val patterns     = List(Wildcard)
-      val continuation = new StringsCaptor
+//  "revertToSoftCheckpoint" should "revert the state of the store to the given checkpoint" in fixture {
+//    (_, storeAtom, space) =>
+//      val channel      = "ch1"
+//      val channels     = List(channel)
+//      val patterns     = List(Wildcard)
+//      val continuation = new StringsCaptor
+//
+//      for {
+//        // create an initial soft checkpoint
+//        s1 <- space.createSoftCheckpoint()
+//        // do an operation
+//        _ <- space.consume(channels, patterns, continuation, persist = false)
+//        changes <- storeAtom
+//                    .get()
+//                    .changes()
+//                    .map(
+//                      collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
+//                    )
+//        // the operation should be on the list of changes
+//        _ = changes should not be empty
+//        _ <- space.revertToSoftCheckpoint(s1)
+//        changes <- storeAtom
+//                    .get()
+//                    .changes()
+//                    .map(
+//                      collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
+//                    )
+//        // after reverting to the initial soft checkpoint the operation is no longer present in the hot store
+//        _ = changes shouldBe empty
+//      } yield ()
+//  }
 
-      for {
-        // create an initial soft checkpoint
-        s1 <- space.createSoftCheckpoint()
-        // do an operation
-        _ <- space.consume(channels, patterns, continuation, persist = false)
-        changes <- storeAtom
-                    .get()
-                    .changes()
-                    .map(
-                      collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-                    )
-        // the operation should be on the list of changes
-        _ = changes should not be empty
-        _ <- space.revertToSoftCheckpoint(s1)
-        changes <- storeAtom
-                    .get()
-                    .changes()
-                    .map(
-                      collectActions[InsertContinuations[String, Pattern, StringsCaptor]]
-                    )
-        // after reverting to the initial soft checkpoint the operation is no longer present in the hot store
-        _ = changes shouldBe empty
-      } yield ()
-  }
-
-  it should "inject the event log" in fixture { (_, storeAtom, space) =>
-    val channel      = "ch1"
-    val channels     = List(channel)
-    val patterns     = List(Wildcard)
-    val continuation = new StringsCaptor
-
-    for {
-      // do an operation
-      _ <- space.consume(channels, patterns, continuation, persist = false)
-      // create a soft checkpoint
-      s1 <- space.createSoftCheckpoint()
-      // do some other operation
-      _  <- space.consume(channels, patterns, continuation, persist = true)
-      s2 <- space.createSoftCheckpoint()
-      _  = s2.log should not be s1.log
-      _  <- space.revertToSoftCheckpoint(s1)
-      s3 <- space.createSoftCheckpoint()
-      _  = s3.log shouldBe s1.log
-    } yield ()
-  }
+//  it should "inject the event log" in fixture { (_, storeAtom, space) =>
+//    val channel      = "ch1"
+//    val channels     = List(channel)
+//    val patterns     = List(Wildcard)
+//    val continuation = new StringsCaptor
+//
+//    for {
+//      // do an operation
+//      _ <- space.consume(channels, patterns, continuation, persist = false)
+//      // create a soft checkpoint
+//      s1 <- space.createSoftCheckpoint()
+//      // do some other operation
+//      _  <- space.consume(channels, patterns, continuation, persist = true)
+//      s2 <- space.createSoftCheckpoint()
+//      _  = s2.log should not be s1.log
+//      _  <- space.revertToSoftCheckpoint(s1)
+//      s3 <- space.createSoftCheckpoint()
+//      _  = s3.log shouldBe s1.log
+//    } yield ()
+//  }
 }
 
 class InMemoryHotStoreStorageActionsTests

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -72,7 +72,7 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
                               cold,
                               channels
                             )
-      cache <- Ref.of[F, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
+      cache         <- Ref.of[F, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
       historyReader <- historyRepository.getHistoryReader(historyRepository.root)
       testStore <- {
         val hr = historyReader.base

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -72,9 +72,9 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
                               cold,
                               channels
                             )
-      cache         <- Ref.of[F, Cache[C, P, A, K]](Cache[C, P, A, K]())
+      cache <- Ref.of[F, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
       historyReader <- historyRepository.getHistoryReader(historyRepository.root)
-      testStore = {
+      testStore <- {
         val hr = historyReader.base
         HotStore.inMem[F, C, P, A, K](cache, hr)
       }


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

rebase the work in https://github.com/rchain/rchain/pull/3270 to the latest dev.

The original pr is intended to fix hotstore error which would cause tuple space mismatch

- [x] create a companion object of `HotStoreState`

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
