### PR TITLE
Replace unsupported + in Docker version (for semantic versioning)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -338,6 +338,8 @@ lazy val node = (project in file("node"))
         ExecCmd("CMD", "run")
       )
     },
+    // Replace unsupported character `+`
+    version in Docker := { version.value.replace("+", "__") },
     mappings in Docker ++= {
       val base = (defaultLinuxInstallLocation in Docker).value
       directory((baseDirectory in rholang).value / "examples")


### PR DESCRIPTION
## Overview

Docker doesn't support `+` character in tag of the image which is specified as special build version by semantic versioning.
- https://github.com/moby/moby/issues/18168
- https://github.com/moby/moby/issues/27269
- https://semver.org/#spec-item-10

This PR adds a change to the build script to replace `+` with `__` in the version name of the tag of Docker image.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
