### PR TITLE
Added ability to disable cost accounting for deploys

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/Casper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Casper.scala
@@ -58,7 +58,11 @@ trait Casper[F[_]] {
   def getValidator: F[Option[ValidatorIdentity]]
   def getVersion: F[Long]
 
-  def validate(b: BlockMessage, s: CasperSnapshot[F]): F[Either[BlockError, ValidBlock]]
+  def validate(
+      b: BlockMessage,
+      s: CasperSnapshot[F],
+      disableCostAccounting: Boolean
+  ): F[Either[BlockError, ValidBlock]]
   def handleValidBlock(block: BlockMessage): F[BlockDagRepresentation[F]]
   def handleInvalidBlock(
       block: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -273,7 +273,8 @@ class MultiParentCasperImpl[F[_]
 
   override def validate(
       b: BlockMessage,
-      s: CasperSnapshot[F]
+      s: CasperSnapshot[F],
+      disableCostAccounting: Boolean
   ): F[Either[BlockError, ValidBlock]] = {
     val validationProcess: EitherT[F, BlockError, ValidBlock] =
       for {
@@ -284,7 +285,7 @@ class MultiParentCasperImpl[F[_]
         _ <- EitherT.liftF(Span[F].mark("post-validation-block-summary"))
         _ <- EitherT(
               InterpreterUtil
-                .validateBlockCheckpoint(b, s, RuntimeManager[F])
+                .validateBlockCheckpoint(b, s, RuntimeManager[F], disableCostAccounting)
                 .map {
                   case Left(ex)       => Left(ex)
                   case Right(Some(_)) => Right(BlockStatus.valid)

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockProcessor.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockProcessor.scala
@@ -119,7 +119,7 @@ object BlockProcessor {
   /* Diagnostics */ : Log
   /* Comm */        : CommUtil: BlockRetriever
   ] // format: on
-  (
+  (disableCostAccounting: Boolean = false)(
       implicit casperBuffer: CasperBufferStorage[F]
   ): BlockProcessor[F] = {
 
@@ -172,7 +172,8 @@ object BlockProcessor {
       )
     }
 
-    val validateBlock = (c: Casper[F], s: CasperSnapshot[F], b: BlockMessage) => c.validate(b, s)
+    val validateBlock = (c: Casper[F], s: CasperSnapshot[F], b: BlockMessage) =>
+      c.validate(b, s, disableCostAccounting)
 
     def ackProcessed =
       (b: BlockMessage) => BlockRetriever[F].ackInCasper(b.blockHash)

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -38,7 +38,8 @@ object BlockCreator {
   def create[F[_]: Concurrent: Log: Time: BlockStore: DeployStorage: Metrics: RuntimeManager: Span](
       s: CasperSnapshot[F],
       validatorIdentity: ValidatorIdentity,
-      dummyDeployOpt: Option[(PrivateKey, String)] = None
+      dummyDeployOpt: Option[(PrivateKey, String)] = None,
+      disableCostAccounting: Boolean
   )(implicit runtimeManager: RuntimeManager[F]): F[BlockCreatorResult] =
     Span[F].trace(ProcessDeploysAndCreateBlockMetricsSource) {
       val selfId         = ByteString.copyFrom(validatorIdentity.publicKey.bytes)
@@ -123,7 +124,8 @@ object BlockCreator {
                                    s,
                                    runtimeManager,
                                    blockData,
-                                   invalidBlocks
+                                   invalidBlocks,
+                                   disableCostAccounting
                                  )
                 (
                   preStateHash,

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -164,15 +164,16 @@ object Proposer {
   ] // format: on
   (
       validatorIdentity: ValidatorIdentity,
-      dummyDeployOpt: Option[(PrivateKey, String)] = None
+      dummyDeployOpt: Option[(PrivateKey, String)] = None,
+      disableCostAccounting: Boolean
   )(implicit runtimeManager: RuntimeManager[F]): Proposer[F] = {
     val getCasperSnapshotSnapshot = (c: Casper[F]) => c.getSnapshot
 
     val createBlock = (s: CasperSnapshot[F], validatorIdentity: ValidatorIdentity) =>
-      BlockCreator.create(s, validatorIdentity, dummyDeployOpt)
+      BlockCreator.create(s, validatorIdentity, dummyDeployOpt, disableCostAccounting)
 
     val validateBlock = (casper: Casper[F], s: CasperSnapshot[F], b: BlockMessage) =>
-      casper.validate(b, s)
+      casper.validate(b, s, disableCostAccounting)
 
     val checkValidatorIsActive = (s: CasperSnapshot[F], validator: ValidatorIdentity) =>
       if (s.onChainState.activeValidators.contains(ByteString.copyFrom(validator.publicKey.bytes)))

--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
@@ -42,7 +42,8 @@ final case class BlockApproverProtocol private (
 
   def unapprovedBlockPacketHandler[F[_]: Concurrent: TransportLayer: Log: Time: RPConfAsk: RuntimeManager](
       peer: PeerNode,
-      u: UnapprovedBlock
+      u: UnapprovedBlock,
+      disableCostAccounting: Boolean = false
   ): F[Unit] = {
     val candidate = u.candidate
     Log[F].info(s"Received expected genesis block candidate from $peer. Verifying...") >>
@@ -57,7 +58,8 @@ final case class BlockApproverProtocol private (
           maximumBond,
           epochLength,
           quarantineLength,
-          numberOfActiveValidators
+          numberOfActiveValidators,
+          disableCostAccounting
         )
         .flatMap {
           case Right(_) =>
@@ -135,7 +137,8 @@ object BlockApproverProtocol {
       maximumBond: Long,
       epochLength: Int,
       quarantineLength: Int,
-      numberOfActiveValidators: Int
+      numberOfActiveValidators: Int,
+      disableCostAccounting: Boolean = false
   )(implicit runtimeManager: RuntimeManager[F]): F[Either[String, Unit]] = {
 
     def validate: Either[String, (Seq[ProcessedDeploy], RChainState)] =
@@ -210,7 +213,8 @@ object BlockApproverProtocol {
                         List.empty,
                         BlockData.fromBlock(candidate.block),
                         Map.empty[BlockHash, Validator],
-                        isGenesis = true
+                        isGenesis = true,
+                        disableCostAccounting
                       )
                   ).leftMap { status =>
                     s"Failed status during replay: $status."

--- a/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Engine.scala
@@ -30,7 +30,7 @@ import fs2.concurrent.Queue
 
 trait Engine[F[_]] {
   def init: F[Unit]
-  def handle(peer: PeerNode, msg: CasperMessage): F[Unit]
+  def handle(peer: PeerNode, msg: CasperMessage, disableCostAccounting: Boolean = false): F[Unit]
   def withCasper[A](
       f: MultiParentCasper[F] => F[A],
       default: F[A]
@@ -40,9 +40,13 @@ trait Engine[F[_]] {
 object Engine {
 
   def noop[F[_]: Applicative] = new Engine[F] {
-    private[this] val noop                                           = Applicative[F].unit
-    override def handle(peer: PeerNode, msg: CasperMessage): F[Unit] = noop
-    override val init: F[Unit]                                       = noop
+    private[this] val noop = Applicative[F].unit
+    override def handle(
+        peer: PeerNode,
+        msg: CasperMessage,
+        disableCostAccounting: Boolean = false
+    ): F[Unit]                 = noop
+    override val init: F[Unit] = noop
   }
 
   /**

--- a/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/GenesisCeremonyMaster.scala
@@ -35,12 +35,17 @@ class GenesisCeremonyMaster[F[_]: Sync: BlockStore: CommUtil: TransportLayer: RP
 
   override def init: F[Unit] = approveProtocol.run()
 
-  override def handle(peer: PeerNode, msg: CasperMessage): F[Unit] = msg match {
-    case br: ApprovedBlockRequest     => sendNoApprovedBlockAvailable(peer, br.identifier)
-    case ba: BlockApproval            => approveProtocol.addApproval(ba)
-    case na: NoApprovedBlockAvailable => logNoApprovedBlockAvailable[F](na.nodeIdentifer)
-    case _                            => noop
-  }
+  override def handle(
+      peer: PeerNode,
+      msg: CasperMessage,
+      disableCostAccounting: Boolean = false
+  ): F[Unit] =
+    msg match {
+      case br: ApprovedBlockRequest     => sendNoApprovedBlockAvailable(peer, br.identifier)
+      case ba: BlockApproval            => approveProtocol.addApproval(ba)
+      case na: NoApprovedBlockAvailable => logNoApprovedBlockAvailable[F](na.nodeIdentifer)
+      case _                            => noop
+    }
 }
 
 // format: off

--- a/casper/src/test/scala/coop/rchain/casper/batch2/EngineWithCasper.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/EngineWithCasper.scala
@@ -7,8 +7,12 @@ import coop.rchain.casper.protocol.CasperMessage
 import coop.rchain.comm.PeerNode
 
 class EngineWithCasper[F[_]: Applicative](casper: MultiParentCasper[F]) extends Engine[F] {
-  override val init                                                = Applicative[F].unit
-  override def handle(peer: PeerNode, msg: CasperMessage): F[Unit] = Applicative[F].unit
+  override val init = Applicative[F].unit
+  override def handle(
+      peer: PeerNode,
+      msg: CasperMessage,
+      disableCostAccounting: Boolean = false
+  ): F[Unit] = Applicative[F].unit
   override def withCasper[A](
       f: MultiParentCasper[F] => F[A],
       default: F[A]

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -87,7 +87,8 @@ object BlockGenerator {
                  s,
                  runtimeManager,
                  BlockData.fromBlock(b),
-                 Map.empty[BlockHash, Validator]
+                 Map.empty[BlockHash, Validator],
+                 disableCostAccounting = false
                ).attempt
       Right((preStateHash, postStateHash, processedDeploys, rejectedDeploys, _)) = result
     } yield (postStateHash, processedDeploys)

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -53,7 +53,8 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   override def getSnapshot: F[CasperSnapshot[F]] = ???
   override def validate(
       b: BlockMessage,
-      s: CasperSnapshot[F]
+      s: CasperSnapshot[F],
+      disableCostAccounting: Boolean
   ): F[Either[BlockError, ValidBlock]]                                             = ???
   override def handleValidBlock(block: BlockMessage): F[BlockDagRepresentation[F]] = ???
   override def handleInvalidBlock(

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -102,7 +102,8 @@ class InterpreterUtilTest
                 genesisContext.validatorPks.head,
                 seqNum
               ),
-              Map.empty[BlockHash, Validator]
+              Map.empty[BlockHash, Validator],
+              disableCostAccounting = false
             )
             .attempt
       )

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -345,3 +345,6 @@ dev {
   # If set, on each propose node will add dummy deploy signed by this key.
   # deployer-private-key =
 }
+
+# Disable cost accounting for deploys
+disable-cost-accounting = false

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -121,6 +121,8 @@ object ConfigMapper {
       add("dev-mode", run.devMode)
       add("dev.deployer-private-key", run.deployerPrivateKey)
 
+      add("disable-cost-accounting", run.disableCostAccounting)
+
       //TODO remove
       //add(keys.KnownValidatorsFile, run.knownValidators
     }

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -542,6 +542,10 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       validate = _ >= 0
     )
 
+    val disableCostAccounting = opt[Flag](
+      descr = "Disable cost accounting for deploys."
+    )
+
   }
   addSubcommand(run)
 

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -29,7 +29,8 @@ final case class NodeConf(
     // So its in HOCON notation that should be loaded into `NodeConf` case class.
     // As we need loader to throw an error when unknown HOCON key is met - this field should also
     // be present in the model.
-    defaultDataDir: String
+    defaultDataDir: String,
+    disableCostAccounting: Boolean
 )
 
 final case class ProtocolServer(

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -193,7 +193,7 @@ object Setup {
       blockProcessor = {
         implicit val (bs, bd)     = (blockStore, blockDagStorage)
         implicit val (br, cb, cu) = (blockRetriever, casperBufferStorage, commUtil)
-        BlockProcessor[F]
+        BlockProcessor[F](conf.disableCostAccounting)
       }
 
       // Proposer instance
@@ -209,7 +209,7 @@ object Setup {
         val dummyDeployerKey          = dummyDeployerKeyOpt.flatMap(Base16.decode(_)).map(PrivateKey(_))
 
         // TODO make term for dummy deploy configurable
-        Proposer[F](validatorIdentity, dummyDeployerKey.map((_, "Nil")))
+        Proposer[F](validatorIdentity, dummyDeployerKey.map((_, "Nil")), conf.disableCostAccounting)
       }
 
       // Propose request is a tuple - Casper, async flag and deferred proposer result that will be resolved by proposer
@@ -246,7 +246,7 @@ object Setup {
       }
       packetHandler = {
         implicit val ec = engineCell
-        CasperPacketHandler[F]
+        CasperPacketHandler[F](conf.disableCostAccounting)
       }
       // Bypass fair dispatcher
       /*packetHandler <- {

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -258,7 +258,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
         zipkin = true,
         sigar = true
       ),
-      dev = DevConf(deployerPrivateKey = None)
+      dev = DevConf(deployerPrivateKey = None),
+      disableCostAccounting = false
     )
     config shouldEqual expectedConfig
   }

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -162,7 +162,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
         zipkin = false,
         sigar = false
       ),
-      dev = DevConf(deployerPrivateKey = None)
+      dev = DevConf(deployerPrivateKey = None),
+      disableCostAccounting = false
     )
     config shouldEqual expectedConfig
   }


### PR DESCRIPTION
## Overview
Added CLI parameter `--disable-cost-accounting`, which, if provided, allows to disable accounting cost for deploys. It makes sense for private blockchain networks, e.g. corporative chats, and for increased performance.

## Performance testing
Sample results for i5 6-gen, 16gb ram, deployed `Nil` program:

**Without `--disable-cost-accounting`**
```
17:48:46.042 [INFO ] ... Block created: #5 (334660a6ff...) (1d) [9.355938963 sec]
17:48:53.413 [INFO ] ... Block replayed: #5 (334660a6ff...) (1d) (Valid) [7.338343166 sec]

17:49:23.986 [INFO ] ... Block created: #6 (14f0c280e1...) (1d) [5.87882144 sec]
17:49:28.852 [INFO ] ... Block replayed: #6 (14f0c280e1...) (1d) (Valid) [4.864034751 sec]
```

**With `--disable-cost-accounting`**
```
17:53:29.504 [INFO ] ... Block created: #7 (50fd4ff71a...) (1d) [3.376250648 sec]
17:53:32.021 [INFO ] ... Block replayed: #7 (50fd4ff71a...) (1d) (Valid) [2.486168413 sec]

17:53:52.726 [INFO ] ... Block created: #8 (536e9acba3...) (1d) [2.02444327 sec]
17:53:54.511 [INFO ] ... Block replayed: #8 (536e9acba3...) (1d) (Valid) [1.783949395 sec]
```

### Notes
* The default value for `disableCostAccounting` is not set whenever possible to make the code more explicit. The default value `false` is set only in cases where the absence of a default value leads to many changes in the tests.
* For tests, the value of the parameter is set to `false`, because tests were written without taking into account this possibility. The main code and test code are executed separately.
* The default value for the `disableCostAccounting` parameter in the `Engine` trait is set to `false`. Also, the default value is explicitly specified in derived classes. I've spent a lot of time trying to figure out why tests don't set a parameter's value when it's not set by default. It turned out that it was specified in the trait, and was inherited for descendants.
* In `TestNode` the parameter is not forwarded. Is it needed there?
* Is the unit test needed for the parameter?

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
