### PR TITLE
History::reset method is wrapped into F

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
@@ -33,9 +33,12 @@ object DeployChainIndex {
     val deploysWithCost = deploys.map(v => DeployIdWithCost(v.deployId, v.cost))
     val eventLogIndex   = deploys.map(_.eventLogIndex).toList.combineAll
 
-    val preStateReader  = historyRepository.getHistoryReader(preStateHash).readerBinary
-    val postStateReader = historyRepository.getHistoryReader(postStateHash).readerBinary
     for {
+      preHistoryReader  <- historyRepository.getHistoryReader(preStateHash)
+      preStateReader    = preHistoryReader.readerBinary
+      postHistoryReader <- historyRepository.getHistoryReader(postStateHash)
+      postStateReader   = postHistoryReader.readerBinary
+
       stateChanges <- StateChange[F, C, P, A, K](
                        preStateReader = preStateReader,
                        postStateReader = postStateReader,

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -220,23 +220,25 @@ class RSpace[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, P, A, K](
       nextHistory <- spanF.withMarks("history-checkpoint") {
                       historyRepositoryAtom.get().checkpoint(changes.toList)
                     }
-      _   = historyRepositoryAtom.set(nextHistory)
-      log = eventLog.take()
-      _   = eventLog.put(Seq.empty)
-      _   = produceCounter.take()
-      _   = produceCounter.put(Map.empty.withDefaultValue(0))
-      _   <- createNewHotStore(nextHistory.getHistoryReader(nextHistory.root))
-      _   <- restoreInstalls()
+      _             = historyRepositoryAtom.set(nextHistory)
+      log           = eventLog.take()
+      _             = eventLog.put(Seq.empty)
+      _             = produceCounter.take()
+      _             = produceCounter.put(Map.empty.withDefaultValue(0))
+      historyReader <- nextHistory.getHistoryReader(nextHistory.root)
+      _             <- createNewHotStore(historyReader)
+      _             <- restoreInstalls()
     } yield Checkpoint(nextHistory.history.root, log)
   }
 
   def spawn: F[ISpace[F, C, P, A, K]] = spanF.withMarks("spawn") {
     for {
-      historyRepo <- Sync[F].delay(historyRepositoryAtom.get())
-      nextHistory <- historyRepo.reset(historyRepo.history.root)
-      hotStore    <- HotStore.empty(nextHistory.getHistoryReader(nextHistory.root).base)
-      rSpace      <- RSpace(nextHistory, hotStore)
-      _           <- rSpace.restoreInstalls()
+      historyRepo   <- Sync[F].delay(historyRepositoryAtom.get())
+      nextHistory   <- historyRepo.reset(historyRepo.history.root)
+      historyReader <- nextHistory.getHistoryReader(nextHistory.root)
+      hotStore      <- HotStore.empty(historyReader.base)
+      rSpace        <- RSpace(nextHistory, hotStore)
+      _             <- rSpace.restoreInstalls()
     } yield rSpace
   }
 }
@@ -309,10 +311,9 @@ object RSpace {
       // Play
       space <- RSpace(historyRepo, store)
       // Replay
-      replayStore <- HotStore.empty(
-                      historyRepo.getHistoryReader(historyRepo.root).base
-                    )
-      replay <- ReplayRSpace(historyRepo, replayStore)
+      historyReader <- historyRepo.getHistoryReader(historyRepo.root)
+      replayStore   <- HotStore.empty(historyReader.base)
+      replay        <- ReplayRSpace(historyRepo, replayStore)
     } yield (space, replay)
 
   /**
@@ -334,7 +335,8 @@ object RSpace {
                       store.cold,
                       store.channels
                     )
-      hotStore <- HotStore.empty(historyRepo.getHistoryReader(historyRepo.root).base)
+      historyReader <- historyRepo.getHistoryReader(historyRepo.root)
+      hotStore      <- HotStore.empty(historyReader.base)
     } yield (historyRepo, hotStore)
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -318,14 +318,15 @@ abstract class RSpaceOps[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, 
 
   override def reset(root: Blake2b256Hash): F[Unit] = spanF.trace(resetSpanLabel) {
     for {
-      nextHistory <- historyRepositoryAtom.get().reset(root)
-      _           = historyRepositoryAtom.set(nextHistory)
-      _           = eventLog.take()
-      _           = eventLog.put(Seq.empty)
-      _           = produceCounter.take()
-      _           = produceCounter.put(Map.empty.withDefaultValue(0))
-      _           <- createNewHotStore(nextHistory.getHistoryReader(root))
-      _           <- restoreInstalls()
+      nextHistory   <- historyRepositoryAtom.get().reset(root)
+      _             = historyRepositoryAtom.set(nextHistory)
+      _             = eventLog.take()
+      _             = eventLog.put(Seq.empty)
+      _             = produceCounter.take()
+      _             = produceCounter.put(Map.empty.withDefaultValue(0))
+      historyReader <- nextHistory.getHistoryReader(root)
+      _             <- createNewHotStore(historyReader)
+      _             <- restoreInstalls()
 
       // TODO: temp fix to release Semaphores inside TwoStepLock
       //  Adjust when runtime changes got in, create instance on spawn runtime.
@@ -357,15 +358,13 @@ abstract class RSpaceOps[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, 
     spanF.trace(revertSoftCheckpointSpanLabel) {
       val history = historyRepositoryAtom.get()
       for {
-        hotStore <- HotStore.from(
-                     checkpoint.cacheSnapshot.cache,
-                     history.getHistoryReader(history.root).base
-                   )
-        _ = storeAtom.set(hotStore)
-        _ = eventLog.take()
-        _ = eventLog.put(checkpoint.log)
-        _ = produceCounter.take()
-        _ = produceCounter.put(checkpoint.produceCounter)
+        historyReader <- history.getHistoryReader(history.root)
+        hotStore      <- HotStore.from(checkpoint.cacheSnapshot.cache, historyReader.base)
+        _             = storeAtom.set(hotStore)
+        _             = eventLog.take()
+        _             = eventLog.put(checkpoint.log)
+        _             = produceCounter.take()
+        _             = produceCounter.put(checkpoint.produceCounter)
       } yield ()
     }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -244,11 +244,12 @@ class ReplayRSpace[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, P, A, 
 
   override def createCheckpoint(): F[Checkpoint] = checkReplayData >> syncF.defer {
     for {
-      changes     <- storeAtom.get().changes()
-      nextHistory <- historyRepositoryAtom.get().checkpoint(changes.toList)
-      _           = historyRepositoryAtom.set(nextHistory)
-      _           <- createNewHotStore(nextHistory.getHistoryReader(nextHistory.root))
-      _           <- restoreInstalls()
+      changes       <- storeAtom.get().changes()
+      nextHistory   <- historyRepositoryAtom.get().checkpoint(changes.toList)
+      _             = historyRepositoryAtom.set(nextHistory)
+      historyReader <- nextHistory.getHistoryReader(nextHistory.root)
+      _             <- createNewHotStore(historyReader)
+      _             <- restoreInstalls()
     } yield Checkpoint(nextHistory.history.root, Seq.empty)
   }
 
@@ -313,11 +314,12 @@ class ReplayRSpace[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, P, A, 
 
   def spawn: F[IReplaySpace[F, C, P, A, K]] = spanF.withMarks("spawn") {
     for {
-      historyRepo  <- Sync[F].delay(historyRepositoryAtom.get())
-      nextHistory  <- historyRepo.reset(historyRepo.history.root)
-      hotStore     <- HotStore.empty(nextHistory.getHistoryReader(nextHistory.root).base)
-      rSpaceReplay <- ReplayRSpace(nextHistory, hotStore)
-      _            <- rSpaceReplay.restoreInstalls()
+      historyRepo   <- Sync[F].delay(historyRepositoryAtom.get())
+      nextHistory   <- historyRepo.reset(historyRepo.history.root)
+      historyReader <- nextHistory.getHistoryReader(nextHistory.root)
+      hotStore      <- HotStore.empty(historyReader.base)
+      rSpaceReplay  <- ReplayRSpace(nextHistory, hotStore)
+      _             <- rSpaceReplay.restoreInstalls()
     } yield rSpaceReplay
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/History.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/History.scala
@@ -33,7 +33,7 @@ trait History[F[_]] {
   /**
     * Returns History with specified with root pointer
     */
-  def reset(root: Blake2b256Hash): History[F]
+  def reset(root: Blake2b256Hash): F[History[F]]
 }
 
 object History {

--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryInstances.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryInstances.scala
@@ -557,8 +557,10 @@ object HistoryInstances {
       (start, key, TriePath.empty).tailRecM(traverse)
     }
 
-    override def reset(root: Blake2b256Hash): History[F] =
-      this.copy(root = root, historyStore = CachingHistoryStore(historyStore.historyStore))
+    override def reset(root: Blake2b256Hash): F[History[F]] =
+      Sync[F].delay(
+        this.copy(root = root, historyStore = CachingHistoryStore(historyStore.historyStore))
+      )
 
   }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepository.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepository.scala
@@ -43,7 +43,7 @@ trait HistoryRepository[F[_], C, P, A, K] extends ChannelStore[F, C] {
 
   def importer: F[RSpaceImporter[F]]
 
-  def getHistoryReader(stateHash: Blake2b256Hash): HistoryReader[F, Blake2b256Hash, C, P, A, K]
+  def getHistoryReader(stateHash: Blake2b256Hash): F[HistoryReader[F, Blake2b256Hash, C, P, A, K]]
 
   def getSerializeC: Serialize[C]
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepositoryImpl.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepositoryImpl.scala
@@ -238,7 +238,7 @@ final case class HistoryRepositoryImpl[F[_]: Concurrent: Parallel: Log: Span, C,
   override def reset(root: Blake2b256Hash): F[HistoryRepository[F, C, P, A, K]] =
     for {
       _    <- rootsRepository.validateAndSetCurrentRoot(root)
-      next = history.reset(root = root)
+      next <- history.reset(root = root)
     } yield this.copy[F, C, P, A, K](currentHistory = next)
 
   override def exporter: F[RSpaceExporter[F]] = Sync[F].delay(rspaceExporter)
@@ -253,8 +253,10 @@ final case class HistoryRepositoryImpl[F[_]: Concurrent: Parallel: Log: Span, C,
 
   override def getHistoryReader(
       stateHash: Blake2b256Hash
-  ): HistoryReader[F, Blake2b256Hash, C, P, A, K] =
-    new RSpaceHistoryReaderImpl(history.reset(root = stateHash), leafStore)(
+  ): F[HistoryReader[F, Blake2b256Hash, C, P, A, K]] =
+    for {
+      targetHistory <- history.reset(root = stateHash)
+    } yield new RSpaceHistoryReaderImpl(targetHistory, leafStore)(
       Concurrent[F],
       serializeC,
       serializeP,

--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepositoryImpl.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepositoryImpl.scala
@@ -254,13 +254,15 @@ final case class HistoryRepositoryImpl[F[_]: Concurrent: Parallel: Log: Span, C,
   override def getHistoryReader(
       stateHash: Blake2b256Hash
   ): F[HistoryReader[F, Blake2b256Hash, C, P, A, K]] =
-    for {
-      targetHistory <- history.reset(root = stateHash)
-    } yield new RSpaceHistoryReaderImpl(targetHistory, leafStore)(
-      Concurrent[F],
-      serializeC,
-      serializeP,
-      serializeA,
-      serializeK
-    )
+    history
+      .reset(root = stateHash)
+      .map(
+        new RSpaceHistoryReaderImpl(_, leafStore)(
+          Concurrent[F],
+          serializeC,
+          serializeP,
+          serializeA,
+          serializeK
+        )
+      )
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -1286,9 +1286,10 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
                             history,
                             channels
                           )
-      cache <- Ref.of[Task, Cache[C, P, A, K]](Cache[C, P, A, K]())
+      cache         <- Ref.of[Task, Cache[C, P, A, K]](Cache[C, P, A, K]())
+      historyReader <- historyRepository.getHistoryReader(historyRepository.root)
       store = {
-        val hr = historyRepository.getHistoryReader(historyRepository.root).base
+        val hr = historyReader.base
         AtomicAny(HotStore.inMem[Task, C, P, A, K](cache, hr))
       }
       space = new RSpace[Task, C, P, A, K](
@@ -1297,7 +1298,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
       )
       historyCache <- Ref.of[Task, Cache[C, P, A, K]](Cache[C, P, A, K]())
       replayStore = {
-        val hr = historyRepository.getHistoryReader(historyRepository.root).base
+        val hr = historyReader.base
         AtomicAny(HotStore.inMem[Task, C, P, A, K](historyCache, hr))
       }
       replaySpace = new ReplayRSpace[Task, C, P, A, K](

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -72,9 +72,10 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
                               cold,
                               channels
                             )
-      cache <- Ref.of[F, Cache[C, P, A, K]](Cache[C, P, A, K]())
+      cache         <- Ref.of[F, Cache[C, P, A, K]](Cache[C, P, A, K]())
+      historyReader <- historyRepository.getHistoryReader(historyRepository.root)
       testStore = {
-        val hr = historyRepository.getHistoryReader(historyRepository.root).base
+        val hr = historyReader.base
         HotStore.inMem[F, C, P, A, K](cache, hr)
       }
       spaceAndStore        <- createISpace(historyRepository, testStore)

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
@@ -121,8 +121,9 @@ abstract class HistoryRepositoryGenerativeDefinition
         actions
           .foldLeftM(repository) { (repo, action) =>
             for {
-              next <- repo.checkpoint(action :: Nil)
-              _    <- checkActionResult(action, next.getHistoryReader(next.root))
+              next          <- repo.checkpoint(action :: Nil)
+              historyReader <- next.getHistoryReader(next.root)
+              _             <- checkActionResult(action, historyReader)
             } yield next
           }
       }

--- a/rspace/src/test/scala/coop/rchain/rspace/history/SimplisticHistory.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/SimplisticHistory.scala
@@ -306,7 +306,7 @@ final case class SimplisticHistory[F[_]: Sync](
     case (trie, path) => (trie, path.nodes)
   }
 
-  def reset(root: Blake2b256Hash): History[F] = this.copy(root = root)
+  def reset(root: Blake2b256Hash): F[History[F]] = Sync[F].delay(this.copy(root = root))
 
 }
 


### PR DESCRIPTION
## Overview
Issue #3533. Solution wraps `History::reset` method into monadic type `F`. Wrapping of `HistoryRepository::getHistoryReader` is related.

### Notes
If `Sync[F].delay` is the correct way to wrap into `F`?

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

bors try