### PR TITLE
[TEST] Cleanup HotStore in-memory implementation

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -360,7 +360,7 @@ private class InMemHotStore[F[_]: Concurrent, C, P, A, K](
 
 object HotStore {
 
-  def inMem[F[_]: Concurrent, C, P, A, K](
+  def apply[F[_]: Concurrent, C, P, A, K](
       hotStoreStateRef: Ref[F, HotStoreState[C, P, A, K]],
       historyReaderBase: HistoryReaderBase[F, C, P, A, K]
   ): F[HotStore[F, C, P, A, K]] =
@@ -370,18 +370,18 @@ object HotStore {
       )
       .map(new InMemHotStore[F, C, P, A, K](hotStoreStateRef, _, historyReaderBase))
 
-  def from[F[_]: Concurrent, C, P, A, K](
+  def apply[F[_]: Concurrent, C, P, A, K](
       cache: HotStoreState[C, P, A, K],
       historyReader: HistoryReaderBase[F, C, P, A, K]
   ): F[HotStore[F, C, P, A, K]] =
     for {
       cache <- Ref.of[F, HotStoreState[C, P, A, K]](cache)
-      store <- HotStore.inMem(cache, historyReader)
+      store <- HotStore(cache, historyReader)
     } yield store
 
-  def empty[F[_]: Concurrent, C, P, A, K](
+  def apply[F[_]: Concurrent, C, P, A, K](
       historyReader: HistoryReaderBase[F, C, P, A, K]
   ): F[HotStore[F, C, P, A, K]] =
-    from(HotStoreState(), historyReader)
+    apply(HotStoreState[C, P, A, K](), historyReader)
 
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -38,14 +38,16 @@ final case class HotStoreState[C, P, A, K](
 )
 
 object HotStoreState {
-  def apply[C, P, A, K](): HotStoreState[C, P, A, K] =
-    HotStoreState[C, P, A, K](
-      Map.empty[Seq[C], Seq[WaitingContinuation[P, K]]],
-      Map.empty[Seq[C], WaitingContinuation[P, K]],
-      Map.empty[C, Seq[Datum[A]]],
-      Map.empty[C, Seq[Seq[C]]],
-      Map.empty[C, Seq[Seq[C]]]
-    )
+  def apply[C, P, A, K](
+      continuations: Map[Seq[C], Seq[WaitingContinuation[P, K]]] =
+        Map.empty[Seq[C], Seq[WaitingContinuation[P, K]]],
+      installedContinuations: Map[Seq[C], WaitingContinuation[P, K]] =
+        Map.empty[Seq[C], WaitingContinuation[P, K]],
+      data: Map[C, Seq[Datum[A]]] = Map.empty[C, Seq[Datum[A]]],
+      joins: Map[C, Seq[Seq[C]]] = Map.empty[C, Seq[Seq[C]]],
+      installedJoins: Map[C, Seq[Seq[C]]] = Map.empty[C, Seq[Seq[C]]]
+  ): HotStoreState[C, P, A, K] =
+    HotStoreState[C, P, A, K](continuations, installedContinuations, data, joins, installedJoins)
 }
 
 private final case class HistoryStoreCache[F[_], C, P, A, K](

--- a/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/HotStore.scala
@@ -47,7 +47,13 @@ object HotStoreState {
       joins: Map[C, Seq[Seq[C]]] = Map.empty[C, Seq[Seq[C]]],
       installedJoins: Map[C, Seq[Seq[C]]] = Map.empty[C, Seq[Seq[C]]]
   ): HotStoreState[C, P, A, K] =
-    HotStoreState[C, P, A, K](continuations, installedContinuations, data, joins, installedJoins)
+    new HotStoreState[C, P, A, K](
+      continuations,
+      installedContinuations,
+      data,
+      joins,
+      installedJoins
+    )
 }
 
 private final case class HistoryStoreCache[F[_], C, P, A, K](

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpace.scala
@@ -236,7 +236,7 @@ class RSpace[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, P, A, K](
       historyRepo   <- Sync[F].delay(historyRepositoryAtom.get())
       nextHistory   <- historyRepo.reset(historyRepo.history.root)
       historyReader <- nextHistory.getHistoryReader(nextHistory.root)
-      hotStore      <- HotStore.empty(historyReader.base)
+      hotStore      <- HotStore(historyReader.base)
       rSpace        <- RSpace(nextHistory, hotStore)
       _             <- rSpace.restoreInstalls()
     } yield rSpace
@@ -312,7 +312,7 @@ object RSpace {
       space <- RSpace(historyRepo, store)
       // Replay
       historyReader <- historyRepo.getHistoryReader(historyRepo.root)
-      replayStore   <- HotStore.empty(historyReader.base)
+      replayStore   <- HotStore(historyReader.base)
       replay        <- ReplayRSpace(historyRepo, replayStore)
     } yield (space, replay)
 
@@ -336,7 +336,7 @@ object RSpace {
                       store.channels
                     )
       historyReader <- historyRepo.getHistoryReader(historyRepo.root)
-      hotStore      <- HotStore.empty(historyReader.base)
+      hotStore      <- HotStore(historyReader.base)
     } yield (historyRepo, hotStore)
   }
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/RSpaceOps.scala
@@ -340,7 +340,7 @@ abstract class RSpaceOps[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, 
       historyReader: HistoryReader[F, Blake2b256Hash, C, P, A, K]
   ): F[Unit] =
     for {
-      nextHotStore <- HotStore.empty(historyReader.base)
+      nextHotStore <- HotStore(historyReader.base)
       _            = storeAtom.set(nextHotStore)
     } yield ()
 
@@ -359,15 +359,12 @@ abstract class RSpaceOps[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, 
       val history = historyRepositoryAtom.get()
       for {
         historyReader <- history.getHistoryReader(history.root)
-        hotStore <- HotStore.from(
-                     checkpoint.cacheSnapshot,
-                     historyReader.base
-                   )
-        _ = storeAtom.set(hotStore)
-        _ = eventLog.take()
-        _ = eventLog.put(checkpoint.log)
-        _ = produceCounter.take()
-        _ = produceCounter.put(checkpoint.produceCounter)
+        hotStore      <- HotStore(checkpoint.cacheSnapshot, historyReader.base)
+        _             = storeAtom.set(hotStore)
+        _             = eventLog.take()
+        _             = eventLog.put(checkpoint.log)
+        _             = produceCounter.take()
+        _             = produceCounter.put(checkpoint.produceCounter)
       } yield ()
     }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -317,7 +317,7 @@ class ReplayRSpace[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, P, A, 
       historyRepo   <- Sync[F].delay(historyRepositoryAtom.get())
       nextHistory   <- historyRepo.reset(historyRepo.history.root)
       historyReader <- nextHistory.getHistoryReader(nextHistory.root)
-      hotStore      <- HotStore.empty(historyReader.base)
+      hotStore      <- HotStore(historyReader.base)
       rSpaceReplay  <- ReplayRSpace(nextHistory, hotStore)
       _             <- rSpaceReplay.restoreInstalls()
     } yield rSpaceReplay

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -1364,7 +1364,7 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task] {
         new History[F, String, Pattern, String, StringsCaptor](historyState)
       }
       cache    <- C()
-      hotStore <- HotStore.inMem[F, String, Pattern, String, StringsCaptor](cache, history)
+      hotStore <- HotStore[F, String, Pattern, String, StringsCaptor](cache, history)
       res      <- f(cache, history, hotStore)
     } yield res).runSyncUnsafe(1.second)
 
@@ -1377,7 +1377,7 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task] {
         new History[F, String, Pattern, String, StringsCaptor](historyState)
       }
       cache    <- C(cache)
-      hotStore <- HotStore.inMem[F, String, Pattern, String, StringsCaptor](cache, history)
+      hotStore <- HotStore[F, String, Pattern, String, StringsCaptor](cache, history)
       res      <- f(hotStore)
     } yield res).runSyncUnsafe(1.second)
 

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -1308,7 +1308,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
   }
 }
 
-class History[F[_]: Sync, C, P, A, K](implicit R: Ref[F, HotStoreState[C, P, A, K]])
+class History[F[_]: Sync, C, P, A, K](R: Ref[F, HotStoreState[C, P, A, K]])
     extends HistoryReaderBase[F, C, P, A, K] {
 
   override def getJoins(channel: C): F[Seq[Seq[C]]] =
@@ -1361,8 +1361,7 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task] {
     (for {
       historyState <- Ref[F].of(HotStoreState[String, Pattern, String, StringsCaptor]())
       history = {
-        implicit val hs = historyState
-        new History[F, String, Pattern, String, StringsCaptor]
+        new History[F, String, Pattern, String, StringsCaptor](historyState)
       }
       cache    <- C()
       hotStore <- HotStore.inMem[F, String, Pattern, String, StringsCaptor](cache, history)
@@ -1375,8 +1374,7 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task] {
     (for {
       historyState <- Ref[F].of(HotStoreState[String, Pattern, String, StringsCaptor]())
       history = {
-        implicit val hs = historyState
-        new History[F, String, Pattern, String, StringsCaptor]
+        new History[F, String, Pattern, String, StringsCaptor](historyState)
       }
       cache    <- C(cache)
       hotStore <- HotStore.inMem[F, String, Pattern, String, StringsCaptor](cache, history)

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -101,21 +101,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         {
           for {
             _ <- history.putContinuations(channels, historyContinuations)
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map(
-                          channels -> cachedContinuations
-                        ),
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map.empty,
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map(
+                        channels -> cachedContinuations
                       ),
-                      ()
-                    )
-                )
+                      installedContinuations = Map.empty,
+                      data = Map.empty,
+                      joins = Map.empty,
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             readContinuations <- hotStore.getContinuations(channels)
 
             cache <- state.get
@@ -135,21 +134,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       fixture { (state, history, hotStore) =>
         {
           for {
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map(
-                          channels -> cachedContinuations
-                        ),
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map.empty,
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map(
+                        channels -> cachedContinuations
                       ),
-                      ()
-                    )
-                )
+                      installedContinuations = Map.empty,
+                      data = Map.empty,
+                      joins = Map.empty,
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             _     <- hotStore.installContinuation(channels, installedContinuation)
             res   <- hotStore.getContinuations(channels)
             cache <- state.get
@@ -193,21 +191,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         {
           for {
             _ <- history.putContinuations(channels, historyContinuations)
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map(
-                          channels -> cachedContinuations
-                        ),
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map.empty,
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map(
+                        channels -> cachedContinuations
                       ),
-                      ()
-                    )
-                )
+                      installedContinuations = Map.empty,
+                      data = Map.empty,
+                      joins = Map.empty,
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             _     <- hotStore.putContinuation(channels, insertedContinuation)
             cache <- state.get
             _ <- S.delay(
@@ -230,21 +227,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         fixture { (state, history, hotStore) =>
           {
             for {
-              _ <- state.modify(
-                    _ =>
-                      (
-                        HotStoreState(
-                          continuations = Map(
-                            channels -> cachedContinuations
-                          ),
-                          installedContinuations = Map.empty,
-                          data = Map.empty,
-                          joins = Map.empty,
-                          installedJoins = Map.empty
+              _ <- state.modify { _ =>
+                    (
+                      HotStoreState(
+                        continuations = Map(
+                          channels -> cachedContinuations
                         ),
-                        ()
-                      )
-                  )
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map.empty,
+                        installedJoins = Map.empty
+                      ),
+                      ()
+                    )
+                  }
               _     <- hotStore.installContinuation(channels, installedContinuation)
               _     <- hotStore.putContinuation(channels, insertedContinuation)
               cache <- state.get
@@ -296,21 +292,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         {
           for {
             _ <- history.putContinuations(channels, historyContinuations)
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map(
-                          channels -> cachedContinuations
-                        ),
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map.empty,
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map(
+                        channels -> cachedContinuations
                       ),
-                      ()
-                    )
-                )
+                      installedContinuations = Map.empty,
+                      data = Map.empty,
+                      joins = Map.empty,
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             res   <- hotStore.removeContinuation(channels, index).attempt
             cache <- state.get
             _ <- checkRemovalWorksOrFailsOnError(
@@ -334,23 +329,22 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       fixture { (state, history, hotStore) =>
         {
           for {
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map(
-                          channels -> cachedContinuations
-                        ),
-                        installedContinuations = Map(
-                          channels -> installedContinuation
-                        ),
-                        data = Map.empty,
-                        joins = Map.empty,
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map(
+                        channels -> cachedContinuations
                       ),
-                      ()
-                    )
-                )
+                      installedContinuations = Map(
+                        channels -> installedContinuation
+                      ),
+                      data = Map.empty,
+                      joins = Map.empty,
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             res   <- hotStore.removeContinuation(channels, index).attempt
             cache <- state.get
             _ <- if (index == 0)
@@ -397,21 +391,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         {
           for {
             _ <- history.putData(channel, historyData)
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map(
-                          channel -> cachedData
-                        ),
-                        joins = Map.empty,
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map.empty,
+                      installedContinuations = Map.empty,
+                      data = Map(
+                        channel -> cachedData
                       ),
-                      ()
-                    )
-                )
+                      joins = Map.empty,
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             readData <- hotStore.getData(channel)
             cache    <- state.get
             _        <- S.delay(cache.data(channel) shouldEqual cachedData)
@@ -450,21 +443,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         {
           for {
             _ <- history.putData(channel, historyData)
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map(
-                          channel -> cachedData
-                        ),
-                        joins = Map.empty,
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map.empty,
+                      installedContinuations = Map.empty,
+                      data = Map(
+                        channel -> cachedData
                       ),
-                      ()
-                    )
-                )
+                      joins = Map.empty,
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             _     <- hotStore.putDatum(channel, insertedData)
             cache <- state.get
             _     <- S.delay(cache.data(channel) shouldEqual insertedData +: cachedData)
@@ -507,21 +499,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         {
           for {
             _ <- history.putData(channel, historyData)
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map(
-                          channel -> cachedData
-                        ),
-                        joins = Map.empty,
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map.empty,
+                      installedContinuations = Map.empty,
+                      data = Map(
+                        channel -> cachedData
                       ),
-                      ()
-                    )
-                )
+                      joins = Map.empty,
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             res   <- hotStore.removeDatum(channel, index).attempt
             cache <- state.get
             _     <- checkRemovalWorksOrFailsOnError(res, cache.data(channel), cachedData, index)
@@ -555,21 +546,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         {
           for {
             _ <- history.putJoins(channel, historyJoins)
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map(
-                          channel -> cachedJoins
-                        ),
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map.empty,
+                      installedContinuations = Map.empty,
+                      data = Map.empty,
+                      joins = Map(
+                        channel -> cachedJoins
                       ),
-                      ()
-                    )
-                )
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             readJoins <- hotStore.getJoins(channel)
             cache     <- state.get
             _         <- S.delay(cache.joins(channel) shouldEqual cachedJoins)
@@ -611,21 +601,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
           {
             for {
               _ <- history.putJoins(channel, historyJoins)
-              _ <- state.modify(
-                    _ =>
-                      (
-                        HotStoreState(
-                          continuations = Map.empty,
-                          installedContinuations = Map.empty,
-                          data = Map.empty,
-                          joins = Map(
-                            channel -> cachedJoins
-                          ),
-                          installedJoins = Map.empty
+              _ <- state.modify { _ =>
+                    (
+                      HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map(
+                          channel -> cachedJoins
                         ),
-                        ()
-                      )
-                  )
+                        installedJoins = Map.empty
+                      ),
+                      ()
+                    )
+                  }
               _     <- hotStore.putJoin(channel, insertedJoin)
               cache <- state.get
               _ <- S.delay {
@@ -646,21 +635,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       fixture { (state, history, hotStore) =>
         {
           for {
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map(
-                          channel -> cachedJoins
-                        ),
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map.empty,
+                      installedContinuations = Map.empty,
+                      data = Map.empty,
+                      joins = Map(
+                        channel -> cachedJoins
                       ),
-                      ()
-                    )
-                )
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             _     <- hotStore.putJoin(channel, insertedJoin)
             cache <- state.get
             _ <- S.delay {
@@ -685,21 +673,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         fixture { (state, history, hotStore) =>
           {
             for {
-              _ <- state.modify(
-                    _ =>
-                      (
-                        HotStoreState(
-                          continuations = Map.empty,
-                          installedContinuations = Map.empty,
-                          data = Map.empty,
-                          joins = Map(
-                            channel -> cachedJoins
-                          ),
-                          installedJoins = Map.empty
+              _ <- state.modify { _ =>
+                    (
+                      HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map(
+                          channel -> cachedJoins
                         ),
-                        ()
-                      )
-                  )
+                        installedJoins = Map.empty
+                      ),
+                      ()
+                    )
+                  }
               _     <- hotStore.putJoin(channel, insertedJoin)
               _     <- hotStore.installJoin(channel, installedJoin)
               cache <- state.get
@@ -729,21 +716,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       fixture { (state, history, hotStore) =>
         {
           for {
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map(
-                          channel -> cachedJoins
-                        ),
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map.empty,
+                      installedContinuations = Map.empty,
+                      data = Map.empty,
+                      joins = Map(
+                        channel -> cachedJoins
                       ),
-                      ()
-                    )
-                )
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             _     <- hotStore.installJoin(channel, installedJoin)
             _     <- hotStore.installJoin(channel, installedJoin)
             cache <- state.get
@@ -795,21 +781,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
             for {
               _        <- history.putJoins(channel, historyJoins)
               toRemove = cachedJoins.get(index.toLong).getOrElse(join)
-              _ <- state.modify(
-                    _ =>
-                      (
-                        HotStoreState(
-                          continuations = Map.empty,
-                          installedContinuations = Map.empty,
-                          data = Map.empty,
-                          joins = Map(
-                            channel -> cachedJoins
-                          ),
-                          installedJoins = Map.empty
+              _ <- state.modify { _ =>
+                    (
+                      HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map(
+                          channel -> cachedJoins
                         ),
-                        ()
-                      )
-                  )
+                        installedJoins = Map.empty
+                      ),
+                      ()
+                    )
+                  }
               res   <- hotStore.removeJoin(channel, toRemove).attempt
               cache <- state.get
               _     <- checkRemovalWorksOrIgnoresErrors(res, cache.joins(channel), cachedJoins, index)
@@ -829,23 +814,22 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
         fixture { (state, history, hotStore) =>
           {
             for {
-              _ <- state.modify(
-                    _ =>
-                      (
-                        HotStoreState(
-                          continuations = Map.empty,
-                          installedContinuations = Map.empty,
-                          data = Map.empty,
-                          joins = Map(
-                            channel -> cachedJoins
-                          ),
-                          installedJoins = Map(
-                            channel -> installedJoins
-                          )
+              _ <- state.modify { _ =>
+                    (
+                      HotStoreState(
+                        continuations = Map.empty,
+                        installedContinuations = Map.empty,
+                        data = Map.empty,
+                        joins = Map(
+                          channel -> cachedJoins
                         ),
-                        ()
-                      )
-                  )
+                        installedJoins = Map(
+                          channel -> installedJoins
+                        )
+                      ),
+                      ()
+                    )
+                  }
               toRemove = Random.shuffle(installedJoins).head
               res      <- hotStore.removeJoin(channel, toRemove).attempt
               cache    <- state.get
@@ -880,21 +864,20 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       fixture { (state, history, hotStore) =>
         {
           for {
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map(
-                          channel -> cachedJoins
-                        ),
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map.empty,
+                      installedContinuations = Map.empty,
+                      data = Map.empty,
+                      joins = Map(
+                        channel -> cachedJoins
                       ),
-                      ()
-                    )
-                )
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             toRemove = Random.shuffle(cachedJoins).head
             _        <- hotStore.putContinuation(toRemove, continuation)
             res      <- hotStore.removeJoin(channel, toRemove).attempt
@@ -921,27 +904,26 @@ trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDriv
       fixture { (state, _, hotStore) =>
         {
           for {
-            _ <- state.modify(
-                  _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map(
-                          channels -> continuations
-                        ),
-                        installedContinuations = Map(
-                          channels -> installedContinuation
-                        ),
-                        data = Map(
-                          channel -> data
-                        ),
-                        joins = Map(
-                          channel -> joins
-                        ),
-                        installedJoins = Map.empty
+            _ <- state.modify { _ =>
+                  (
+                    HotStoreState(
+                      continuations = Map(
+                        channels -> continuations
                       ),
-                      ()
-                    )
-                )
+                      installedContinuations = Map(
+                        channels -> installedContinuation
+                      ),
+                      data = Map(
+                        channel -> data
+                      ),
+                      joins = Map(
+                        channel -> joins
+                      ),
+                      installedJoins = Map.empty
+                    ),
+                    ()
+                  )
+                }
             res   <- hotStore.changes()
             cache <- state.get
             _ <- S.delay {

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -102,18 +102,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           for {
             _ <- history.putContinuations(channels, historyContinuations)
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map(
-                        channels -> cachedContinuations
-                      ),
-                      installedContinuations = Map.empty,
-                      data = Map.empty,
-                      joins = Map.empty,
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(continuations = Map(channels -> cachedContinuations)), ())
                 }
             readContinuations <- hotStore.getContinuations(channels)
 
@@ -135,18 +124,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
         {
           for {
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map(
-                        channels -> cachedContinuations
-                      ),
-                      installedContinuations = Map.empty,
-                      data = Map.empty,
-                      joins = Map.empty,
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(continuations = Map(channels -> cachedContinuations)), ())
                 }
             _     <- hotStore.installContinuation(channels, installedContinuation)
             res   <- hotStore.getContinuations(channels)
@@ -192,18 +170,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           for {
             _ <- history.putContinuations(channels, historyContinuations)
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map(
-                        channels -> cachedContinuations
-                      ),
-                      installedContinuations = Map.empty,
-                      data = Map.empty,
-                      joins = Map.empty,
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(continuations = Map(channels -> cachedContinuations)), ())
                 }
             _     <- hotStore.putContinuation(channels, insertedContinuation)
             cache <- state.get
@@ -228,18 +195,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           {
             for {
               _ <- state.modify { _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map(
-                          channels -> cachedContinuations
-                        ),
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map.empty,
-                        installedJoins = Map.empty
-                      ),
-                      ()
-                    )
+                    (HotStoreState(continuations = Map(channels -> cachedContinuations)), ())
                   }
               _     <- hotStore.installContinuation(channels, installedContinuation)
               _     <- hotStore.putContinuation(channels, insertedContinuation)
@@ -293,18 +249,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           for {
             _ <- history.putContinuations(channels, historyContinuations)
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map(
-                        channels -> cachedContinuations
-                      ),
-                      installedContinuations = Map.empty,
-                      data = Map.empty,
-                      joins = Map.empty,
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(continuations = Map(channels -> cachedContinuations)), ())
                 }
             res   <- hotStore.removeContinuation(channels, index).attempt
             cache <- state.get
@@ -332,15 +277,8 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
             _ <- state.modify { _ =>
                   (
                     HotStoreState(
-                      continuations = Map(
-                        channels -> cachedContinuations
-                      ),
-                      installedContinuations = Map(
-                        channels -> installedContinuation
-                      ),
-                      data = Map.empty,
-                      joins = Map.empty,
-                      installedJoins = Map.empty
+                      continuations = Map(channels          -> cachedContinuations),
+                      installedContinuations = Map(channels -> installedContinuation)
                     ),
                     ()
                   )
@@ -392,18 +330,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           for {
             _ <- history.putData(channel, historyData)
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map.empty,
-                      installedContinuations = Map.empty,
-                      data = Map(
-                        channel -> cachedData
-                      ),
-                      joins = Map.empty,
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(data = Map(channel -> cachedData)), ())
                 }
             readData <- hotStore.getData(channel)
             cache    <- state.get
@@ -444,18 +371,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           for {
             _ <- history.putData(channel, historyData)
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map.empty,
-                      installedContinuations = Map.empty,
-                      data = Map(
-                        channel -> cachedData
-                      ),
-                      joins = Map.empty,
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(data = Map(channel -> cachedData)), ())
                 }
             _     <- hotStore.putDatum(channel, insertedData)
             cache <- state.get
@@ -500,18 +416,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           for {
             _ <- history.putData(channel, historyData)
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map.empty,
-                      installedContinuations = Map.empty,
-                      data = Map(
-                        channel -> cachedData
-                      ),
-                      joins = Map.empty,
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(data = Map(channel -> cachedData)), ())
                 }
             res   <- hotStore.removeDatum(channel, index).attempt
             cache <- state.get
@@ -547,18 +452,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           for {
             _ <- history.putJoins(channel, historyJoins)
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map.empty,
-                      installedContinuations = Map.empty,
-                      data = Map.empty,
-                      joins = Map(
-                        channel -> cachedJoins
-                      ),
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(joins = Map(channel -> cachedJoins)), ())
                 }
             readJoins <- hotStore.getJoins(channel)
             cache     <- state.get
@@ -602,18 +496,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
             for {
               _ <- history.putJoins(channel, historyJoins)
               _ <- state.modify { _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map(
-                          channel -> cachedJoins
-                        ),
-                        installedJoins = Map.empty
-                      ),
-                      ()
-                    )
+                    (HotStoreState(joins = Map(channel -> cachedJoins)), ())
                   }
               _     <- hotStore.putJoin(channel, insertedJoin)
               cache <- state.get
@@ -636,18 +519,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
         {
           for {
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map.empty,
-                      installedContinuations = Map.empty,
-                      data = Map.empty,
-                      joins = Map(
-                        channel -> cachedJoins
-                      ),
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(joins = Map(channel -> cachedJoins)), ())
                 }
             _     <- hotStore.putJoin(channel, insertedJoin)
             cache <- state.get
@@ -674,18 +546,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
           {
             for {
               _ <- state.modify { _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map(
-                          channel -> cachedJoins
-                        ),
-                        installedJoins = Map.empty
-                      ),
-                      ()
-                    )
+                    (HotStoreState(joins = Map(channel -> cachedJoins)), ())
                   }
               _     <- hotStore.putJoin(channel, insertedJoin)
               _     <- hotStore.installJoin(channel, installedJoin)
@@ -717,18 +578,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
         {
           for {
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map.empty,
-                      installedContinuations = Map.empty,
-                      data = Map.empty,
-                      joins = Map(
-                        channel -> cachedJoins
-                      ),
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(joins = Map(channel -> cachedJoins)), ())
                 }
             _     <- hotStore.installJoin(channel, installedJoin)
             _     <- hotStore.installJoin(channel, installedJoin)
@@ -782,18 +632,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
               _        <- history.putJoins(channel, historyJoins)
               toRemove = cachedJoins.get(index.toLong).getOrElse(join)
               _ <- state.modify { _ =>
-                    (
-                      HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map(
-                          channel -> cachedJoins
-                        ),
-                        installedJoins = Map.empty
-                      ),
-                      ()
-                    )
+                    (HotStoreState(joins = Map(channel -> cachedJoins)), ())
                   }
               res   <- hotStore.removeJoin(channel, toRemove).attempt
               cache <- state.get
@@ -817,15 +656,8 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
               _ <- state.modify { _ =>
                     (
                       HotStoreState(
-                        continuations = Map.empty,
-                        installedContinuations = Map.empty,
-                        data = Map.empty,
-                        joins = Map(
-                          channel -> cachedJoins
-                        ),
-                        installedJoins = Map(
-                          channel -> installedJoins
-                        )
+                        joins = Map(channel          -> cachedJoins),
+                        installedJoins = Map(channel -> installedJoins)
                       ),
                       ()
                     )
@@ -865,18 +697,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
         {
           for {
             _ <- state.modify { _ =>
-                  (
-                    HotStoreState(
-                      continuations = Map.empty,
-                      installedContinuations = Map.empty,
-                      data = Map.empty,
-                      joins = Map(
-                        channel -> cachedJoins
-                      ),
-                      installedJoins = Map.empty
-                    ),
-                    ()
-                  )
+                  (HotStoreState(joins = Map(channel -> cachedJoins)), ())
                 }
             toRemove = Random.shuffle(cachedJoins).head
             _        <- hotStore.putContinuation(toRemove, continuation)
@@ -918,8 +739,7 @@ trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenProp
                       ),
                       joins = Map(
                         channel -> joins
-                      ),
-                      installedJoins = Map.empty
+                      )
                     ),
                     ()
                   )

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -21,7 +21,7 @@ import scala.collection.SortedSet
 import scala.concurrent.duration._
 import scala.util.Random
 
-trait HotStoreSpec[F[_], M[_]] extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
 
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(minSize = 0, sizeRange = 10, minSuccessful = 20)
@@ -1342,7 +1342,7 @@ class History[F[_]: Sync, C, P, A, K](implicit R: Ref[F, HotStoreState[C, P, A, 
   override def getJoinsProj[R](key: C): ((Seq[C], ByteVector) => R) => F[Seq[R]] = ???
 }
 
-trait InMemHotStoreSpec extends HotStoreSpec[Task, Task.Par] {
+trait InMemHotStoreSpec extends HotStoreSpec[Task] {
 
   protected type F[A] = Task[A]
   implicit override val S: Sync[F]        = implicitly[Concurrent[Task]]

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -1359,9 +1359,7 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task, Task.Par] {
       ) => F[Unit]
   ) =
     (for {
-      historyState <- Ref.of[F, HotStoreState[String, Pattern, String, StringsCaptor]](
-                       HotStoreState[String, Pattern, String, StringsCaptor]()
-                     )
+      historyState <- Ref[F].of(HotStoreState[String, Pattern, String, StringsCaptor]())
       history = {
         implicit val hs = historyState
         new History[F, String, Pattern, String, StringsCaptor]
@@ -1375,9 +1373,7 @@ trait InMemHotStoreSpec extends HotStoreSpec[Task, Task.Par] {
       f: HotStore[F, String, Pattern, String, StringsCaptor] => F[Unit]
   ) =
     (for {
-      historyState <- Ref.of[F, HotStoreState[String, Pattern, String, StringsCaptor]](
-                       HotStoreState[String, Pattern, String, StringsCaptor]()
-                     )
+      historyState <- Ref[F].of(HotStoreState[String, Pattern, String, StringsCaptor]())
       history = {
         implicit val hs = historyState
         new History[F, String, Pattern, String, StringsCaptor]
@@ -1393,6 +1389,6 @@ class RefHotStoreStatedInMemHotStoreSpec extends InMemHotStoreSpec {
   implicit override def C(
       cache: HotStoreState[String, Pattern, String, StringsCaptor]
   ): F[Ref[F, HotStoreState[String, Pattern, String, StringsCaptor]]] =
-    Ref.of[F, HotStoreState[String, Pattern, String, StringsCaptor]](cache)
+    Ref[F].of(cache)
 
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -1288,7 +1288,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
                             history,
                             channels
                           )
-      cache         <- Ref.of[Task, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
+      cache         <- Ref[Task].of(HotStoreState[C, P, A, K]())
       historyReader <- historyRepository.getHistoryReader(historyRepository.root)
       store <- {
         val hr = historyReader.base
@@ -1299,7 +1299,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
         historyRepository,
         store
       )
-      historyCache <- Ref.of[Task, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
+      historyCache <- Ref[Task].of(HotStoreState[C, P, A, K]())
       replayStore <- {
         val hr = historyReader.base
         HotStore.inMem[Task, C, P, A, K](historyCache, hr).map(AtomicAny(_))

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -1292,7 +1292,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
       historyReader <- historyRepository.getHistoryReader(historyRepository.root)
       store <- {
         val hr = historyReader.base
-        HotStore.inMem[Task, C, P, A, K](cache, hr).map(AtomicAny(_))
+        HotStore[Task, C, P, A, K](cache, hr).map(AtomicAny(_))
       }
 
       space = new RSpace[Task, C, P, A, K](
@@ -1302,7 +1302,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
       historyCache <- Ref[Task].of(HotStoreState[C, P, A, K]())
       replayStore <- {
         val hr = historyReader.base
-        HotStore.inMem[Task, C, P, A, K](historyCache, hr).map(AtomicAny(_))
+        HotStore[Task, C, P, A, K](historyCache, hr).map(AtomicAny(_))
       }
       replaySpace = new ReplayRSpace[Task, C, P, A, K](
         historyRepository,

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -72,7 +72,7 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
                               cold,
                               channels
                             )
-      cache         <- Ref.of[F, HotStoreState[C, P, A, K]](HotStoreState[C, P, A, K]())
+      cache         <- Ref[F].of(HotStoreState[C, P, A, K]())
       historyReader <- historyRepository.getHistoryReader(historyRepository.root)
       testStore <- {
         val hr = historyReader.base

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -76,7 +76,7 @@ trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with Opt
       historyReader <- historyRepository.getHistoryReader(historyRepository.root)
       testStore <- {
         val hr = historyReader.base
-        HotStore.inMem[F, C, P, A, K](cache, hr)
+        HotStore[F, C, P, A, K](cache, hr)
       }
       spaceAndStore        <- createISpace(historyRepository, testStore)
       (store, atom, space) = spaceAndStore


### PR DESCRIPTION
## Overview
Refactoring of HotStore with broken PoSSpec test. Probably test was broken in [this commit](https://github.com/rchain/rchain/pull/3569/commits/04e0ddc0c8ae962ffbf145523acc7d88195ae667).

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
