### PR TITLE
Unwraps bundle body in WebAPI implementation

### DIFF
--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -250,7 +250,10 @@ object WebApi {
   // RhoExpr from protobuf
 
   private def exprFromParProto(par: Par): Option[RhoExpr] = {
-    val exprs = par.exprs.flatMap(exprFromExprProto) ++ par.unforgeables.flatMap(unforgFromProto)
+    val exprs =
+      par.exprs.flatMap(exprFromExprProto) ++
+        par.unforgeables.flatMap(unforgFromProto) ++
+        par.bundles.flatMap(exprFromBundleProto)
     // Implements semantic of Par with Unit: P | Nil ==> P
     if (exprs.size == 1) exprs.head.some
     else if (exprs.isEmpty) none
@@ -311,6 +314,8 @@ object WebApi {
     else if (un.unfInstance.isGDeployerIdBody)
       mkUnforgExpr(UnforgDeployer, un.unfInstance.gDeployerIdBody.get.publicKey).some
     else none
+
+  private def exprFromBundleProto(b: Bundle): Option[RhoExpr] = exprFromParProto(b.body)
 
   private def mkUnforgExpr(f: String => RhoUnforg, bs: ByteString): ExprUnforg =
     ExprUnforg(f(toHex(bs)))


### PR DESCRIPTION
## Overview

Fix #3317.
WebAPI doesn't transform all types to JSON like gRPC and protobuf. This PR unwraps bundle body for WebAPI.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

bors try