### PR TITLE
Replace `+` with `__` for Docker image tag in CI action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -424,7 +424,9 @@ jobs:
           set -x
 
           image_name="$DOCKER_IMAGE_NAME$suffix"
-          img_version="$image_name:$VERSION$ci_run"
+          img_version_raw="$image_name:$VERSION$ci_run"
+          # Replace unsupported character `+`
+          img_version="${img_version_raw//[+]/__}"
           img_latest="$image_name:latest"
 
           # Release Docker image


### PR DESCRIPTION
## Overview

In addition to replace `+` when Docker image is built #3550, this PR fixes CI job to replace the same when image is published.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
