### PR TITLE
Parameterize minimum Phlo price

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -30,6 +30,7 @@ object BlockStatus {
   def containsExpiredDeploy: BlockError    = InvalidBlock.ContainsExpiredDeploy
   def containsFutureDeploy: BlockError     = InvalidBlock.ContainsFutureDeploy
   def notOfInterest: BlockError            = InvalidBlock.NotOfInterest
+  def lowDeployCost: BlockError            = InvalidBlock.LowDeployCost
 
   def isInDag(blockStatus: BlockStatus): Boolean =
     blockStatus match {
@@ -86,6 +87,7 @@ object InvalidBlock {
   case object ContainsExpiredDeploy   extends InvalidBlock
   case object ContainsFutureDeploy    extends InvalidBlock
   case object NotOfInterest           extends InvalidBlock
+  case object LowDeployCost           extends InvalidBlock
 
   val slashableOffenses: Set[InvalidBlock] =
     Set(

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -128,7 +128,7 @@ final case class CasperShardConf(
     bondMaximum: Long,
     epochLength: Int,
     quarantineLength: Int,
-    minPhloPrice: Int
+    minPhloPrice: Long
 )
 
 sealed abstract class MultiParentCasperInstances {

--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -127,7 +127,8 @@ final case class CasperShardConf(
     bondMinimum: Long,
     bondMaximum: Long,
     epochLength: Int,
-    quarantineLength: Int
+    quarantineLength: Int,
+    minPhloPrice: Int
 )
 
 sealed abstract class MultiParentCasperInstances {

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -22,7 +22,8 @@ final case class CasperConf(
     heightConstraintThreshold: Long,
     roundRobinDispatcher: RoundRobinDispatcher,
     genesisBlockData: GenesisBlockData,
-    genesisCeremony: GenesisCeremonyConf
+    genesisCeremony: GenesisCeremonyConf,
+    minPhloPrice: Int
 )
 
 final case class GenesisBlockData(

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -23,7 +23,7 @@ final case class CasperConf(
     roundRobinDispatcher: RoundRobinDispatcher,
     genesisBlockData: GenesisBlockData,
     genesisCeremony: GenesisCeremonyConf,
-    minPhloPrice: Int
+    minPhloPrice: Long
 )
 
 final case class GenesisBlockData(

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -300,6 +300,8 @@ class MultiParentCasperImpl[F[_]
               EquivocationDetector.checkNeglectedEquivocationsWithUpdate(b, s.dag, approvedBlock)
             )
         _      <- EitherT.liftF(Span[F].mark("neglected-equivocation-validated"))
+        _      <- EitherT(Validate.phloPrice(b, casperShardConf.minPhloPrice))
+        _      <- EitherT.liftF(Span[F].mark("phlogiston-price-validated"))
         depDag <- EitherT.liftF(CasperBufferStorage[F].toDoublyLinkedDag)
         status <- EitherT(EquivocationDetector.checkEquivocations(depDag, b, s.dag))
         _      <- EitherT.liftF(Span[F].mark("equivocation-validated"))

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -299,9 +299,13 @@ class MultiParentCasperImpl[F[_]
         _ <- EitherT(
               EquivocationDetector.checkNeglectedEquivocationsWithUpdate(b, s.dag, approvedBlock)
             )
-        _      <- EitherT.liftF(Span[F].mark("neglected-equivocation-validated"))
-        _      <- EitherT(Validate.phloPrice(b, casperShardConf.minPhloPrice))
-        _      <- EitherT.liftF(Span[F].mark("phlogiston-price-validated"))
+        _ <- EitherT.liftF(Span[F].mark("neglected-equivocation-validated"))
+
+        // This validation is only to punish validator which accepted lower price deploys.
+        // And this can happen if not configured correctly.
+        // _      <- EitherT(Validate.phloPrice(b, casperShardConf.minPhloPrice))
+        // _      <- EitherT.liftF(Span[F].mark("phlogiston-price-validated"))
+
         depDag <- EitherT.liftF(CasperBufferStorage[F].toDoublyLinkedDag)
         status <- EitherT(EquivocationDetector.checkEquivocations(depDag, b, s.dag))
         _      <- EitherT.liftF(Span[F].mark("equivocation-validated"))

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -645,7 +645,7 @@ object Validate {
     */
   def phloPrice[F[_]: Log: Concurrent](
       b: BlockMessage,
-      minPhloPrice: Int
+      minPhloPrice: Long
   ): F[ValidBlockProcessing] =
     if (b.body.deploys.forall(_.deploy.data.phloPrice >= minPhloPrice)) {
       BlockStatus.valid.asRight[BlockError].pure

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -639,4 +639,17 @@ object Validate {
         } yield BlockError.BlockException(ex).asLeft[ValidBlock]
     }
   }
+
+  /**
+    * All of deploys must have greater or equal phloPrice then minPhloPrice
+    */
+  def phloPrice[F[_]: Log: Concurrent](
+      b: BlockMessage,
+      minPhloPrice: Int
+  ): F[ValidBlockProcessing] =
+    if (b.body.deploys.forall(_.deploy.data.phloPrice >= minPhloPrice)) {
+      BlockStatus.valid.asRight[BlockError].pure
+    } else {
+      BlockStatus.lowDeployCost.asLeft[ValidBlock].pure
+    }
 }

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -53,7 +53,7 @@ object BlockAPI {
   def deploy[F[_]: Concurrent: EngineCell: Log: Span](
       d: Signed[DeployData],
       triggerPropose: Option[ProposeFunction[F]],
-      minPhloPrice: Int
+      minPhloPrice: Long
   ): F[ApiErr[String]] = Span[F].trace(DeploySource) {
 
     def casperDeploy(casper: MultiParentCasper[F]): F[ApiErr[String]] =

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -52,7 +52,8 @@ object BlockAPI {
 
   def deploy[F[_]: Concurrent: EngineCell: Log: Span](
       d: Signed[DeployData],
-      triggerPropose: Option[ProposeFunction[F]]
+      triggerPropose: Option[ProposeFunction[F]],
+      minPhloPrice: Int
   ): F[ApiErr[String]] = Span[F].trace(DeploySource) {
 
     def casperDeploy(casper: MultiParentCasper[F]): F[ApiErr[String]] =
@@ -77,7 +78,6 @@ object BlockAPI {
     val forbiddenKeyCheck = forbiddenKeyError.whenA(isForbiddenKey)
 
     // Check if deploy has minimum phlo price
-    val minPhloPrice = 1
     val minPriceError = new RuntimeException(
       s"Phlo price is less than minimum price $minPhloPrice."
     ).raiseError[F, ApiErr[String]]

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -79,7 +79,7 @@ object BlockAPI {
 
     // Check if deploy has minimum phlo price
     val minPriceError = new RuntimeException(
-      s"Phlo price is less than minimum price $minPhloPrice."
+      s"Phlo price ${d.data.phloPrice} is less than minimum price $minPhloPrice."
     ).raiseError[F, ApiErr[String]]
     val minPhloPriceCheck = minPriceError.whenA(d.data.phloPrice < minPhloPrice)
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -63,7 +63,8 @@ object CasperLaunch {
         conf.genesisBlockData.bondMinimum,
         conf.genesisBlockData.bondMaximum,
         conf.genesisBlockData.epochLength,
-        conf.genesisBlockData.quarantineLength
+        conf.genesisBlockData.quarantineLength,
+        conf.minPhloPrice
       )
       def launch(): F[Unit] =
         BlockStore[F].getApprovedBlock map {

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
@@ -1,11 +1,17 @@
 package coop.rchain.casper.batch1
 
+import cats.implicits.catsSyntaxApplicativeError
+import coop.rchain.casper.MultiParentCasper
+import coop.rchain.casper.api.BlockAPI
+import coop.rchain.casper.batch2.EngineWithCasper
 import coop.rchain.casper.blocks.proposer.{Created, NoNewDeploys}
+import coop.rchain.casper.engine.Engine
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode._
 import coop.rchain.casper.util.ConstructDeploy
-import coop.rchain.casper.MultiParentCasper
+import coop.rchain.metrics.{NoopSpan, Span}
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
+import coop.rchain.shared.Cell
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
@@ -64,6 +70,27 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
         r              <- node.createBlock(deployData)
         Created(block) = r
       } yield assert(!block.body.deploys.head.isFailed)
+    }
+  }
+
+  it should "reject deploy with phloPrice lower than minPhloPrice" in effectTest {
+    TestNode.standaloneEff(genesis).use { node =>
+      import node.logEff
+      implicit val noopSpan: Span[Effect] = NoopSpan[Effect]()
+      val engine                          = new EngineWithCasper[Effect](node.casperEff)
+      Cell.mvarCell[Effect, Engine[Effect]](engine).flatMap { implicit engineCell =>
+        val minPhloPrice = 10.toLong
+        for {
+          deployData <- ConstructDeploy.sourceDeployNowF[Effect]("Nil", phloPrice = 1)
+          _ <- BlockAPI.deploy[Effect](deployData, None, minPhloPrice = minPhloPrice).handleError {
+                exception =>
+                  assert(
+                    exception.getMessage == s"Phlo price is less than minimum price $minPhloPrice."
+                  )
+                  Right("Ok")
+              }
+        } yield ()
+      }
     }
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -61,7 +61,7 @@ class ValidateTest
       0,
       Map.empty,
       OnChainCasperState(
-        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         Map.empty,
         Seq.empty
       )

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -159,7 +159,8 @@ object Setup {
       genesisParams.proofOfStake.minimumBond,
       genesisParams.proofOfStake.maximumBond,
       genesisParams.proofOfStake.epochLength,
-      genesisParams.proofOfStake.quarantineLength
+      genesisParams.proofOfStake.quarantineLength,
+      1
     )
   }
   private def endpoint(port: Int): Endpoint = Endpoint("host", port, port)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -46,7 +46,7 @@ class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDag
       0,
       Map.empty,
       OnChainCasperState(
-        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         Map.empty,
         Seq.empty
       )

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -46,7 +46,7 @@ object BlockGenerator {
       0,
       Map.empty,
       OnChainCasperState(
-        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         Map.empty,
         Seq.empty
       )

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -152,7 +152,8 @@ case class TestNode[F[_]: Timer](
     bondMinimum = 0,
     bondMaximum = Long.MaxValue,
     epochLength = 10000,
-    quarantineLength = 20000
+    quarantineLength = 20000,
+    minPhloPrice = 1
   )
 
   implicit val casperEff = new MultiParentCasperImpl[F](

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -68,7 +68,7 @@ class InterpreterUtilTest
       0,
       Map.empty,
       OnChainCasperState(
-        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         Map.empty,
         Seq.empty
       )

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -130,7 +130,7 @@ object Resources {
       0,
       Map.empty,
       OnChainCasperState(
-        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        CasperShardConf(0, "", "", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         Map.empty,
         Seq.empty
       )

--- a/integration-tests/test/rnode.py
+++ b/integration-tests/test/rnode.py
@@ -511,7 +511,8 @@ def make_bootstrap_node(
     drop_peer_after_retries: int = 0,
     number_of_active_validators: int = 10,
     epoch_length: int = 10000,
-    quarantine_length: int = 50000
+    quarantine_length: int = 50000,
+    min_phlo_price: int = 1
 ) -> Node:
 
     container_name = make_bootstrap_name(network)
@@ -535,7 +536,8 @@ def make_bootstrap_node(
         "--frrd-drop-peer-after-retries":        drop_peer_after_retries,
         "--number-of-active-validators":    number_of_active_validators,
         "--epoch-length":                   epoch_length,
-        "--quarantine-length":              quarantine_length
+        "--quarantine-length":              quarantine_length,
+        "--min-phlo-price":                 min_phlo_price
     }
 
     if cli_flags is not None:
@@ -741,7 +743,8 @@ def started_bootstrap(
     extra_volumes: Optional[List[str]] = None,
     synchrony_constraint_threshold: float = 0.0,
     epoch_length: int = 10000,
-    quarantine_length: int = 50000
+    quarantine_length: int = 50000,
+    min_phlo_price: int = 1
 ) -> Generator[Node, None, None]:
     bootstrap_node = make_bootstrap_node(
         docker_client=context.docker,
@@ -755,7 +758,8 @@ def started_bootstrap(
         extra_volumes=extra_volumes,
         synchrony_constraint_threshold=synchrony_constraint_threshold,
         epoch_length=epoch_length,
-        quarantine_length=quarantine_length
+        quarantine_length=quarantine_length,
+        min_phlo_price=min_phlo_price
     )
     try:
         wait_for_node_started(context, bootstrap_node)
@@ -772,6 +776,7 @@ def started_bootstrap_with_network(
     synchrony_constraint_threshold: float = 0.0,
     epoch_length: int = 10000,
     quarantine_length: int = 50000,
+    min_phlo_price: int = 1,
     extra_volumes: Optional[List[str]] = None,
     wait_for_approved_block: bool = False,
 ) -> Generator[Node, None, None]:
@@ -784,7 +789,8 @@ def started_bootstrap_with_network(
                 synchrony_constraint_threshold=synchrony_constraint_threshold,
                 extra_volumes=extra_volumes,
                 epoch_length=epoch_length,
-                quarantine_length=quarantine_length
+                quarantine_length=quarantine_length,
+                min_phlo_price=min_phlo_price
         ) as bootstrap:
             if wait_for_approved_block:
                 wait_for_approved_block_received_handler_state(context, bootstrap)

--- a/integration-tests/test/test_propose.py
+++ b/integration-tests/test/test_propose.py
@@ -4,6 +4,7 @@ import shutil
 from typing import Generator
 from contextlib import contextmanager
 import pytest
+from rchain.client import RClientException
 from rchain.crypto import PrivateKey
 from docker.client import DockerClient
 
@@ -37,13 +38,13 @@ FIX_COST_RHO_CONTRACTS = {
 }
 
 @contextmanager
-def start_node(command_line_options: CommandLineOptions, docker_client: DockerClient, random_generator: Random) -> Generator[Node, None, None]:
+def start_node(command_line_options: CommandLineOptions, docker_client: DockerClient, random_generator: Random, min_phlo_price: int = 1) -> Generator[Node, None, None]:
     genesis_vault = {
         USER_KEY: 5000000000
     }
 
     with testing_context(command_line_options, random_generator, docker_client, wallets_dict=genesis_vault) as context, \
-            started_bootstrap_with_network(context=context) as bootstrap:
+            started_bootstrap_with_network(context=context, min_phlo_price=min_phlo_price) as bootstrap:
             wait_for_approved_block_received_handler_state(context, bootstrap)
             yield bootstrap
 
@@ -85,3 +86,16 @@ def test_deploy_invalid_contract(command_line_options: CommandLineOptions, docke
         block_hash = bootstrap.propose()
         block_info = bootstrap.get_block(block_hash)
         assert len(block_info.deploys) == 1
+
+
+def test_deploy_phlo_price_too_small(command_line_options: CommandLineOptions, docker_client: DockerClient, random_generator: Random) -> None:
+    deploy_phlo_price = 1  # less than min_phlo_price
+    min_phlo_price = 10
+    with start_node(command_line_options, docker_client, random_generator, min_phlo_price=min_phlo_price) as bootstrap:
+        contract = 'contract.rho'
+        shutil.copyfile(f'resources/{contract}', os.path.join(bootstrap.local_deploy_dir, contract))
+        container_contract_file_path = os.path.join(bootstrap.remote_deploy_dir, contract)
+
+        with pytest.raises(RClientException) as ex:
+            bootstrap.deploy(container_contract_file_path, USER_KEY, 100000000, deploy_phlo_price)
+            assert ex == f'Phlo price is less than minimum price {min_phlo_price}.'

--- a/integration-tests/test/test_propose.py
+++ b/integration-tests/test/test_propose.py
@@ -96,6 +96,6 @@ def test_deploy_phlo_price_too_small(command_line_options: CommandLineOptions, d
         shutil.copyfile(f'resources/{contract}', os.path.join(bootstrap.local_deploy_dir, contract))
         container_contract_file_path = os.path.join(bootstrap.remote_deploy_dir, contract)
 
-        with pytest.raises(RClientException) as ex:
+        with pytest.raises(RClientException,
+                           match=f'Phlo price {deploy_phlo_price} is less than minimum price {min_phlo_price}.'):
             bootstrap.deploy(container_contract_file_path, USER_KEY, 100000000, deploy_phlo_price)
-            assert ex == f'Phlo price is less than minimum price {min_phlo_price}.'

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -228,7 +228,7 @@ message Status {
   string shardId      = 4;
   int32 peers         = 5;
   int32 nodes         = 6;
-  int32 minPhloPrice  = 7;
+  int64 minPhloPrice  = 7;
 }
 
 message VersionInfo {

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -228,6 +228,7 @@ message Status {
   string shardId      = 4;
   int32 peers         = 5;
   int32 nodes         = 6;
+  int32 minPhloPrice  = 7;
 }
 
 message VersionInfo {

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -153,6 +153,7 @@ object HashM extends HashMDerivation {
   implicit val DataWithBlockInfoHash          = gen[DataWithBlockInfo]
   implicit val WaitingContinuationInfoHash    = gen[WaitingContinuationInfo]
   implicit val BlockQueryByHeightHash         = gen[BlocksQueryByHeight]
+  implicit val Status                         = gen[Status]
 
   implicit val ApprovedBlockHash          = gen[ApprovedBlock]
   implicit val ApprovedBlockCandidateHash = gen[ApprovedBlockCandidate]

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -319,6 +319,10 @@ casper {
     # If this is `true` and no genesis block available on startup node will start genesis ceremony.
     ceremony-master-mode = ${standalone}
   }
+
+  # The minimum Phlogiston price. Value can be configured to provide sufficient transaction fees to cover
+  # the cost of the network and equipment
+  min-phlo-price = 1
 }
 
 # Enable/disable Kamon reporters. Kamon is used for metrics collection / aggregation.

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -34,7 +34,8 @@ object DeployGrpcServiceV1 {
       triggerProposeF: Option[ProposeFunction[F]],
       devMode: Boolean = false,
       networkId: String,
-      shardId: String
+      shardId: String,
+      minPhloPrice: Int
   )(
       implicit worker: Scheduler
   ): DeployServiceV1GrpcMonix.DeployService =
@@ -307,7 +308,8 @@ object DeployGrpcServiceV1 {
             networkId,
             shardId,
             peers.length,
-            nodes.length
+            nodes.length,
+            minPhloPrice
           )
           response = StatusResponse().withStatus(status)
         } yield response).toTask

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -87,7 +87,7 @@ object DeployGrpcServiceV1 {
               })
             },
             dd => {
-              defer(BlockAPI.deploy[F](dd, triggerProposeF)) { r =>
+              defer(BlockAPI.deploy[F](dd, triggerProposeF, minPhloPrice)) { r =>
                 import DeployResponse.Message
                 import DeployResponse.Message._
                 DeployResponse(r.fold[Message](Error, Result))

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -309,7 +309,7 @@ object DeployGrpcServiceV1 {
             shardId,
             peers.length,
             nodes.length,
-            minPhloPrice.toInt
+            minPhloPrice
           )
           response = StatusResponse().withStatus(status)
         } yield response).toTask

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -35,7 +35,7 @@ object DeployGrpcServiceV1 {
       devMode: Boolean = false,
       networkId: String,
       shardId: String,
-      minPhloPrice: Int
+      minPhloPrice: Long
   )(
       implicit worker: Scheduler
   ): DeployServiceV1GrpcMonix.DeployService =
@@ -309,7 +309,7 @@ object DeployGrpcServiceV1 {
             shardId,
             peers.length,
             nodes.length,
-            minPhloPrice
+            minPhloPrice.toInt
           )
           response = StatusResponse().withStatus(status)
         } yield response).toTask

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -93,7 +93,7 @@ object WebApi {
 
     def deploy(request: DeployRequest): F[String] =
       toSignedDeploy(request)
-        .flatMap(BlockAPI.deploy(_, triggerProposeF))
+        .flatMap(BlockAPI.deploy(_, triggerProposeF, minPhloPrice))
         .flatMap(_.liftToBlockApiErr)
 
     def listenForDataAtName(req: DataRequest): F[DataResponse] =

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -70,7 +70,7 @@ object WebApi {
       triggerProposeF: Option[ProposeFunction[F]],
       networkId: String,
       shardId: String,
-      minPhloPrice: Int
+      minPhloPrice: Long
   ) extends WebApi[F] {
     import WebApiSyntax._
 
@@ -233,7 +233,7 @@ object WebApi {
       shardId: String,
       peers: Int,
       nodes: Int,
-      minPhloPrice: Int
+      minPhloPrice: Long
   )
 
   final case class VersionInfo(api: String, node: String)

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -69,7 +69,8 @@ object WebApi {
       cacheTransactionAPI: CacheTransactionAPI[F],
       triggerProposeF: Option[ProposeFunction[F]],
       networkId: String,
-      shardId: String
+      shardId: String,
+      minPhloPrice: Int
   ) extends WebApi[F] {
     import WebApiSyntax._
 
@@ -136,7 +137,8 @@ object WebApi {
         networkId,
         shardId,
         peers.length,
-        nodes.length
+        nodes.length,
+        minPhloPrice
       )
 
     def getBlocksByHeights(startBlockNumber: Long, endBlockNumber: Long): F[List[LightBlockInfo]] =
@@ -230,7 +232,8 @@ object WebApi {
       networkId: String,
       shardId: String,
       peers: Int,
-      nodes: Int
+      nodes: Int,
+      minPhloPrice: Int
   )
 
   final case class VersionInfo(api: String, node: String)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -91,6 +91,7 @@ object ConfigMapper {
       add("casper.genesis-ceremony.approve-interval", run.approveInterval)
       add("casper.genesis-ceremony.approve-duration", run.approveDuration) //TODO remove
       add("casper.genesis-ceremony.autogen-shard-size", run.autogenShardSize)
+      add("casper.min-phlo-price", run.minPhloPrice)
 
       add("api-server.port-grpc-external", run.apiPortGrpcExternal)
       add("api-server.port-grpc-internal", run.apiPortGrpcInternal)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -534,7 +534,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     // Similar value `casper.min-phlo-price` defined in defaults.conf and should be moved to Scala based config
     val minPhloPrice = opt[Long](
       descr = "MinPhloPrice",
-      default = Some(1),
       validate = _ >= 0
     )
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -531,6 +531,13 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "Private key for dummy deploys."
     )
 
+    // Similar value `casper.min-phlo-price` defined in defaults.conf and should be moved to Scala based config
+    val minPhloPrice = opt[Long](
+      descr = "MinPhloPrice",
+      default = Some(1),
+      validate = _ >= 0
+    )
+
   }
   addSubcommand(run)
 

--- a/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
@@ -36,7 +36,7 @@ object APIServers {
       blockReportAPI: BlockReportAPI[F],
       networkId: String,
       shardId: String,
-      minPhloPrice: Int
+      minPhloPrice: Long
   )(
       implicit
       blockStore: BlockStore[F],

--- a/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
@@ -35,7 +35,8 @@ object APIServers {
       proposeFOpt: Option[ProposeFunction[F]],
       blockReportAPI: BlockReportAPI[F],
       networkId: String,
-      shardId: String
+      shardId: String,
+      minPhloPrice: Int
   )(
       implicit
       blockStore: BlockStore[F],
@@ -57,7 +58,8 @@ object APIServers {
         proposeFOpt,
         devMode,
         networkId,
-        shardId
+        shardId,
+        minPhloPrice
       )
     val propose = ProposeGrpcServiceV1(triggerProposeFOpt, proposerStateRefOpt)
     APIServers(repl, propose, deploy)

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -278,7 +278,8 @@ object Setup {
           else none[ProposeFunction[F]],
           blockReportAPI,
           conf.protocolServer.networkId,
-          conf.casper.shardName
+          conf.casper.shardName,
+          conf.casper.minPhloPrice
         )
       }
       reportingRoutes = {

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -324,7 +324,8 @@ object Setup {
           if (conf.autopropose && conf.dev.deployerPrivateKey.isDefined) triggerProposeFOpt
           else none[ProposeFunction[F]],
           conf.protocolServer.networkId,
-          conf.casper.shardName
+          conf.casper.shardName,
+          conf.casper.minPhloPrice
         )
       }
       adminWebApi = {

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -248,7 +248,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
           autogenShardSize = 111111,
           genesisValidatorMode = true,
           ceremonyMasterMode = true
-        )
+        ),
+        minPhloPrice = 1
       ),
       metrics = Metrics(
         prometheus = true,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -152,7 +152,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
           autogenShardSize = 5,
           genesisValidatorMode = false,
           ceremonyMasterMode = false
-        )
+        ),
+        minPhloPrice = 1
       ),
       metrics = Metrics(
         prometheus = false,


### PR DESCRIPTION
## Overview
Added parametrization of minimal phlogiston price. To do this, you need to set the `--min-phlo-price` CLI parameter when running the node. Default value defined in [defaults.conf](https://github.com/rchain/rchain/blob/530ec0ea124e477a9219175ba09f4ef34fc9e0ce/node/src/main/resources/defaults.conf#L325) and equals `1`. For each deploy in block performs check that it's phlo price is greater or equal than the minimal phlogiston price. If at least one of the deploys has lower phloPrice, propose will be rejected. More info about `phloPrice` and usage [here](https://github.com/rchain/rchain/wiki/Cost-accounting-in-RChain).

The motivation is to provide sufficient transaction fees to cover the cost of the network and equipment.

### How to check validation is performs

1. Run two nodes in a bundle: bootstrap and validator (read-only node). See schema below:
```
(1)(2)
+------------------+                +-------------------+
|    bootstrap     |  (5) validate  |     validator     |----+
|                  |--------------->|    (read-only)    |    | (6) Log warning: One or more deploys...
| minPhloPrice = 1 |                | minPhloPrice = 10 | <--+
+------------------+                +-------------------+
     ^      ^
     |      |
     |      |
(3) deploy[phloPrice=1]
            |
      (4) propose
```
2. Bootstrap node should have lower `min-phlo-price`. For example, default value `1`. Validator node should have greater `min-phlo-price`. For example, `10`.
3. Make deploys on bootstrap node with appropriate phloPrice, for example `1`, but lower than needed for validator node.
4. Propose on bootstrap node
5. Validator will start validation
6. Warning log message `One or more deploys has phloPrice lower than 10` will be printed to stdout.

**Command to running bootstrap node**
```shell
./rnode run -s --validator-private-key <VALIDATOR_PRIVATE_KEY> --wallets-file wallets.txt --bonds-file bonds.txt --host 127.0.0.1 --allow-private-addresses
```
**Note**. The bootstrap node should be started from a "clean" state.

**Command to running validator node**
```shell
run -b "<BOOTSTRAP_NODE_ADDRESS>" --host 127.0.0.1 --allow-private-addresses --api-port-grpc-external 40411 --api-port-grpc-internal 40412 --api-port-admin-http 40415 --api-port-http 40413 --protocol-port 40410 --discovery-port 40414 --min-phlo-price 10 --data-dir .
```
**Note**. The `--data-dir` for validator node should be different from the bootstrap node, so this parameter should be provided.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
