### PR TITLE
Replaying cost match tests

### DIFF
--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -253,7 +253,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
   "replay the same term with same event logs" should "get the same cost" in {
     val r = scala.util.Random
     for (_ <- 1 to 100) {
-      val long     = ((r.nextLong % 0X144000000L) + 0X144000000L) % 0X144000000L
+      val long     = math.abs(r.nextLong)
       val contract = fromLong(long)
       if (contract != "") {
         val result = evaluateAndReplay(Cost(Integer.MAX_VALUE), contract)
@@ -267,7 +267,7 @@ class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with
   "replay the same term with not enough phlo" should "get the same result" in {
     val r = scala.util.Random
     for (_ <- 1 to 100) {
-      val long        = ((r.nextLong % 0X144000000L) + 0X144000000L) % 0X144000000L
+      val long        = math.abs(r.nextLong)
       val contract    = fromLong(long)
       val parsingCost = accounting.parsingCost(contract)
       if (contract != "") {


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
Previously we disable replay cost tests because we  got some problems on consume on the same channel https://github.com/rchain/rchain/pull/3579/files#diff-a8950e05083ebb606328a9eb162794f4d131f122e08a886f90c911e77969fd82L252 . But we fixed that in https://github.com/rchain/rchain/pull/2888.
So it would be better to re-enable these tests.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
