### PR TITLE
Check that bootstrap node and the current node has the same shard name

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -131,6 +131,13 @@ class Initializing[F[_]
 
       _ <- Log[F].info("Invalid LastFinalizedBlock received; refusing to add.").whenA(!isValid)
 
+      _ <- Log[F]
+            .info(
+              s"Bootstrap's node shard name '${approvedBlock.candidate.block.shardId}' " +
+                s"doesn't equals to current node shard name '${casperShardConf.shardName}'."
+            )
+            .whenA(!shardNameIsValid)
+
       // Start only once, when state is true and approved block is valid
       start <- startRequester.modify {
                 case true if isValid  => (false, true)

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -89,6 +89,7 @@ class Initializing[F[_]
       disableStateExporter: Boolean
   ): F[Unit] = {
     val senderIsBootstrap = RPConfAsk[F].ask.map(_.bootstrap.exists(_ == sender))
+    val shardNameIsValid  = approvedBlock.candidate.block.shardId == casperShardConf.shardName
 
     def handleApprovedBlock = {
       val block = approvedBlock.candidate.block
@@ -124,7 +125,7 @@ class Initializing[F[_]
     for {
       // TODO resolve validation of approved block - we should be sure that bootstrap is not lying
       // Might be Validate.approvedBlock is enough but have to check
-      isValid <- senderIsBootstrap &&^ Validate.approvedBlock[F](approvedBlock)
+      isValid <- senderIsBootstrap &&^ Validate.approvedBlock[F](approvedBlock) &&^ shardNameIsValid.pure
 
       _ <- Log[F].info("Received approved block from bootstrap node.").whenA(isValid)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -127,7 +127,9 @@ class Initializing[F[_]
     for {
       // TODO resolve validation of approved block - we should be sure that bootstrap is not lying
       // Might be Validate.approvedBlock is enough but have to check
-      isValid <- senderIsBootstrap &&^ Validate.approvedBlock[F](approvedBlock) &&^ shardNameIsValid.pure
+      isValid <- senderIsBootstrap &&^ shardNameIsValid.pure &&^ Validate.approvedBlock[F](
+                  approvedBlock
+                )
 
       _ <- Log[F].info("Received approved block from bootstrap node.").whenA(isValid)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -89,7 +89,9 @@ class Initializing[F[_]
       disableStateExporter: Boolean
   ): F[Unit] = {
     val senderIsBootstrap = RPConfAsk[F].ask.map(_.bootstrap.exists(_ == sender))
-    val shardNameIsValid  = approvedBlock.candidate.block.shardId == casperShardConf.shardName
+    val receivedShard     = approvedBlock.candidate.block.shardId
+    val expectedShard     = casperShardConf.shardName
+    val shardNameIsValid  = receivedShard == expectedShard
 
     def handleApprovedBlock = {
       val block = approvedBlock.candidate.block
@@ -134,8 +136,7 @@ class Initializing[F[_]
       _ <- Log[F]
             .info(
               s"Connected to the wrong shard. Approved block received from bootstrap is in shard " +
-                s"'${approvedBlock.candidate.block.shardId}' but expected is '${casperShardConf.shardName}'. " +
-                s"Check configuration option shard-name."
+                s"'${receivedShard}' but expected is '${expectedShard}'. Check configuration option shard-name."
             )
             .whenA(!shardNameIsValid)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -127,9 +127,8 @@ class Initializing[F[_]
     for {
       // TODO resolve validation of approved block - we should be sure that bootstrap is not lying
       // Might be Validate.approvedBlock is enough but have to check
-      isValid <- senderIsBootstrap &&^ shardNameIsValid.pure &&^ Validate.approvedBlock[F](
-                  approvedBlock
-                )
+      isValid <- senderIsBootstrap &&^ shardNameIsValid.pure &&^
+                  Validate.approvedBlock[F](approvedBlock)
 
       _ <- Log[F].info("Received approved block from bootstrap node.").whenA(isValid)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -133,8 +133,9 @@ class Initializing[F[_]
 
       _ <- Log[F]
             .info(
-              s"Bootstrap's node shard name '${approvedBlock.candidate.block.shardId}' " +
-                s"doesn't equals to current node shard name '${casperShardConf.shardName}'."
+              s"Connected to the wrong shard. Approved block received from bootstrap is in shard " +
+                s"'${approvedBlock.candidate.block.shardId}' but expected is '${casperShardConf.shardName}'. " +
+                s"Check configuration option shard-name."
             )
             .whenA(!shardNameIsValid)
 


### PR DESCRIPTION
## Overview
Issue #3547. When ApprovedBlock is received from bootstrap node, checking that both nodes have the same shard names is performed.

### Notes
Sample output for same shard names
```
ApprovedBlock is self-signed by ceremony master.
Received approved block from bootstrap node.
Valid approved block Block #0 (918c70e135...) with empty parents (supposedly genesis) received. Restoring approved state.
Block Block #0 (918c70e135...) with empty parents (supposedly genesis) sender is empty.
Sending StoreItemsRequest to bootstrap
Stream collected.
...
```

Sample output for different shard names
```
Invalid LastFinalizedBlock received; refusing to add.
Connected to the wrong shard. Approved block received from bootstrap is in shard 'root' but expected is 'another-shard'. Check configuration option shard-name.
```

bors try