### PR TITLE
Add `no_box` option to complex routing protobuf types

### DIFF
--- a/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/HandleMessages.scala
@@ -24,12 +24,7 @@ object HandleMessages {
 
   def handle[F[_]: Monad: Sync: Log: Time: Metrics: TransportLayer: PacketHandler: ConnectionsCell: RPConfAsk](
       protocol: Protocol
-  ): F[CommunicationResponse] =
-    ProtocolHelper.sender(protocol) match {
-      case None =>
-        Log[F].error(s"Sender not present, DROPPING $protocol").as(notHandled(senderNotAvailable))
-      case Some(sender) => handle_[F](protocol, sender)
-    }
+  ): F[CommunicationResponse] = handle_[F](protocol, ProtocolHelper.sender(protocol))
 
   private def handle_[F[_]: Monad: Sync: Log: Time: Metrics: TransportLayer: PacketHandler: ConnectionsCell: RPConfAsk](
       proto: Protocol,

--- a/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
@@ -25,10 +25,7 @@ object ProtocolHelper {
       .withUdpPort(n.endpoint.udpPort)
       .withTcpPort(n.endpoint.tcpPort)
 
-  def sender(proto: Protocol): Option[PeerNode] =
-    for {
-      h <- proto.header
-    } yield toPeerNode(h.sender)
+  def sender(proto: Protocol): Option[PeerNode] = Some(toPeerNode(proto.header.sender))
 
   def toPeerNode(n: Node): PeerNode =
     PeerNode(NodeIdentifier(n.id.toByteArray), Endpoint(n.host.toStringUtf8, n.tcpPort, n.udpPort))

--- a/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
@@ -25,7 +25,7 @@ object ProtocolHelper {
       .withUdpPort(n.endpoint.udpPort)
       .withTcpPort(n.endpoint.tcpPort)
 
-  def sender(proto: Protocol): Option[PeerNode] = Some(toPeerNode(proto.header.sender))
+  def sender(proto: Protocol): PeerNode = toPeerNode(proto.header.sender)
 
   def toPeerNode(n: Node): PeerNode =
     PeerNode(NodeIdentifier(n.id.toByteArray), Endpoint(n.host.toStringUtf8, n.tcpPort, n.udpPort))

--- a/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
+++ b/comm/src/main/scala/coop/rchain/comm/rp/ProtocolHelper.scala
@@ -28,8 +28,7 @@ object ProtocolHelper {
   def sender(proto: Protocol): Option[PeerNode] =
     for {
       h <- proto.header
-      s <- h.sender
-    } yield toPeerNode(s)
+    } yield toPeerNode(h.sender)
 
   def toPeerNode(n: Node): PeerNode =
     PeerNode(NodeIdentifier(n.id.toByteArray), Endpoint(n.host.toStringUtf8, n.tcpPort, n.udpPort))

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransport.scala
@@ -94,7 +94,7 @@ object GrpcTransport {
     for {
       _ <- metrics.incrementCounter("send")
       result <- transport
-                 .send(TLRequest(msg.some))
+                 .send(TLRequest(msg))
                  .fromTask
                  .attempt
                  .timer("send-time")

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -94,7 +94,7 @@ object GrpcTransportReceiver {
             for {
               _                <- Metrics[F].incrementCounter("packets.received")
               self             <- RPConfAsk[F].reader(_.local)
-              peer             = PeerNode.from(p.header.get.sender)
+              peer             = PeerNode.from(p.header.sender)
               packetDroppedMsg = s"Packet dropped, ${peer.endpoint.host} packet queue overflown."
               targetBuffer     <- getBuffers(peer).map(_._1)
               r <- if (targetBuffer.pushNext(Send(p)))

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -154,7 +154,7 @@ object GrpcTransportReceiver {
 
       private def ack(src: PeerNode): TLResponse =
         TLResponse(
-          TLResponse.Payload.Ack(Ack(Some(ProtocolHelper.header(src, networkId))))
+          TLResponse.Payload.Ack(Ack(ProtocolHelper.header(src, networkId)))
         )
     }
 

--- a/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/GrpcTransportReceiver.scala
@@ -94,7 +94,7 @@ object GrpcTransportReceiver {
             for {
               _                <- Metrics[F].incrementCounter("packets.received")
               self             <- RPConfAsk[F].reader(_.local)
-              peer             = PeerNode.from(p.header.get.sender.get)
+              peer             = PeerNode.from(p.header.get.sender)
               packetDroppedMsg = s"Packet dropped, ${peer.endpoint.host} packet queue overflown."
               targetBuffer     <- getBuffers(peer).map(_._1)
               r <- if (targetBuffer.pushNext(Send(p)))

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -53,7 +53,7 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
 
     override def onMessage(message: RespT): Unit =
       message match {
-        case TLResponse(Payload.Ack(Ack(Some(RHeader(sender, nid))))) =>
+        case TLResponse(Payload.Ack(Ack(RHeader(sender, nid)))) =>
           if (nid == networkID) {
             val sslSession: Option[SSLSession] = Option(
               self.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionClientInterceptor.scala
@@ -53,7 +53,7 @@ class SslSessionClientCallInterceptor[ReqT, RespT](next: ClientCall[ReqT, RespT]
 
     override def onMessage(message: RespT): Unit =
       message match {
-        case TLResponse(Payload.Ack(Ack(Some(RHeader(Some(sender), nid))))) =>
+        case TLResponse(Payload.Ack(Ack(Some(RHeader(sender, nid))))) =>
           if (nid == networkID) {
             val sslSession: Option[SSLSession] = Option(
               self.getAttributes.get(Grpc.TRANSPORT_ATTR_SSL_SESSION)

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -40,7 +40,7 @@ class SslSessionServerInterceptor(networkID: String) extends ServerInterceptor {
 
     override def onMessage(message: ReqT): Unit =
       message match {
-        case TLRequest(Some(Protocol(Some(RHeader(Some(sender), nid)), msg))) =>
+        case TLRequest(Some(Protocol(Some(RHeader(sender, nid)), msg))) =>
           if (nid == networkID) {
             if (log.isTraceEnabled) {
               val peerNode = ProtocolHelper.toPeerNode(sender)

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -40,7 +40,7 @@ class SslSessionServerInterceptor(networkID: String) extends ServerInterceptor {
 
     override def onMessage(message: ReqT): Unit =
       message match {
-        case TLRequest(Some(Protocol(RHeader(sender, nid), msg))) =>
+        case TLRequest(Protocol(RHeader(sender, nid), msg)) =>
           if (nid == networkID) {
             if (log.isTraceEnabled) {
               val peerNode = ProtocolHelper.toPeerNode(sender)

--- a/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/SslSessionServerInterceptor.scala
@@ -40,7 +40,7 @@ class SslSessionServerInterceptor(networkID: String) extends ServerInterceptor {
 
     override def onMessage(message: ReqT): Unit =
       message match {
-        case TLRequest(Some(Protocol(Some(RHeader(sender, nid)), msg))) =>
+        case TLRequest(Some(Protocol(RHeader(sender, nid), msg))) =>
           if (nid == networkID) {
             if (log.isTraceEnabled) {
               val peerNode = ProtocolHelper.toPeerNode(sender)

--- a/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
+++ b/comm/src/main/scala/coop/rchain/comm/transport/StreamHandler.scala
@@ -113,10 +113,7 @@ object StreamHandler {
         .foldWhileLeftL(init) {
           case (
               stmd,
-              Chunk(
-                Chunk.Content
-                  .Header(ChunkHeader(Some(sender), typeId, compressed, cl, nid))
-              )
+              Chunk(Chunk.Content.Header(ChunkHeader(sender, typeId, compressed, cl, nid)))
               ) =>
             val newStmd = stmd.copy(
               header = Some(Header(ProtocolHelper.toPeerNode(sender), typeId, cl, nid, compressed))

--- a/comm/src/test/scala/coop/rchain/comm/transport/GrpcTransportSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/GrpcTransportSpec.scala
@@ -77,7 +77,7 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
           case Right(Right(p)) => p shouldEqual unit
         }
         stub.sendMessages.length shouldBe 1
-        stub.sendMessages.head shouldBe TLRequest(Some(msg))
+        stub.sendMessages.head shouldBe TLRequest(msg)
         stub.streamMessages.length shouldBe 0
       }
     }
@@ -93,7 +93,7 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
             p shouldEqual internalCommunicationError("Got response: Test error")
         }
         stub.sendMessages.length shouldBe 1
-        stub.sendMessages.head shouldBe TLRequest(Some(msg))
+        stub.sendMessages.head shouldBe TLRequest(msg)
         stub.streamMessages.length shouldBe 0
       }
     }
@@ -108,7 +108,7 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
             p shouldEqual peerUnavailable(peerRemote)
         }
         stub.sendMessages.length shouldBe 1
-        stub.sendMessages.head shouldBe TLRequest(Some(msg))
+        stub.sendMessages.head shouldBe TLRequest(msg)
         stub.streamMessages.length shouldBe 0
       }
     }
@@ -123,7 +123,7 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
             p shouldEqual timeout
         }
         stub.sendMessages.length shouldBe 1
-        stub.sendMessages.head shouldBe TLRequest(Some(msg))
+        stub.sendMessages.head shouldBe TLRequest(msg)
         stub.streamMessages.length shouldBe 0
       }
     }
@@ -138,7 +138,7 @@ class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
             p shouldEqual protocolException(testThrowable)
         }
         stub.sendMessages.length shouldBe 1
-        stub.sendMessages.head shouldBe TLRequest(Some(msg))
+        stub.sendMessages.head shouldBe TLRequest(msg)
         stub.streamMessages.length shouldBe 0
       }
     }

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -61,28 +61,6 @@ class StreamHandlerSpec extends FunSpec with Matchers with Inside {
       cache shouldBe empty
     }
 
-    it("should stop processing a stream if stream is missing part of header") {
-      // given
-      val cache = TrieMap[String, Array[Byte]]()
-      val streamWithIncompleteHeader: Observable[Chunk] =
-        Observable.fromIterator(createStreamIterator().map(_.toList).map {
-          case header :: data =>
-            val newHeaderContent: Chunk.Content =
-              Chunk.Content.Header(header.content.header.get.copy(sender = None))
-            val incompleteHeader = header.copy(content = newHeaderContent)
-            (incompleteHeader :: data).toIterator
-          case Nil => throw new RuntimeException("")
-        })
-      // when
-      val err: StreamHandler.StreamError =
-        handleStreamErr(streamWithIncompleteHeader, cache = cache)
-      // then
-      inside(err) {
-        case StreamHandler.StreamError.NotFullMessage(_) =>
-      }
-      cache shouldBe empty
-    }
-
     it("should stop processing a stream if stream is missing header") {
       // given
       val cache = TrieMap[String, Array[Byte]]()

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -32,7 +32,7 @@ abstract class TransportLayerSpec[F[_]: Monad: cats.effect.Timer, E <: Environme
 
           protocolDispatcher.received should have length 1
           val (_, protocol2)           = protocolDispatcher.received.head
-          val sender: Option[PeerNode] = ProtocolHelper.sender(protocol2)
+          val sender: Option[PeerNode] = Some(ProtocolHelper.sender(protocol2))
           sender shouldBe 'defined
           sender.get shouldEqual result.localNode
           protocol2.message shouldBe 'heartbeat
@@ -53,8 +53,8 @@ abstract class TransportLayerSpec[F[_]: Monad: cats.effect.Timer, E <: Environme
 
           protocolDispatcher.received should have length 2
           val Seq((r1, p1), (r2, p2))   = protocolDispatcher.received
-          val sender1: Option[PeerNode] = ProtocolHelper.sender(p1)
-          val sender2: Option[PeerNode] = ProtocolHelper.sender(p2)
+          val sender1: Option[PeerNode] = Some(ProtocolHelper.sender(p1))
+          val sender2: Option[PeerNode] = Some(ProtocolHelper.sender(p2))
           sender1 shouldBe 'defined
           sender2 shouldBe 'defined
           sender1.get shouldEqual result.localNode

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -31,10 +31,10 @@ abstract class TransportLayerSpec[F[_]: Monad: cats.effect.Timer, E <: Environme
           val result: TwoNodesResult = run()
 
           protocolDispatcher.received should have length 1
-          val (_, protocol2)           = protocolDispatcher.received.head
-          val sender: Option[PeerNode] = Some(ProtocolHelper.sender(protocol2))
+          val (_, protocol2)   = protocolDispatcher.received.head
+          val sender: PeerNode = ProtocolHelper.sender(protocol2)
           sender shouldBe 'defined
-          sender.get shouldEqual result.localNode
+          sender shouldEqual result.localNode
           protocol2.message shouldBe 'heartbeat
         }
     }
@@ -52,13 +52,13 @@ abstract class TransportLayerSpec[F[_]: Monad: cats.effect.Timer, E <: Environme
           val result: ThreeNodesResult = run()
 
           protocolDispatcher.received should have length 2
-          val Seq((r1, p1), (r2, p2))   = protocolDispatcher.received
-          val sender1: Option[PeerNode] = Some(ProtocolHelper.sender(p1))
-          val sender2: Option[PeerNode] = Some(ProtocolHelper.sender(p2))
+          val Seq((r1, p1), (r2, p2)) = protocolDispatcher.received
+          val sender1: PeerNode       = ProtocolHelper.sender(p1)
+          val sender2: PeerNode       = ProtocolHelper.sender(p2)
           sender1 shouldBe 'defined
           sender2 shouldBe 'defined
-          sender1.get shouldEqual result.localNode
-          sender2.get shouldEqual result.localNode
+          sender1 shouldEqual result.localNode
+          sender2 shouldEqual result.localNode
           p1.message shouldBe 'heartbeat
           p2.message shouldBe 'heartbeat
           r1 should (equal(result.remoteNode1) or equal(result.remoteNode2))

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -33,7 +33,6 @@ abstract class TransportLayerSpec[F[_]: Monad: cats.effect.Timer, E <: Environme
           protocolDispatcher.received should have length 1
           val (_, protocol2)   = protocolDispatcher.received.head
           val sender: PeerNode = ProtocolHelper.sender(protocol2)
-          sender shouldBe 'defined
           sender shouldEqual result.localNode
           protocol2.message shouldBe 'heartbeat
         }
@@ -55,8 +54,6 @@ abstract class TransportLayerSpec[F[_]: Monad: cats.effect.Timer, E <: Environme
           val Seq((r1, p1), (r2, p2)) = protocolDispatcher.received
           val sender1: PeerNode       = ProtocolHelper.sender(p1)
           val sender2: PeerNode       = ProtocolHelper.sender(p2)
-          sender1 shouldBe 'defined
-          sender2 shouldBe 'defined
           sender1 shouldEqual result.localNode
           sender2 shouldEqual result.localNode
           p1.message shouldBe 'heartbeat

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -73,7 +73,7 @@ message InternalServerError {
 }
 
 message Ack {
-    Header header = 1;
+    Header header = 1 [(scalapb.field).no_box = true];
 }
 
 message TLResponse {

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -84,7 +84,7 @@ message TLResponse {
 }
 
 message ChunkHeader {
-  Node   sender             = 1;
+  Node   sender             = 1 [(scalapb.field).no_box = true];
   string typeId             = 2;
   bool   compressed         = 3;
   int32  contentLength      = 4;

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -49,7 +49,7 @@ message Disconnect {
 }
 
 message Protocol {
-    Header header                                                 = 1;
+    Header header                                                 = 1 [(scalapb.field).no_box = true];
     oneof message {
         Heartbeat                   heartbeat                     = 2;
         ProtocolHandshake           protocol_handshake            = 3;

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -65,7 +65,7 @@ service TransportLayer {
 }
 
 message TLRequest {
-  Protocol protocol = 1;
+  Protocol protocol = 1 [(scalapb.field).no_box = true];
 }
 
 message InternalServerError {

--- a/models/src/main/protobuf/routing.proto
+++ b/models/src/main/protobuf/routing.proto
@@ -22,7 +22,7 @@ message Node {
 }
 
 message Header {
-  Node   sender         = 1;
+  Node   sender         = 1 [(scalapb.field).no_box = true];
   string networkId      = 2;
 }
 


### PR DESCRIPTION
## Overview
Issue #3548. The addition of the `no_box` option makes the related code smaller and cleaner.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

bors try
