### PR TITLE
Implemented HTTP binding for `getDataAtPar` method

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -811,9 +811,7 @@ object BlockAPI {
         implicit casper: MultiParentCasper[F]
     ): F[ApiErr[(Seq[Par], LightBlockInfo)]] =
       for {
-        block <- BlockStore[F].getUnsafe(blockHash.unsafeHexToByteString)
-        stateHash = if (usePreStateHash) block.body.state.preStateHash
-        else block.body.state.postStateHash
+        block          <- BlockStore[F].getUnsafe(blockHash.unsafeHexToByteString)
         sortedPar      <- parSortable.sortMatch[F](par).map(_.term)
         runtimeManager <- casper.getRuntimeManager
         data           <- getDataWithBlockInfo(runtimeManager, sortedPar, block).map(_.get)

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -55,7 +55,7 @@ trait WebApi[F[_]] {
       term: String,
       blockHash: Option[String],
       usePreStateHash: Boolean
-  ): F[ExploratoryDeployResponse]
+  ): F[RhoDataResponse]
 
   def getBlocksByHeights(startBlockNumber: Long, endBlockNumber: Long): F[List[LightBlockInfo]]
 
@@ -130,11 +130,11 @@ object WebApi {
         term: String,
         blockHash: Option[String],
         usePreStateHash: Boolean
-    ): F[ExploratoryDeployResponse] =
+    ): F[RhoDataResponse] =
       BlockAPI
         .exploratoryDeploy(term, blockHash, usePreStateHash, devMode)
         .flatMap(_.liftToBlockApiErr)
-        .map(toExploratoryResponse)
+        .map(toRhoDataResponse)
 
     def status: F[ApiStatus] =
       for {
@@ -390,18 +390,9 @@ object WebApi {
     DataAtNameResponse(exprsWithBlock, length)
   }
 
-  private def toResponse[A](
-      data: (Seq[Par], LightBlockInfo),
-      responseFactory: (Seq[RhoExpr], LightBlockInfo) => A
-  ): A = {
+  private def toRhoDataResponse(data: (Seq[Par], LightBlockInfo)): RhoDataResponse = {
     val (pars, lightBlockInfo) = data
     val rhoExprs               = pars.flatMap(exprFromParProto)
-    responseFactory(rhoExprs, lightBlockInfo)
+    RhoDataResponse(rhoExprs, lightBlockInfo)
   }
-
-  private def toExploratoryResponse(data: (Seq[Par], LightBlockInfo)): ExploratoryDeployResponse =
-    toResponse(data, (expr, block) => ExploratoryDeployResponse(expr, block))
-
-  private def toRhoDataResponse(data: (Seq[Par], LightBlockInfo)): RhoDataResponse =
-    toResponse(data, (expr, block) => RhoDataResponse(expr, block))
 }

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -39,7 +39,7 @@ trait WebApi[F[_]] {
   // Read data (listen)
   def listenForDataAtName(request: DataAtNameRequest): F[DataAtNameResponse]
 
-  def getDataAtPar(request: DataAtParRequest): F[RhoDataResponse]
+  def getDataAtPar(request: DataAtNameByBlockHashRequest): F[RhoDataResponse]
 
   // Blocks info
 
@@ -106,7 +106,7 @@ object WebApi {
         .flatMap(_.liftToBlockApiErr)
         .map(toDataAtNameResponse)
 
-    def getDataAtPar(req: DataAtParRequest): F[RhoDataResponse] =
+    def getDataAtPar(req: DataAtNameByBlockHashRequest): F[RhoDataResponse] =
       BlockAPI
         .getDataAtPar(toPar(req), req.blockHash, req.usePreStateHash)
         .flatMap(_.liftToBlockApiErr)
@@ -210,9 +210,9 @@ object WebApi {
       depth: Int
   )
 
-  final case class DataAtParRequest(
-      blockHash: String,
+  final case class DataAtNameByBlockHashRequest(
       name: RhoUnforg,
+      blockHash: String,
       usePreStateHash: Boolean
   )
 
@@ -375,7 +375,7 @@ object WebApi {
   private def toPar(req: DataAtNameRequest): Par =
     Par(unforgeables = Seq(GUnforgeable(unforgToUnforgProto(req.name))))
 
-  private def toPar(req: DataAtParRequest): Par =
+  private def toPar(req: DataAtNameByBlockHashRequest): Par =
     Par(unforgeables = Seq(GUnforgeable(unforgToUnforgProto(req.name))))
 
   private def toDataAtNameResponse(req: (Seq[DataWithBlockInfo], Int)): DataAtNameResponse = {

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -107,9 +107,12 @@ object WebApi {
         .map(toDataAtNameResponse)
 
     def getDataAtPar(req: DataAtParRequest): F[RhoDataResponse] =
-      BlockAPI.getDataAtPar(req.blockHash, toPar(req), req.usePreStateHash).map {
-        case (pars, block) => RhoDataResponse(pars.flatMap(exprFromParProto), block)
-      }
+      BlockAPI
+        .getDataAtPar(toPar(req), req.blockHash, req.usePreStateHash)
+        .flatMap(_.liftToBlockApiErr)
+        .map {
+          case (pars, block) => RhoDataResponse(pars.flatMap(exprFromParProto), block)
+        }
 
     def lastFinalizedBlock: F[BlockInfo] =
       BlockAPI.lastFinalizedBlock[F].flatMap(_.liftToBlockApiErr)

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -318,10 +318,9 @@ object Setup {
       )
       cacheTransactionAPI <- Transaction.cacheTransactionAPI(transactionAPI, rnodeStoreManager)
       webApi = {
-        implicit val (ec, bs, or, sp)      = (engineCell, blockStore, oracle, span)
-        implicit val (ra, rc)              = (rpConfAsk, rpConnections)
-        val isNodeReadOnly                 = conf.casper.validatorPrivateKey.isEmpty
-        implicit val rm: RuntimeManager[F] = runtimeManager
+        implicit val (ec, bs, or, sp) = (engineCell, blockStore, oracle, span)
+        implicit val (ra, rc)         = (rpConfAsk, rpConnections)
+        val isNodeReadOnly            = conf.casper.validatorPrivateKey.isEmpty
 
         new WebApiImpl[F](
           conf.apiServer.maxBlocksLimit,
@@ -332,7 +331,8 @@ object Setup {
           conf.protocolServer.networkId,
           conf.casper.shardName,
           conf.casper.minPhloPrice,
-          isNodeReadOnly
+          isNodeReadOnly,
+          runtimeManager
         )
       }
       adminWebApi = {

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -318,9 +318,10 @@ object Setup {
       )
       cacheTransactionAPI <- Transaction.cacheTransactionAPI(transactionAPI, rnodeStoreManager)
       webApi = {
-        implicit val (ec, bs, or, sp) = (engineCell, blockStore, oracle, span)
-        implicit val (ra, rc)         = (rpConfAsk, rpConnections)
-        val isNodeReadOnly            = conf.casper.validatorPrivateKey.isEmpty
+        implicit val (ec, bs, or, sp)      = (engineCell, blockStore, oracle, span)
+        implicit val (ra, rc)              = (rpConfAsk, rpConnections)
+        val isNodeReadOnly                 = conf.casper.validatorPrivateKey.isEmpty
+        implicit val rm: RuntimeManager[F] = runtimeManager
 
         new WebApiImpl[F](
           conf.apiServer.maxBlocksLimit,

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -331,8 +331,7 @@ object Setup {
           conf.protocolServer.networkId,
           conf.casper.shardName,
           conf.casper.minPhloPrice,
-          isNodeReadOnly,
-          runtimeManager
+          isNodeReadOnly
         )
       }
       adminWebApi = {

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -102,7 +102,7 @@ object WebApiRoutes {
     // Decoders
     implicit val deployRequestDecoder     = jsonOf[F, DeployRequest]
     implicit val dataAtNameRequestDecoder = jsonOf[F, DataAtNameRequest]
-    implicit val dataAtParRequestDecoder  = jsonOf[F, DataAtParRequest]
+    implicit val dataAtParRequestDecoder  = jsonOf[F, DataAtNameByBlockHashRequest]
     implicit val prepareDecoder           = jsonOf[F, PrepareRequest]
     implicit val ExploreDeployRequest     = jsonOf[F, ExploreDeployRequest]
 
@@ -142,8 +142,8 @@ object WebApiRoutes {
       case req @ POST -> Root / "data-at-name" =>
         req.handle[DataAtNameRequest, DataAtNameResponse](webApi.listenForDataAtName)
 
-      case req @ POST -> Root / "data-at-par" =>
-        req.handle[DataAtParRequest, RhoDataResponse](webApi.getDataAtPar)
+      case req @ POST -> Root / "data-at-name-by-block-hash" =>
+        req.handle[DataAtNameByBlockHashRequest, RhoDataResponse](webApi.getDataAtPar)
 
       // Blocks
 

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -98,7 +98,6 @@ object WebApiRoutes {
     implicit val dataAtNameRespEncoder      = jsonEncoderOf[F, DataAtNameResponse]
     implicit val dataAtParRespEncoder       = jsonEncoderOf[F, RhoDataResponse]
     implicit val prepareEncoder             = jsonEncoderOf[F, PrepareResponse]
-    implicit val explRespEncoder            = jsonEncoderOf[F, ExploratoryDeployResponse]
     implicit val transactionResponseEncoder = jsonEncoderOf[F, TransactionResponse]
     // Decoders
     implicit val deployRequestDecoder     = jsonOf[F, DeployRequest]
@@ -125,12 +124,12 @@ object WebApiRoutes {
         req.handle[DeployRequest, String](webApi.deploy)
 
       case req @ POST -> Root / "explore-deploy" =>
-        req.handle[String, ExploratoryDeployResponse](
+        req.handle[String, RhoDataResponse](
           term => webApi.exploratoryDeploy(term, none[String], usePreStateHash = false)
         )
 
       case req @ POST -> Root / "explore-deploy-by-block-hash" =>
-        req.handle[ExploreDeployRequest, ExploratoryDeployResponse](
+        req.handle[ExploreDeployRequest, RhoDataResponse](
           req =>
             if (req.blockHash.isEmpty)
               webApi.exploratoryDeploy(req.term, none[String], req.usePreStateHash)

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -96,7 +96,7 @@ object WebApiRoutes {
     implicit val lightBlockEncoder          = jsonEncoderOf[F, LightBlockInfo]
     implicit val lightBlockListEnc          = jsonEncoderOf[F, List[LightBlockInfo]]
     implicit val dataAtNameRespEncoder      = jsonEncoderOf[F, DataAtNameResponse]
-    implicit val dataAtParRespEncoder       = jsonEncoderOf[F, DataAtParResponse]
+    implicit val dataAtParRespEncoder       = jsonEncoderOf[F, RhoDataResponse]
     implicit val prepareEncoder             = jsonEncoderOf[F, PrepareResponse]
     implicit val explRespEncoder            = jsonEncoderOf[F, ExploratoryDeployResponse]
     implicit val transactionResponseEncoder = jsonEncoderOf[F, TransactionResponse]
@@ -144,7 +144,7 @@ object WebApiRoutes {
         req.handle[DataAtNameRequest, DataAtNameResponse](webApi.listenForDataAtName)
 
       case req @ POST -> Root / "data-at-par" =>
-        req.handle[DataAtParRequest, DataAtParResponse](webApi.listenForDataAtPar)
+        req.handle[DataAtParRequest, RhoDataResponse](webApi.getDataAtPar)
 
       // Blocks
 

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -95,15 +95,17 @@ object WebApiRoutes {
     implicit val blockInfoEncoder           = jsonEncoderOf[F, BlockInfo]
     implicit val lightBlockEncoder          = jsonEncoderOf[F, LightBlockInfo]
     implicit val lightBlockListEnc          = jsonEncoderOf[F, List[LightBlockInfo]]
-    implicit val dataRespEncoder            = jsonEncoderOf[F, DataResponse]
+    implicit val dataAtNameRespEncoder      = jsonEncoderOf[F, DataAtNameResponse]
+    implicit val dataAtParRespEncoder       = jsonEncoderOf[F, DataAtParResponse]
     implicit val prepareEncoder             = jsonEncoderOf[F, PrepareResponse]
     implicit val explRespEncoder            = jsonEncoderOf[F, ExploratoryDeployResponse]
     implicit val transactionResponseEncoder = jsonEncoderOf[F, TransactionResponse]
     // Decoders
-    implicit val deployRequestDecoder = jsonOf[F, DeployRequest]
-    implicit val dataRequestDecoder   = jsonOf[F, DataRequest]
-    implicit val prepareDecoder       = jsonOf[F, PrepareRequest]
-    implicit val ExploreDeployRequest = jsonOf[F, ExploreDeployRequest]
+    implicit val deployRequestDecoder     = jsonOf[F, DeployRequest]
+    implicit val dataAtNameRequestDecoder = jsonOf[F, DataAtNameRequest]
+    implicit val dataAtParRequestDecoder  = jsonOf[F, DataAtParRequest]
+    implicit val prepareDecoder           = jsonOf[F, PrepareRequest]
+    implicit val ExploreDeployRequest     = jsonOf[F, ExploreDeployRequest]
 
     HttpRoutes.of[F] {
       case GET -> Root / "status" =>
@@ -139,7 +141,10 @@ object WebApiRoutes {
       // Get data
 
       case req @ POST -> Root / "data-at-name" =>
-        req.handle[DataRequest, DataResponse](webApi.listenForDataAtName)
+        req.handle[DataAtNameRequest, DataAtNameResponse](webApi.listenForDataAtName)
+
+      case req @ POST -> Root / "data-at-par" =>
+        req.handle[DataAtParRequest, DataAtParResponse](webApi.listenForDataAtPar)
 
       // Blocks
 


### PR DESCRIPTION
## Overview
Added support for method `getDataAtPar` from WebAPI. This method allows getting deploy results more effectively than `getDataAtName` because doesn't use the `depth` parameter.

### How to check solution locally

1. Run RNode locally as validator (with `--validator-private-key` and other necessary parameters)
2. Make deploy with code below and store deploy signature
```
new return(`rho:rchain:deployId`) in { return!("data-at-par") }
```
3. Make propose and store returned block hash
4. Make POST request on `http://localhost:40403/api/data-at-name-by-block-hash` with JSON data
```json
{
    "blockHash": "<ADDED_IN_PROPOSE_BLOCK_HASH>",
    "name": {
        "UnforgDeploy": {
            "data": "<DEPLOY_SIGNATURE>"
            }
        },
    "usePreStateHash": false
}
```

The result of this request should be like this
```json
{
    "expr": [
        {
            "ExprString": {
                "data": "data-at-par"
            }
        }
    ],
    "block": {
        "blockHash": "2a0ef3da0b3d929fb9dada1a94a4bebd216dcdf1e474e28c831e417a6a957fb5",
        "sender": "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3",
        "seqNum": 17,
        "sig": "3045022100f2c2e6f44075ae5097f51d2fae62dbfea76869f66bd0de8404df56fd0c46fc40022063b105ef8eddd86c5669d5215be2d688955de68bb205cf3d4466ac5566247cb8",
        "sigAlgorithm": "secp256k1",
        "shardId": "root",
        "extraBytes": "",
        "version": 1,
        "timestamp": 1643023442303,
        "headerExtraBytes": "",
        "parentsHashList": [
            "7a5024910e00c581c692ae52fdb9fe56407dad2989f7a14d7d2fb42abf4f8615"
        ],
        "blockNumber": 17,
        "preStateHash": "7fbb7ad62521ab64be0e54285d64f9dd4329d0b34a889052347bded047a271e5",
        "postStateHash": "4060c2837da16b736d5ca6ebba95fe13a78424c06f0b6be143fce765fa122530",
        "bodyExtraBytes": "",
        "bonds": [
            {
                "validator": "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3",
                "stake": 150500000000000
            }
        ],
        "blockSize": "127859",
        "deployCount": 1,
        "faultTolerance": 1.0,
        "justifications": [
            {
                "validator": "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3",
                "latestBlockHash": "7a5024910e00c581c692ae52fdb9fe56407dad2989f7a14d7d2fb42abf4f8615"
            }
        ],
        "rejectedDeploys": []
    }
}
```

**The sample output of `data-at-name` for compare**
```json
{
    "exprs": [
        {
            "expr": {
                "ExprString": {
                    "data": "data-at-name"
                }
            },
            "block": {
                "blockHash": "8c3ca0d7a0f500873408591df94e3fc872350f64aa94ebb34341faa2a3b39716",
                "sender": "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3",
                "seqNum": 14,
                "sig": "304402204d1cc30afbfb3c4add72edee0d150fe2681271e1b63c729253e5eb9ef3ab5bd2022067a34bfc5e2e26a75caf243270aa1bcf8f603f8bfa58708fa99ffe83c33b63cf",
                "sigAlgorithm": "secp256k1",
                "shardId": "root",
                "extraBytes": "",
                "version": 1,
                "timestamp": 1642606004650,
                "headerExtraBytes": "",
                "parentsHashList": [
                    "dd4a3d1a0cb2571aa5cb86b4eded05125afb11c921e255185fd9ef1109ac57b9"
                ],
                "blockNumber": 14,
                "preStateHash": "594f4ee2bb7cb943f6e4ca66e26e8934bf98313929077442256efe2fdbc76c01",
                "postStateHash": "ccbcf5bee2c76731789dfed322ad11df2633ca5fadc33e8eef7497d0544436cb",
                "bodyExtraBytes": "",
                "bonds": [
                    {
                        "validator": "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3",
                        "stake": 150500000000000
                    }
                ],
                "blockSize": "127861",
                "deployCount": 1,
                "faultTolerance": 1.0,
                "justifications": [
                    {
                        "validator": "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3",
                        "latestBlockHash": "dd4a3d1a0cb2571aa5cb86b4eded05125afb11c921e255185fd9ef1109ac57b9"
                    }
                ],
                "rejectedDeploys": []
            }
        }
    ],
    "length": 1
}
```

### Notes
1. Is there way to combine functions https://github.com/rchain/rchain/blob/729c72dacc6e0f9855ffb5ab94fcb668fbc0d55d/node/src/main/scala/coop/rchain/node/api/WebApi.scala#L373-L377 with providing generic type with type bounds?
2. Is it necessary requirement?
> Response should be the same as for exploratory deploy (Seq[Par], LightBlockInfo).


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
