### PR TITLE
Added network-id and shard name to API response

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -110,6 +110,8 @@ object DeployRuntime {
       )
     )
 
+  def status[F[_]: Sync: DeployService]: F[Unit] = gracefulExit(DeployService[F].status)
+
   private def gracefulExit[F[_]: Monad: Sync, A](
       program: F[Either[Seq[String], String]]
   ): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -29,6 +29,7 @@ trait DeployService[F[_]] {
   def lastFinalizedBlock: F[Either[Seq[String], String]]
   def isFinalized(q: IsFinalizedQuery): F[Either[Seq[String], String]]
   def bondStatus(q: BondStatusQuery): F[Either[Seq[String], String]]
+  def status: F[Either[Seq[String], String]]
 }
 
 object DeployService {
@@ -179,6 +180,15 @@ class GrpcDeployService[F[_]: Monixable: Sync](host: String, port: Int, maxMessa
         )
       )
   }
+
+  def status: F[Either[Seq[String], String]] =
+    stub
+      .status(com.google.protobuf.empty.Empty())
+      .fromTask
+      .toEitherF(
+        _.message.error,
+        _.message.status.map(_.toProtoString)
+      )
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   override def close(): Unit = {

--- a/integration-tests/test/http_client.py
+++ b/integration-tests/test/http_client.py
@@ -12,15 +12,22 @@ class HttpRequestException(Exception):
        self.status_code = status_code
        self.content = content
 
+
+@dataclass
+class VersionInfo:
+    api: str
+    node: str
+
+
 @dataclass
 class ApiStatus:
-    version: int
-    version_info: str
+    version: VersionInfo
     address: str
     network_id: str
     shard_id: str
     peers: int
     nodes: int
+
 
 @dataclass
 class PrepareResponse:
@@ -51,8 +58,9 @@ class HttpClient():
         _check_reponse(rep)
         message = rep.json()
         return ApiStatus(
-            version=message['version'],
-            version_info=message['versionInfo'],
+            version=VersionInfo(
+                api=message['version']['api'],
+                node=message['version']['node']),
             address=message['address'],
             network_id=message['networkId'],
             shard_id=message['shardId'],

--- a/integration-tests/test/http_client.py
+++ b/integration-tests/test/http_client.py
@@ -15,7 +15,12 @@ class HttpRequestException(Exception):
 @dataclass
 class ApiStatus:
     version: int
-    message: str
+    version_info: str
+    address: str
+    network_id: str
+    shard_id: str
+    peers: int
+    nodes: int
 
 @dataclass
 class PrepareResponse:
@@ -45,7 +50,14 @@ class HttpClient():
         rep = requests.get(status_url)
         _check_reponse(rep)
         message = rep.json()
-        return ApiStatus(version=message['version'], message=message['message'])
+        return ApiStatus(
+            version=message['version'],
+            version_info=message['versionInfo'],
+            address=message['address'],
+            network_id=message['networkId'],
+            shard_id=message['shardId'],
+            peers=message['peers'],
+            nodes=message['nodes'])
 
     def prepare_deploy(self, deployer: Optional[str] =None, timestamp: Optional[int] = None, name_qty: Optional[int] = None) -> PrepareResponse:
         prepare_deploy_url = self.url + '/prepare-deploy'

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -222,7 +222,7 @@ message BlockEventInfo{
 }
 
 message Status {
-  int32 versionNumber = 1;
+  int32 version = 1;
   string versionInfo  = 2;
   string address      = 3;
   string networkId    = 4;

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -222,7 +222,7 @@ message BlockEventInfo{
 }
 
 message Status {
-  VersionInfo version = 1;
+  VersionInfo version = 1 [(scalapb.field).no_box = true];
   string address      = 2;
   string networkId    = 3;
   string shardId      = 4;

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -220,3 +220,14 @@ message BlockEventInfo{
   repeated SystemDeployInfoWithEventData systemDeploys = 3;
   bytes postStateHash = 4;
 }
+
+message Status {
+  int32 versionNumber = 1;
+  string versionInfo  = 2;
+  string address      = 3;
+  string networkId    = 4;
+  string shardId      = 5;
+  int32 peers         = 6;
+  int32 nodes         = 7;
+}
+

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -222,12 +222,15 @@ message BlockEventInfo{
 }
 
 message Status {
-  int32 version = 1;
-  string versionInfo  = 2;
-  string address      = 3;
-  string networkId    = 4;
-  string shardId      = 5;
-  int32 peers         = 6;
-  int32 nodes         = 7;
+  VersionInfo version = 1;
+  string address      = 2;
+  string networkId    = 3;
+  string shardId      = 4;
+  int32 peers         = 5;
+  int32 nodes         = 6;
 }
 
+message VersionInfo {
+  string api  = 1;
+  string node = 2;
+}

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -15,6 +15,8 @@ import "DeployServiceCommon.proto";
 
 import "scalapb/scalapb.proto";
 
+import "google/protobuf/empty.proto";
+
 option (scalapb.options) = {
   package_name: "coop.rchain.casper.protocol.deploy.v1"
   flat_package: true
@@ -60,6 +62,8 @@ service DeployService {
   rpc getBlocksByHeights(BlocksQueryByHeight) returns (stream BlockInfoResponse){}
   // temporary api for testing
   rpc getEventByHash(ReportQuery) returns (EventInfoResponse){}
+  // Get node status
+  rpc status(google.protobuf.Empty) returns (StatusResponse){}
 }
 
 message EventInfoResponse{
@@ -182,5 +186,12 @@ message BondStatusResponse {
   oneof message {
     ServiceError error = 1;
     bool isBonded   = 2;
+  }
+}
+
+message StatusResponse {
+  oneof message {
+    ServiceError error  = 1;
+    Status status = 2;
   }
 }

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -169,6 +169,7 @@ object Main {
       case LastFinalizedBlock    => DeployRuntime.lastFinalizedBlock[F]
       case IsFinalized(hash)     => DeployRuntime.isFinalized[F](hash)
       case BondStatus(publicKey) => DeployRuntime.bondStatus[F](publicKey)
+      case Status                => DeployRuntime.status[F]
       case _                     => Sync[F].delay(options.printHelp())
     }
 
@@ -213,6 +214,7 @@ object Main {
       case Some(options.bondStatus)           => BondStatus(options.bondStatus.validatorPublicKey())
       case Some(options.dataAtName)           => DataAtName(options.dataAtName.name())
       case Some(options.contAtName)           => ContAtName(options.contAtName.name())
+      case Some(options.status)               => Status
       case _                                  => Help
     }
 

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -297,7 +297,7 @@ object DeployGrpcServiceV1 {
           .flatMap(Observable.fromIterable)
 
       def status(request: com.google.protobuf.empty.Empty): Task[StatusResponse] =
-        Monixable.apply.toTask(for {
+        (for {
           address <- RPConfAsk[F].ask
           peers   <- ConnectionsCell[F].read
           nodes   <- NodeDiscovery[F].peers
@@ -311,6 +311,6 @@ object DeployGrpcServiceV1 {
             nodes.length
           )
           response = StatusResponse().withStatus(status)
-        } yield response)
+        } yield response).toTask
     }
 }

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -305,7 +305,7 @@ object DeployGrpcServiceV1 {
           peers   <- ConnectionsCell[F].read
           nodes   <- NodeDiscovery[F].peers
           status = Status(
-            versionNumber = 1,
+            version = 1,
             VersionInfo.get,
             address.local.toAddress,
             networkId,

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -22,7 +22,6 @@ import coop.rchain.shared.{Base16, Log}
 import coop.rchain.shared.ThrowableOps._
 import coop.rchain.shared.syntax._
 import coop.rchain.models.syntax._
-import coop.rchain.node.web.VersionInfo
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
@@ -305,8 +304,8 @@ object DeployGrpcServiceV1 {
           peers   <- ConnectionsCell[F].read
           nodes   <- NodeDiscovery[F].peers
           status = Status(
-            version = 1,
-            VersionInfo.get,
+            version =
+              Some(VersionInfo(api = 1.toString, node = coop.rchain.node.web.VersionInfo.get)),
             address.local.toAddress,
             networkId,
             shardId,

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -302,8 +302,7 @@ object DeployGrpcServiceV1 {
           peers   <- ConnectionsCell[F].read
           nodes   <- NodeDiscovery[F].peers
           status = Status(
-            version =
-              Some(VersionInfo(api = 1.toString, node = coop.rchain.node.web.VersionInfo.get)),
+            version = VersionInfo(api = 1.toString, node = coop.rchain.node.web.VersionInfo.get),
             address.local.toAddress,
             networkId,
             shardId,

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -33,7 +33,8 @@ object DeployGrpcServiceV1 {
       blockReportAPI: BlockReportAPI[F],
       triggerProposeF: Option[ProposeFunction[F]],
       devMode: Boolean = false,
-      networkId: String
+      networkId: String,
+      shardId: String
   )(
       implicit worker: Scheduler
   ): DeployServiceV1GrpcMonix.DeployService =
@@ -298,9 +299,6 @@ object DeployGrpcServiceV1 {
       def status(request: com.google.protobuf.empty.Empty): Task[StatusResponse] =
         Monixable.apply.toTask(for {
           address <- RPConfAsk[F].ask
-          apiErr  <- BlockAPI.getBlocks(1, 1)
-          blocks  = apiErr.right.getOrElse(List[LightBlockInfo]())
-          shardId = blocks.headOption.getOrElse(LightBlockInfo()).shardId
           peers   <- ConnectionsCell[F].read
           nodes   <- NodeDiscovery[F].peers
           status = Status(

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -68,7 +68,8 @@ object WebApi {
       devMode: Boolean = false,
       cacheTransactionAPI: CacheTransactionAPI[F],
       triggerProposeF: Option[ProposeFunction[F]],
-      networkId: String
+      networkId: String,
+      shardId: String
   ) extends WebApi[F] {
     import WebApiSyntax._
 
@@ -127,8 +128,6 @@ object WebApi {
     def status: F[ApiStatus] =
       for {
         address <- RPConfAsk[F].ask
-        blocks  <- getBlocks(depth = 1)
-        shardId = blocks.headOption.getOrElse(LightBlockInfo()).shardId
         peers   <- ConnectionsCell[F].read
         nodes   <- NodeDiscovery[F].peers
       } yield ApiStatus(

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -126,15 +126,14 @@ object WebApi {
 
     def status: F[ApiStatus] =
       for {
-        versionInfo <- Sync[F].delay(VersionInfo.get)
-        address     <- RPConfAsk[F].ask
-        blocks      <- getBlocks(depth = 1)
-        shardId     = blocks.headOption.getOrElse(LightBlockInfo()).shardId
-        peers       <- ConnectionsCell[F].read
-        nodes       <- NodeDiscovery[F].peers
+        address <- RPConfAsk[F].ask
+        blocks  <- getBlocks(depth = 1)
+        shardId = blocks.headOption.getOrElse(LightBlockInfo()).shardId
+        peers   <- ConnectionsCell[F].read
+        nodes   <- NodeDiscovery[F].peers
       } yield ApiStatus(
         versionNumber = 1,
-        versionInfo,
+        VersionInfo.get,
         address.local.toAddress,
         networkId,
         shardId,

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -132,7 +132,7 @@ object WebApi {
         peers   <- ConnectionsCell[F].read
         nodes   <- NodeDiscovery[F].peers
       } yield ApiStatus(
-        versionNumber = 1,
+        version = 1,
         VersionInfo.get,
         address.local.toAddress,
         networkId,
@@ -227,7 +227,7 @@ object WebApi {
   )
 
   final case class ApiStatus(
-      versionNumber: Int,
+      version: Int,
       versionInfo: String,
       address: String,
       networkId: String,

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -18,7 +18,7 @@ import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.GUnforgeable.UnfInstance.{GDeployIdBody, GDeployerIdBody, GPrivateBody}
 import coop.rchain.models._
 import coop.rchain.node.api.WebApi._
-import coop.rchain.node.web.{CacheTransactionAPI, TransactionResponse, VersionInfo}
+import coop.rchain.node.web.{CacheTransactionAPI, TransactionResponse}
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
 import coop.rchain.models.syntax._
@@ -132,8 +132,7 @@ object WebApi {
         peers   <- ConnectionsCell[F].read
         nodes   <- NodeDiscovery[F].peers
       } yield ApiStatus(
-        version = 1,
-        VersionInfo.get,
+        version = VersionInfo(api = 1.toString, node = coop.rchain.node.web.VersionInfo.get),
         address.local.toAddress,
         networkId,
         shardId,
@@ -227,14 +226,15 @@ object WebApi {
   )
 
   final case class ApiStatus(
-      version: Int,
-      versionInfo: String,
+      version: VersionInfo,
       address: String,
       networkId: String,
       shardId: String,
       peers: Int,
       nodes: Int
   )
+
+  final case class VersionInfo(api: String, node: String)
 
   // Exception thrown by BlockAPI
   final class BlockApiException(message: String) extends Exception(message)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -766,5 +766,13 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
   }
   addSubcommand(bondStatus)
 
+  val status = new Subcommand("status") {
+    descr(
+      "Get RNode status information"
+    )
+    helpWidth(width)
+  }
+  addSubcommand(status)
+
   verify()
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -122,3 +122,4 @@ final case class BondStatus(publicKey: PublicKey)                          exten
 final case object Help                                                     extends Command
 final case class DataAtName(name: Name)                                    extends Command
 final case class ContAtName(names: List[Name])                             extends Command
+final case object Status                                                   extends Command

--- a/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
@@ -34,7 +34,8 @@ object APIServers {
       devMode: Boolean,
       proposeFOpt: Option[ProposeFunction[F]],
       blockReportAPI: BlockReportAPI[F],
-      networkId: String
+      networkId: String,
+      shardId: String
   )(
       implicit
       blockStore: BlockStore[F],
@@ -55,7 +56,8 @@ object APIServers {
         blockReportAPI,
         proposeFOpt,
         devMode,
-        networkId
+        networkId,
+        shardId
       )
     val propose = ProposeGrpcServiceV1(triggerProposeFOpt, proposerStateRefOpt)
     APIServers(repl, propose, deploy)

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
@@ -147,6 +147,7 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
         implicit val tr = transport
         implicit val ti = time
         implicit val me = metrics
+        implicit val nd = nodeDiscovery
         Setup.setupNodeProgram[F](
           rpConnections,
           rpConfAsk,

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -22,6 +22,7 @@ import coop.rchain.casper.storage.RNodeKeyValueStoreManager
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager.legacyRSpacePathPrefix
 import coop.rchain.casper.util.comm.{CasperPacketHandler, CommUtil}
 import coop.rchain.casper.util.rholang.RuntimeManager
+import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.rp.Connect.ConnectionsCell
 import coop.rchain.comm.rp.RPConf
 import coop.rchain.comm.transport.TransportLayer
@@ -50,7 +51,7 @@ import monix.execution.Scheduler
 import java.nio.file.Files
 
 object Setup {
-  def setupNodeProgram[F[_]: Monixable: Concurrent: Parallel: ContextShift: Time: Timer: TransportLayer: LocalEnvironment: Log: EventLog: Metrics](
+  def setupNodeProgram[F[_]: Monixable: Concurrent: Parallel: ContextShift: Time: Timer: TransportLayer: LocalEnvironment: Log: EventLog: Metrics: NodeDiscovery](
       rpConnections: ConnectionsCell[F],
       rpConfAsk: ApplicativeAsk[F, RPConf],
       commUtil: CommUtil[F],
@@ -311,12 +312,15 @@ object Setup {
       cacheTransactionAPI <- Transaction.cacheTransactionAPI(transactionAPI, rnodeStoreManager)
       webApi = {
         implicit val (ec, bs, or, sp) = (engineCell, blockStore, oracle, span)
+        implicit val (ra, rc)         = (rpConfAsk, rpConnections)
+
         new WebApiImpl[F](
           conf.apiServer.maxBlocksLimit,
           conf.devMode,
           cacheTransactionAPI,
           if (conf.autopropose && conf.dev.deployerPrivateKey.isDefined) triggerProposeFOpt
-          else none[ProposeFunction[F]]
+          else none[ProposeFunction[F]],
+          conf.protocolServer.networkId
         )
       }
       adminWebApi = {

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -277,7 +277,8 @@ object Setup {
           if (conf.autopropose && conf.dev.deployerPrivateKey.isDefined) triggerProposeFOpt
           else none[ProposeFunction[F]],
           blockReportAPI,
-          conf.protocolServer.networkId
+          conf.protocolServer.networkId,
+          conf.casper.shardName
         )
       }
       reportingRoutes = {

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -323,7 +323,8 @@ object Setup {
           cacheTransactionAPI,
           if (conf.autopropose && conf.dev.deployerPrivateKey.isDefined) triggerProposeFOpt
           else none[ProposeFunction[F]],
-          conf.protocolServer.networkId
+          conf.protocolServer.networkId,
+          conf.casper.shardName
         )
       }
       adminWebApi = {

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -267,6 +267,7 @@ object Setup {
       apiServers = {
         implicit val (ec, bs, or, sp) = (engineCell, blockStore, oracle, span)
         implicit val (sc, lh)         = (synchronyConstraintChecker, lastFinalizedHeightConstraintChecker)
+        implicit val (ra, rp)         = (rpConfAsk, rpConnections)
         APIServers.build[F](
           evalRuntime,
           triggerProposeFOpt,
@@ -275,7 +276,8 @@ object Setup {
           conf.devMode,
           if (conf.autopropose && conf.dev.deployerPrivateKey.isDefined) triggerProposeFOpt
           else none[ProposeFunction[F]],
-          blockReportAPI
+          blockReportAPI,
+          conf.protocolServer.networkId
         )
       }
       reportingRoutes = {


### PR DESCRIPTION
## Overview
Issue #3532. Added network-id and shard name to WebAPI and gRPC response. Additionally added CLI parameter `status` to get node status info from another node.

### Notes
* Is it correct to place call of gRPC `status` method to `DeployRuntime`?
* Is it correct to use `VersionInfo.get` to getting version info instead of `versionInfo <- Sync[F].delay(VersionInfo.get)` such as [`StatusInfo.scala`](https://github.com/rchain/rchain/blob/c0bebe29bd8ad61fbffc382a5bbd8003be6b10e7/node/src/main/scala/coop/rchain/node/web/StatusInfo.scala#L20)?

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

bors try
