### PR TITLE
Make 40402 the default internal grpc port to create Repl/eval and propose clients

### DIFF
--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -124,7 +124,7 @@ object Main {
     implicit val proposeServiceClient: GrpcProposeService[F] =
       new GrpcProposeService[F](
         options.grpcHost(),
-        options.grpcPort(),
+        grpcPort,
         options.grpcMaxRecvMessageSize()
       )
 

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -109,7 +109,7 @@ object Main {
     implicit val replServiceClient: GrpcReplClient[F] =
       new GrpcReplClient[F](
         options.grpcHost(),
-        options.grpcPort(),
+        options.grpcInternalPort(),
         options.grpcMaxRecvMessageSize()
       )
     implicit val deployServiceClient: GrpcDeployService[F] =

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -105,14 +105,14 @@ object Main {
   private def runCLI[F[_]: Sync: Monixable: ConsoleIO: Timer](
       options: commandline.Options
   ): F[Unit] = {
-    val internalPort =
-      if (options.grpcPort.isSupplied) options.grpcPort() else options.grpcInternalPort()
+    val grpcPort =
+      if (options.grpcPort.isSupplied) options.grpcPort() else commandline.Options.GrpcInternalPort
 
     // Clients for executing gRPC calls on remote RNode instance
     implicit val replServiceClient: GrpcReplClient[F] =
       new GrpcReplClient[F](
         options.grpcHost(),
-        internalPort,
+        grpcPort,
         options.grpcMaxRecvMessageSize()
       )
     implicit val deployServiceClient: GrpcDeployService[F] =

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -109,7 +109,7 @@ object Main {
     implicit val replServiceClient: GrpcReplClient[F] =
       new GrpcReplClient[F](
         options.grpcHost(),
-        options.grpcInternalPort(),
+        replPort(options),
         options.grpcMaxRecvMessageSize()
       )
     implicit val deployServiceClient: GrpcDeployService[F] =
@@ -181,6 +181,16 @@ object Main {
       }
     ) >> program
   }
+
+  /**
+    * If --grpc-port option specified, returns it's value. Otherwise returns port-grpc-internal default value
+    * @param options command line options
+    * @return port for repl/eval mode
+    */
+  private def replPort(options: commandline.Options): Int =
+    if (options.grpcPort.isSupplied) options.grpcPort()
+    else
+      Configuration.defaultConf().at("api-server.port-grpc-internal").load[Int].getOrElse(40402)
 
   private def subcommand(options: commandline.Options): Command =
     options.subcommand match {

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -105,11 +105,14 @@ object Main {
   private def runCLI[F[_]: Sync: Monixable: ConsoleIO: Timer](
       options: commandline.Options
   ): F[Unit] = {
+    val internalPort =
+      if (options.grpcPort.isSupplied) options.grpcPort() else options.grpcInternalPort()
+
     // Clients for executing gRPC calls on remote RNode instance
     implicit val replServiceClient: GrpcReplClient[F] =
       new GrpcReplClient[F](
         options.grpcHost(),
-        replPort(options),
+        internalPort,
         options.grpcMaxRecvMessageSize()
       )
     implicit val deployServiceClient: GrpcDeployService[F] =
@@ -181,16 +184,6 @@ object Main {
       }
     ) >> program
   }
-
-  /**
-    * If --grpc-port option specified, returns it's value. Otherwise returns port-grpc-internal default value
-    * @param options command line options
-    * @return port for repl/eval mode
-    */
-  private def replPort(options: commandline.Options): Int =
-    if (options.grpcPort.isSupplied) options.grpcPort()
-    else
-      Configuration.defaultConf().at("api-server.port-grpc-internal").load[Int].getOrElse(40402)
 
   private def subcommand(options: commandline.Options): Command =
     options.subcommand match {

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -146,4 +146,13 @@ object Configuration {
   // TODO do we need this constraint? Let user set any but warn?
   // private val MaxMessageSizeMinimumValue: Int = 256 * 1024 // 0.25 MB
   // private val MaxMessageSizeMaximumValue: Int = 10 * 1024 * 1024
+
+  def defaultConf(dataDir: Path = Paths.get(".")) =
+    ConfigSource
+      .resources("defaults.conf")
+      .withFallback(
+        ConfigSource.string(
+          s"default-data-dir = $dataDir"
+        )
+      )
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -146,13 +146,4 @@ object Configuration {
   // TODO do we need this constraint? Let user set any but warn?
   // private val MaxMessageSizeMinimumValue: Int = 256 * 1024 // 0.25 MB
   // private val MaxMessageSizeMaximumValue: Int = 10 * 1024 * 1024
-
-  def defaultConf(dataDir: Path = Paths.get(".")) =
-    ConfigSource
-      .resources("defaults.conf")
-      .withFallback(
-        ConfigSource.string(
-          s"default-data-dir = $dataDir"
-        )
-      )
 }

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -127,8 +127,22 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val grpcPort = opt[Int](
     short = 'p',
-    default = Some(40401),
+    default = grpcExternalPort.toOption,
     descr = s"Remote gRPC host for client calls. Defaults to 40401."
+  )
+
+  // Similar value `api-server.port-grpc-external` defined in defaults.conf and should be moved to Scala based config
+  val grpcExternalPort = opt[Int](
+    short = 'e',
+    default = Some(40401),
+    descr = s"Port for external gRPC API. Defaults to 40401"
+  )
+
+  // Similar value `api-server.port-grpc-internal` defined in defaults.conf and should be moved to Scala based config
+  val grpcInternalPort = opt[Int](
+    short = 'i',
+    default = Some(40402),
+    descr = s"Port for internal gRPC API. Defaults to 40402"
   )
 
   val grpcMaxRecvMessageSize = opt[Int](

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -131,12 +131,6 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     descr = s"Remote gRPC host for client calls. Defaults to 40401."
   )
 
-  val grpcInternalPort = opt[Int](
-    short = 'i',
-    default = Some(40402),
-    descr = s"Port for internal gRPC API. Defaults to 40402"
-  )
-
   val grpcMaxRecvMessageSize = opt[Int](
     short = 's',
     default = Some(16 * 1024 * 1024),

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -131,6 +131,12 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     descr = s"Remote gRPC host for client calls. Defaults to 40401."
   )
 
+  val grpcInternalPort = opt[Int](
+    short = 'i',
+    default = Some(40402),
+    descr = s"Port for internal gRPC API. Defaults to 40402"
+  )
+
   val grpcMaxRecvMessageSize = opt[Int](
     short = 's',
     default = Some(16 * 1024 * 1024),

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -98,6 +98,11 @@ object Options {
   // We need this conversion because ScallopOption[A] is invariant in A
   implicit def scallopOptionFlagToBoolean(so: ScallopOption[Flag]): ScallopOption[Boolean] =
     so.map(identity)
+
+  // Similar values `api-server.port-grpc-internal` and `api-server.port-grpc-external`
+  // defined in defaults.conf and should be moved to Scala based config
+  val GrpcExternalPort = 40401
+  val GrpcInternalPort = 40402
 }
 
 final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) {
@@ -127,22 +132,8 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
 
   val grpcPort = opt[Int](
     short = 'p',
-    default = grpcExternalPort.toOption,
+    default = Some(Options.GrpcExternalPort),
     descr = s"Remote gRPC host for client calls. Defaults to 40401."
-  )
-
-  // Similar value `api-server.port-grpc-external` defined in defaults.conf and should be moved to Scala based config
-  val grpcExternalPort = opt[Int](
-    short = 'e',
-    default = Some(40401),
-    descr = s"Port for external gRPC API. Defaults to 40401"
-  )
-
-  // Similar value `api-server.port-grpc-internal` defined in defaults.conf and should be moved to Scala based config
-  val grpcInternalPort = opt[Int](
-    short = 'i',
-    default = Some(40402),
-    descr = s"Port for internal gRPC API. Defaults to 40402"
   )
 
   val grpcMaxRecvMessageSize = opt[Int](


### PR DESCRIPTION
## Overview
Allows to use *repl/eval* mode without explicit passing `--grpc-port` parameter (see [comment](https://github.com/rchain/rchip-proposals/issues/48#issuecomment-991793435)). Now this mode can be used as shown below
```shell
./rnode --grpc-internal-port 40412 eval hello.rho
or
./rnode -i 40412 eval hello.rho
or simply (with default value 40402)
./rnode eval hello.rho
```
**Note**: In the first two cases master rnode should be run with `--api-port-grpc-internal 40412`.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
