### PR TITLE
Remove check for propose reason [HF2]

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -71,6 +71,8 @@ class Proposer[F[_]: Concurrent: Log: Span](
                 .shouldPropose(s, loadDeploys)
                 .ifM(
                   checkProposeConstraints(genesis, s),
+                  // TODO re-enable reasons to propose, so blocks are created lazily
+                  //  disabled due to https://github.com/rchain/rchain/pull/3570
                   checkProposeConstraints(genesis, s) //CheckProposeConstraintsResult.noReasonToPropose.pure[F]
                 )
         r <- chk match {

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -71,7 +71,7 @@ class Proposer[F[_]: Concurrent: Log: Span](
                 .shouldPropose(s, loadDeploys)
                 .ifM(
                   checkProposeConstraints(genesis, s),
-                  CheckProposeConstraintsResult.noReasonToPropose.pure[F]
+                  checkProposeConstraints(genesis, s) //CheckProposeConstraintsResult.noReasonToPropose.pure[F]
                 )
         r <- chk match {
               case v: CheckProposeConstraintsFailure =>


### PR DESCRIPTION
## Overview
HF2 branch contains preparation code for lazy block producing. 
This logic contradicts with necessity to propose blocks in --dev mode with --autopropose.
This makes testing complicated which became obvious when testing https://github.com/rchain/rchain/pull/3568. For now for ease of testing, this PR bypasses the check for reasons to propose. Later the logic should be adjusted to handle `--dev --autopropose` mode.


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
