### PR TITLE
Fixed method to find BlockHash by truncated string with odd length

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -21,7 +21,7 @@ import coop.rchain.models.Validator.Validator
 import coop.rchain.models.{BlockHash, BlockMetadata, EquivocationRecord, Validator}
 import coop.rchain.shared.syntax._
 import coop.rchain.models.syntax._
-import coop.rchain.shared.{Log, LogSource}
+import coop.rchain.shared.{Base16, Log, LogSource}
 import coop.rchain.store.{KeyValueStoreManager, KeyValueTypedStore}
 
 import scala.collection.immutable.SortedMap
@@ -77,8 +77,20 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
       finalizedBlocksSet.contains(blockHash).pure[F]
 
     override def find(truncatedHash: String): F[Option[BlockHash]] = Sync[F].delay {
-      val truncatedByteString = truncatedHash.unsafeHexToByteString
-      dagSet.find(hash => hash.startsWith(truncatedByteString))
+      if (truncatedHash.length % 2 == 0) {
+        val truncatedByteString = truncatedHash.unsafeHexToByteString
+        dagSet.find(hash => hash.startsWith(truncatedByteString))
+      } else {
+        // if truncatedHash is odd length string we cannot convert it to ByteString with 8 bit resolution
+        // because each symbol has 4 bit resolution. Need to make a string of even length by removing the last symbol,
+        // then find all the matching hashes and choose one that matches the full truncatedHash string
+        val truncatedByteString = truncatedHash.dropRight(1).unsafeHexToByteString
+        dagSet
+          .filter(hash => hash.startsWith(truncatedByteString))
+          .find(
+            hash => Base16.encode(hash.toByteArray).startsWith(truncatedHash)
+          )
+      }
     }
 
     def topoSort(

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -86,10 +86,8 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
         // then find all the matching hashes and choose one that matches the full truncatedHash string
         val truncatedByteString = truncatedHash.dropRight(1).unsafeHexToByteString
         dagSet
-          .filter(hash => hash.startsWith(truncatedByteString))
-          .find(
-            hash => Base16.encode(hash.toByteArray).startsWith(truncatedHash)
-          )
+          .filter(_.startsWith(truncatedByteString))
+          .find(_.toHexString.startsWith(truncatedHash))
       }
     }
 


### PR DESCRIPTION
## Overview
Fix #3495.

If `truncatedHash` is **odd** length string we cannot convert it to `ByteString` with **8 bit** resolution because each symbol has **4 bit** resolution. Need to make a string of **even** length by removing the last symbol, then find all the matching hashes and choose one that matches the full `truncatedHash` string.

## Performance results
Hash to search: **1234abcd** (actually doesn’t exist)

|machine|averaged request time|factor|
|---|---|---|
| Test net observer | 1.66 sec | 20.75x |
| Current (de1a.dev.rchain.coop) | ~80 ms | 1x |

**1234abcd** (even) vs **1234abc** (odd) on locally running node

| hash length | averaged request time | factor |
|---|---|---|
| even length (1234abcd) | ~48 ms | 1.14x |
| odd length (1234abc) | ~42 ms | 1x |

| node | find block request time | factor |
|---|---|---|
| Main net, node0 | ~10.2s | 102x |
| Main net, observer-us | ~100ms | 1x |

bors try
