### PR TITLE
Prevent read-only node to accept deploys

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -73,8 +73,7 @@ object BlockAPI {
 
     // Check if node is read-only
     val readOnlyError = new RuntimeException(
-      s"Deploy was rejected because node is running in read-only mode. " +
-        s"To be a validator node should be run with a validator private key."
+      "Deploy was rejected because node is running in read-only mode."
     ).raiseError[F, ApiErr[String]]
     val readOnlyCheck = readOnlyError.whenA(isNodeReadOnly)
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
@@ -79,11 +79,14 @@ class MultiParentCasperDeploySpec extends FlatSpec with Matchers with Inspectors
       implicit val noopSpan: Span[Effect] = NoopSpan[Effect]()
       val engine                          = new EngineWithCasper[Effect](node.casperEff)
       Cell.mvarCell[Effect, Engine[Effect]](engine).flatMap { implicit engineCell =>
-        val minPhloPrice = 10.toLong
-        val phloPrice    = 1.toLong
+        val minPhloPrice   = 10.toLong
+        val phloPrice      = 1.toLong
+        val isNodeReadOnly = false
         for {
           deployData <- ConstructDeploy.sourceDeployNowF[Effect]("Nil", phloPrice = phloPrice)
-          err        <- BlockAPI.deploy[Effect](deployData, None, minPhloPrice = minPhloPrice).attempt
+          err <- BlockAPI
+                  .deploy[Effect](deployData, None, minPhloPrice = minPhloPrice, isNodeReadOnly)
+                  .attempt
         } yield {
           err.isLeft shouldBe true
           val ex = err.left.get

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -35,7 +35,8 @@ object DeployGrpcServiceV1 {
       devMode: Boolean = false,
       networkId: String,
       shardId: String,
-      minPhloPrice: Long
+      minPhloPrice: Long,
+      isNodeReadOnly: Boolean
   )(
       implicit worker: Scheduler
   ): DeployServiceV1GrpcMonix.DeployService =
@@ -87,7 +88,7 @@ object DeployGrpcServiceV1 {
               })
             },
             dd => {
-              defer(BlockAPI.deploy[F](dd, triggerProposeF, minPhloPrice)) { r =>
+              defer(BlockAPI.deploy[F](dd, triggerProposeF, minPhloPrice, isNodeReadOnly)) { r =>
                 import DeployResponse.Message
                 import DeployResponse.Message._
                 DeployResponse(r.fold[Message](Error, Result))

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -70,7 +70,8 @@ object WebApi {
       triggerProposeF: Option[ProposeFunction[F]],
       networkId: String,
       shardId: String,
-      minPhloPrice: Long
+      minPhloPrice: Long,
+      isNodeReadOnly: Boolean
   ) extends WebApi[F] {
     import WebApiSyntax._
 
@@ -93,7 +94,7 @@ object WebApi {
 
     def deploy(request: DeployRequest): F[String] =
       toSignedDeploy(request)
-        .flatMap(BlockAPI.deploy(_, triggerProposeF, minPhloPrice))
+        .flatMap(BlockAPI.deploy(_, triggerProposeF, minPhloPrice, isNodeReadOnly))
         .flatMap(_.liftToBlockApiErr)
 
     def listenForDataAtName(req: DataRequest): F[DataResponse] =

--- a/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/APIServers.scala
@@ -36,7 +36,8 @@ object APIServers {
       blockReportAPI: BlockReportAPI[F],
       networkId: String,
       shardId: String,
-      minPhloPrice: Long
+      minPhloPrice: Long,
+      isNodeReadOnly: Boolean
   )(
       implicit
       blockStore: BlockStore[F],
@@ -59,7 +60,8 @@ object APIServers {
         devMode,
         networkId,
         shardId,
-        minPhloPrice
+        minPhloPrice,
+        isNodeReadOnly
       )
     val propose = ProposeGrpcServiceV1(triggerProposeFOpt, proposerStateRefOpt)
     APIServers(repl, propose, deploy)

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -268,6 +268,8 @@ object Setup {
         implicit val (ec, bs, or, sp) = (engineCell, blockStore, oracle, span)
         implicit val (sc, lh)         = (synchronyConstraintChecker, lastFinalizedHeightConstraintChecker)
         implicit val (ra, rp)         = (rpConfAsk, rpConnections)
+        val isNodeReadOnly            = conf.casper.validatorPrivateKey.isEmpty
+
         APIServers.build[F](
           evalRuntime,
           triggerProposeFOpt,
@@ -279,7 +281,8 @@ object Setup {
           blockReportAPI,
           conf.protocolServer.networkId,
           conf.casper.shardName,
-          conf.casper.minPhloPrice
+          conf.casper.minPhloPrice,
+          isNodeReadOnly
         )
       }
       reportingRoutes = {
@@ -317,6 +320,7 @@ object Setup {
       webApi = {
         implicit val (ec, bs, or, sp) = (engineCell, blockStore, oracle, span)
         implicit val (ra, rc)         = (rpConfAsk, rpConnections)
+        val isNodeReadOnly            = conf.casper.validatorPrivateKey.isEmpty
 
         new WebApiImpl[F](
           conf.apiServer.maxBlocksLimit,
@@ -326,7 +330,8 @@ object Setup {
           else none[ProposeFunction[F]],
           conf.protocolServer.networkId,
           conf.casper.shardName,
-          conf.casper.minPhloPrice
+          conf.casper.minPhloPrice,
+          isNodeReadOnly
         )
       }
       adminWebApi = {


### PR DESCRIPTION
## Overview
If the node is running in read-only mode (without validator private key) it's rejecting deploys. Exception with text below are thrown
```
Deploy was rejected because node is running in read-only mode.```
This text is visible for client and shown in the log.

### Checking

1. Run node with command
```shell
./rnode run -s
```
Without `--validator-private-key` rnode runs in read-only mode.
2. Make deploy to this node. Deploy will be rejected with the message (see above).

### Notes
* Is it a beautiful solution to pass additional parameter `isNodeReadOnly`? Maybe better to pass the whole `conf` instance?
* Should `isNodeReadOnly` parameter have default value?


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
