### PR TITLE
New reject rule for overflow and negative merged results

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/ConflictSetMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/ConflictSetMerger.scala
@@ -17,7 +17,6 @@ import coop.rchain.rspace.internal.Datum
 object ConflictSetMerger {
 
   /** R is a type for minimal rejection unit */
-  @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Throw"))
   def merge[F[_]: Concurrent: Log, R: Ordering](
       actualSet: Set[R],
       lateSet: Set[R],
@@ -59,11 +58,8 @@ object ConflictSetMerger {
       diff.foldLeft(originResult) {
         case (ba, br) =>
           val result = Math.addExact(ba.getOrElse(br._1, 0L), br._2)
-          if (result < 0) {
-            throw new ArithmeticException("merged result negative")
-          } else {
-            ba.updated(br._1, result)
-          }
+          assert(result >= 0, "merged result negative")
+          ba.updated(br._1, result)
       }
     }
 
@@ -81,6 +77,7 @@ object ConflictSetMerger {
             (calMergedResult(deploy, balances), rejected)
           } catch {
             case _: ArithmeticException => (balances, rejected + deploy)
+            case _: AssertionError      => (balances, rejected + deploy)
           }
       }
       rejected

--- a/casper/src/main/scala/coop/rchain/casper/merging/ConflictSetMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/ConflictSetMerger.scala
@@ -70,6 +70,13 @@ object ConflictSetMerger {
     def foldRejection(baseBalance: Map[Blake2b256Hash, Long], branches: Set[Branch]) = {
       val (_, rejected) = branches.foldLeft((baseBalance, Set.empty[Branch])) {
         case ((balances, rejected), deploy) =>
+          // TODO come up with a better algorithm to solve below case
+          // currently we are accumulating result from some order and reject the deploy once negative result happens
+          // which doesn't seem perfect cases below
+          //
+          // base result 10 and folding the result from order like [-10, -1, 20]
+          // which on the second case `-1`, the calculation currently would reject it because the result turns
+          // into negative.However, if you look at the all the item view 10 - 10 -1 + 20 is not negative
           try {
             (calMergedResult(deploy, balances), rejected)
           } catch {

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -26,6 +26,8 @@ import monix.execution.Scheduler.Implicits.global
 import org.scalatest.FlatSpec
 import scodec.bits.ByteVector
 
+final case class DeployTestInfo(term: String, cost: Long, sig: String)
+
 class MergeNumberChannelSpec extends FlatSpec {
 
   val rhoST = """
@@ -71,28 +73,36 @@ class MergeNumberChannelSpec extends FlatSpec {
                          |}
                          |""".stripMargin
 
-  def testCase[F[_]: Concurrent: ContextShift: Parallel: Span: Log] = {
-    def makeSig(hex: String) = {
-      val bv = ByteVector.fromHex(hex).get
-      ByteString.copyFrom(bv.toArray)
-    }
+  def makeSig(hex: String) = {
+    val bv = ByteVector.fromHex(hex).get
+    ByteString.copyFrom(bv.toArray)
+  }
+
+  def testCase[F[_]: Concurrent: ContextShift: Parallel: Span: Log](
+      baseTerms: Seq[String],
+      leftTerms: Seq[DeployTestInfo],
+      rightTerms: Seq[DeployTestInfo],
+      expectedRejected: Set[ByteString],
+      expectedFinalResult: Long
+  ) = {
+
 
     Resources.mkRuntimeManager[F]("merging-test").use { rm =>
       for {
         runtime <- rm.spawnRuntime
 
         // Run Rholang terms / simulate deploys in a block
-        runRholang = (terms: Seq[(String, Long, String)], preState: Blake2b256Hash) =>
+        runRholang = (terms: Seq[DeployTestInfo], preState: Blake2b256Hash) =>
           for {
             _ <- runtime.reset(preState)
 
             evalResults <- terms.toList.traverse {
-                            case (term, _, _) =>
+                            case deploy =>
                               for {
-                                evalResult <- runtime.evaluate(term)
+                                evalResult <- runtime.evaluate(deploy.term)
                                 _ = assert(
                                   evalResult.errors.isEmpty,
-                                  s"${evalResult.errors}\n$term"
+                                  s"${evalResult.errors}\n$deploy.term"
                                 )
                                 // Get final values for mergeable (number) channels
                                 numChanFinal <- runtime
@@ -110,7 +120,7 @@ class MergeNumberChannelSpec extends FlatSpec {
 
             // Create event log indices
             evLogIndices <- logSeq.zip(numChanDiffs).zip(terms).traverse {
-                             case ((cp, numberChanDiff), (_, cost, sig)) =>
+                             case ((cp, numberChanDiff), deploy) =>
                                for {
                                  evLogIndex <- BlockIndex.createEventLogIndex(
                                                 cp.log
@@ -120,23 +130,24 @@ class MergeNumberChannelSpec extends FlatSpec {
                                                 preState,
                                                 numberChanDiff
                                               )
-                                 sigBS = makeSig(sig)
-                               } yield DeployIndex(sigBS, cost, evLogIndex)
+                                 sigBS = makeSig(deploy.sig)
+                               } yield DeployIndex(sigBS, deploy.cost, evLogIndex)
                            }
           } yield (evLogIndices.toSet, endCheckpoint.root)
 
         historyRepo = rm.getHistoryRepo
 
         // Base state
-        baseRes <- runtime.evaluate(rhoST)
-        _       = assert(baseRes.errors.isEmpty, s"BASE: ${baseRes.errors}")
-        baseCp  <- runtime.createCheckpoint
+        _ <- baseTerms.zipWithIndex.toList.traverse {
+              case (term, i) =>
+                for {
+                  baseRes <- runtime.evaluate(term)
+                  _       = assert(baseRes.errors.isEmpty, s"BASE $i: ${baseRes.errors}")
+                } yield ()
+            }
+        baseCp <- runtime.createCheckpoint
 
         // Branch 1 change
-        leftTerms = Seq(
-          (rhoChange(10), 10L, "0x10"), // +10
-          (rhoChange(-5), 10L, "0x11")  //  -5
-        )
         leftResult                     <- runRholang(leftTerms, baseCp.root)
         (leftEvIndices, leftPostState) = leftResult
 
@@ -146,11 +157,6 @@ class MergeNumberChannelSpec extends FlatSpec {
         )
 
         // Branch 2 change
-        rightTerms = Seq(
-          (rhoChange(15), 10L, "0x20"), // +15
-          (rhoChange(10), 10L, "0x21"), // +10
-          (rhoChange(-20), 10L, "0x22") // -20
-        )
         rightResult                      <- runRholang(rightTerms, baseCp.root)
         (rightEvIndices, rightPostState) = rightResult
 
@@ -218,8 +224,8 @@ class MergeNumberChannelSpec extends FlatSpec {
             )
 
         (finalHash, rejected) = r
-
-        _ = rejected shouldBe empty
+        rejectedSigs = rejected.flatMap(_.deploysWithCost.map(_.id))
+        _ = rejectedSigs shouldBe expectedRejected
 
         // Read merged value
 
@@ -227,346 +233,59 @@ class MergeNumberChannelSpec extends FlatSpec {
 
         Number(finalBalance) = res.head
 
-        _ = finalBalance shouldBe 10
+        _ = finalBalance shouldBe expectedFinalResult
 
       } yield ()
     }
   }
-
   implicit val timeEff = new LogicalTime[Task]
   implicit val logEff  = Log.log[Task]
   implicit val spanEff = Span.noop[Task]
 
-  def testNegativeMergeadResult[F[_]: Concurrent: ContextShift: Parallel: Span: Log] = {
-    def makeSig(hex: String) = {
-      val bv = ByteVector.fromHex(hex).get
-      ByteString.copyFrom(bv.toArray)
-    }
-
-    Resources.mkRuntimeManager[F]("merging-test-negative").use { rm =>
-      for {
-        runtime <- rm.spawnRuntime
-
-        // Run Rholang terms / simulate deploys in a block
-        runRholang = (terms: Seq[(String, Long, String)], preState: Blake2b256Hash) =>
-          for {
-            _ <- runtime.reset(preState)
-            evalResults <- terms.toList.traverse {
-                            case (term, _, _) =>
-                              for {
-                                evalResult <- runtime.evaluate(term)
-                                _ = assert(
-                                  evalResult.errors.isEmpty,
-                                  s"${evalResult.errors}\n$term"
-                                )
-                                // Get final values for mergeable (number) channels
-                                numChanFinal <- runtime
-                                                 .getNumberChannelsData(evalResult.mergeable)
-
-                                softPoint <- runtime.createSoftCheckpoint
-                              } yield (softPoint, numChanFinal)
-                          }
-            // Create checkpoint with state hash
-            endCheckpoint <- runtime.createCheckpoint
-
-            (logSeq, numChanAbs) = evalResults.unzip
-
-            numChanDiffs <- rm.convertNumberChannelsToDiff(numChanAbs, preState)
-
-            // Create event log indices
-            evLogIndices <- logSeq.zip(numChanDiffs).zip(terms).traverse {
-                             case ((cp, numberChanDiff), (_, cost, sig)) =>
-                               for {
-                                 evLogIndex <- BlockIndex.createEventLogIndex(
-                                                cp.log
-                                                  .map(EventConverter.toCasperEvent)
-                                                  .toList,
-                                                rm.getHistoryRepo,
-                                                preState,
-                                                numberChanDiff
-                                              )
-                                 sigBS = makeSig(sig)
-                               } yield DeployIndex(sigBS, cost, evLogIndex)
-                           }
-          } yield (evLogIndices.toSet, endCheckpoint.root)
-
-        historyRepo = rm.getHistoryRepo
-
-        // Base state
-        baseRes      <- runtime.evaluate(rhoST)
-        _            = assert(baseRes.errors.isEmpty, s"BASE: ${baseRes.errors}")
-        increaseBase <- runtime.evaluate(rhoChange(10))
-        _            = assert(increaseBase.errors.isEmpty, s"BASE: ${increaseBase.errors}")
-        baseCp       <- runtime.createCheckpoint
-
-        // Branch 1 change
-        leftTerms = Seq(
-          (rhoChange(-5), 10L, "0x11") //  -5
-        )
-        leftResult                     <- runRholang(leftTerms, baseCp.root)
-        (leftEvIndices, leftPostState) = leftResult
-
-        leftDeployIndices = MergingLogic.computeRelatedSets[DeployIndex](
-          leftEvIndices,
-          (x, y) => MergingLogic.depends(x.eventLogIndex, y.eventLogIndex)
-        )
-
-        // Branch 2 change
-        rightTerms = Seq(
-          (rhoChange(-6), 10L, "0x22") // -20
-        )
-        rightResult                      <- runRholang(rightTerms, baseCp.root)
-        (rightEvIndices, rightPostState) = rightResult
-
-        rightDeployIndices = MergingLogic.computeRelatedSets[DeployIndex](
-          rightEvIndices,
-          (x, y) => MergingLogic.depends(x.eventLogIndex, y.eventLogIndex)
-        )
-
-        // Calculate deploy chains / deploy dependency
-
-        leftDeployChains <- leftDeployIndices.toList.traverse(
-                             DeployChainIndex(_, baseCp.root, leftPostState, historyRepo)
-                           )
-        rightDeployChains <- rightDeployIndices.toList.traverse(
-                              DeployChainIndex(_, baseCp.root, rightPostState, historyRepo)
-                            )
-
-        _ = println(s"DEPLOY_CHAINS LEFT : ${leftDeployChains.size}")
-        _ = println(s"DEPLOY_CHAINS RIGHT: ${rightDeployChains.size}")
-
-        // Detect rejections / number channel overflow/negative
-
-        branchesAreConflicting = (as: Set[DeployChainIndex], bs: Set[DeployChainIndex]) =>
-          MergingLogic.areConflicting(
-            as.map(_.eventLogIndex).toList.combineAll,
-            bs.map(_.eventLogIndex).toList.combineAll
-          )
-
-        // Base state reader
-        baseReader       <- rm.getHistoryRepo.getHistoryReader(baseCp.root)
-        baseReaderBinary = baseReader.readerBinary
-        baseGetData      = baseReader.getData _
-
-        // Merging handler for number channels
-        overrideTrieAction = (
-            hash: Blake2b256Hash,
-            changes: ChannelChange[ByteVector],
-            numberChs: NumberChannelsDiff
-        ) =>
-          numberChs.get(hash).traverse {
-            RholangMergingLogic.calculateNumberChannelMerge(hash, _, changes, baseGetData)
-          }
-
-        // Create store actions / uses handler for number channels
-        computeTrieActions = (changes: StateChange, mergeableChs: NumberChannelsDiff) => {
-          StateChangeMerger
-            .computeTrieActions(changes, baseReaderBinary, mergeableChs, overrideTrieAction)
-        }
-
-        applyTrieActions = (actions: Seq[HotStoreTrieAction]) =>
-          rm.getHistoryRepo.reset(baseCp.root).flatMap(_.doCheckpoint(actions).map(_.root))
-
-        r <- ConflictSetMerger.merge[F, DeployChainIndex](
-              actualSet = leftDeployChains.toSet ++ rightDeployChains.toSet,
-              lateSet = Set(),
-              depends = (target, source) =>
-                MergingLogic.depends(target.eventLogIndex, source.eventLogIndex),
-              conflicts = branchesAreConflicting,
-              cost = DagMerger.costOptimalRejectionAlg,
-              stateChanges = r => r.stateChanges.pure,
-              mergeableChannels = _.eventLogIndex.numberChannelsData,
-              computeTrieActions = computeTrieActions,
-              applyTrieActions = applyTrieActions,
-              getData = baseReader.getData
-            )
-
-        (finalHash, rejected) = r
-
-        _ = rejected shouldBe rightDeployChains.toSet
-
-        // Read merged value
-
-        res <- runtime.playExploratoryDeploy(rhoExploreRead, finalHash.toByteString)
-
-        Number(finalBalance) = res.head
-
-        _ = finalBalance shouldBe 5
-
-      } yield ()
-    }
-  }
-
-  def testOverFlowMergeadResult[F[_]: Concurrent: ContextShift: Parallel: Span: Log] = {
-    def makeSig(hex: String) = {
-      val bv = ByteVector.fromHex(hex).get
-      ByteString.copyFrom(bv.toArray)
-    }
-
-    Resources.mkRuntimeManager[F]("merging-test-negative").use { rm =>
-      for {
-        runtime <- rm.spawnRuntime
-
-        // Run Rholang terms / simulate deploys in a block
-        runRholang = (terms: Seq[(String, Long, String)], preState: Blake2b256Hash) =>
-          for {
-            _ <- runtime.reset(preState)
-            evalResults <- terms.toList.traverse {
-                            case (term, _, _) =>
-                              for {
-                                evalResult <- runtime.evaluate(term)
-                                _ = assert(
-                                  evalResult.errors.isEmpty,
-                                  s"${evalResult.errors}\n$term"
-                                )
-                                // Get final values for mergeable (number) channels
-                                numChanFinal <- runtime
-                                                 .getNumberChannelsData(evalResult.mergeable)
-
-                                softPoint <- runtime.createSoftCheckpoint
-                              } yield (softPoint, numChanFinal)
-                          }
-            // Create checkpoint with state hash
-            endCheckpoint <- runtime.createCheckpoint
-
-            (logSeq, numChanAbs) = evalResults.unzip
-
-            numChanDiffs <- rm.convertNumberChannelsToDiff(numChanAbs, preState)
-
-            // Create event log indices
-            evLogIndices <- logSeq.zip(numChanDiffs).zip(terms).traverse {
-                             case ((cp, numberChanDiff), (_, cost, sig)) =>
-                               for {
-                                 evLogIndex <- BlockIndex.createEventLogIndex(
-                                                cp.log
-                                                  .map(EventConverter.toCasperEvent)
-                                                  .toList,
-                                                rm.getHistoryRepo,
-                                                preState,
-                                                numberChanDiff
-                                              )
-                                 sigBS = makeSig(sig)
-                               } yield DeployIndex(sigBS, cost, evLogIndex)
-                           }
-          } yield (evLogIndices.toSet, endCheckpoint.root)
-
-        historyRepo = rm.getHistoryRepo
-
-        // Base state
-        baseRes      <- runtime.evaluate(rhoST)
-        _            = assert(baseRes.errors.isEmpty, s"BASE: ${baseRes.errors}")
-        increaseBase <- runtime.evaluate(rhoChange(10))
-        _            = assert(increaseBase.errors.isEmpty, s"BASE: ${increaseBase.errors}")
-        baseCp       <- runtime.createCheckpoint
-
-        // Branch 1 change
-        leftTerms = Seq(
-          (rhoChange(-5L), 10L, "0x11") //  -5
-        )
-        leftResult                     <- runRholang(leftTerms, baseCp.root)
-        (leftEvIndices, leftPostState) = leftResult
-
-        leftDeployIndices = MergingLogic.computeRelatedSets[DeployIndex](
-          leftEvIndices,
-          (x, y) => MergingLogic.depends(x.eventLogIndex, y.eventLogIndex)
-        )
-
-        // Branch 2 change
-        rightTerms = Seq(
-          (rhoChange(9223372036854775806L), 10L, "0x22") // + 9223372036854775802
-        )
-        rightResult                      <- runRholang(rightTerms, baseCp.root)
-        (rightEvIndices, rightPostState) = rightResult
-
-        rightDeployIndices = MergingLogic.computeRelatedSets[DeployIndex](
-          rightEvIndices,
-          (x, y) => MergingLogic.depends(x.eventLogIndex, y.eventLogIndex)
-        )
-
-        // Calculate deploy chains / deploy dependency
-
-        leftDeployChains <- leftDeployIndices.toList.traverse(
-                             DeployChainIndex(_, baseCp.root, leftPostState, historyRepo)
-                           )
-        rightDeployChains <- rightDeployIndices.toList.traverse(
-                              DeployChainIndex(_, baseCp.root, rightPostState, historyRepo)
-                            )
-
-        _ = println(s"DEPLOY_CHAINS LEFT : ${leftDeployChains.size}")
-        _ = println(s"DEPLOY_CHAINS RIGHT: ${rightDeployChains.size}")
-
-        // Detect rejections / number channel overflow/negative
-
-        branchesAreConflicting = (as: Set[DeployChainIndex], bs: Set[DeployChainIndex]) =>
-          MergingLogic.areConflicting(
-            as.map(_.eventLogIndex).toList.combineAll,
-            bs.map(_.eventLogIndex).toList.combineAll
-          )
-
-        // Base state reader
-        baseReader       <- rm.getHistoryRepo.getHistoryReader(baseCp.root)
-        baseReaderBinary = baseReader.readerBinary
-        baseGetData      = baseReader.getData _
-
-        // Merging handler for number channels
-        overrideTrieAction = (
-            hash: Blake2b256Hash,
-            changes: ChannelChange[ByteVector],
-            numberChs: NumberChannelsDiff
-        ) =>
-          numberChs.get(hash).traverse {
-            RholangMergingLogic.calculateNumberChannelMerge(hash, _, changes, baseGetData)
-          }
-
-        // Create store actions / uses handler for number channels
-        computeTrieActions = (changes: StateChange, mergeableChs: NumberChannelsDiff) => {
-          StateChangeMerger
-            .computeTrieActions(changes, baseReaderBinary, mergeableChs, overrideTrieAction)
-        }
-
-        applyTrieActions = (actions: Seq[HotStoreTrieAction]) =>
-          rm.getHistoryRepo.reset(baseCp.root).flatMap(_.doCheckpoint(actions).map(_.root))
-
-        r <- ConflictSetMerger.merge[F, DeployChainIndex](
-              actualSet = leftDeployChains.toSet ++ rightDeployChains.toSet,
-              lateSet = Set(),
-              depends = (target, source) =>
-                MergingLogic.depends(target.eventLogIndex, source.eventLogIndex),
-              conflicts = branchesAreConflicting,
-              cost = DagMerger.costOptimalRejectionAlg,
-              stateChanges = r => r.stateChanges.pure,
-              mergeableChannels = _.eventLogIndex.numberChannelsData,
-              computeTrieActions = computeTrieActions,
-              applyTrieActions = applyTrieActions,
-              getData = baseReader.getData
-            )
-
-        (finalHash, rejected) = r
-
-//        _ = rejected shouldBe rightDeployChains.toSet
-
-        // Read merged value
-
-        res <- runtime.playExploratoryDeploy(rhoExploreRead, finalHash.toByteString)
-
-        Number(finalBalance) = res.head
-
-        _ = finalBalance shouldBe 5
-
-      } yield ()
-    }
-  }
-
   "multiple branches" should "reject deploy when mergeable number channels got negative number" in effectTest {
-    testNegativeMergeadResult[Task]
+    testCase[Task](
+      baseTerms = Seq(rhoST, rhoChange(10)),
+      leftTerms = Seq(
+        DeployTestInfo(rhoChange(-5), 10L, "0x11") //  -5
+      ),
+      rightTerms = Seq(
+        DeployTestInfo(rhoChange(-6), 10L, "0x22") // -20
+
+      ),
+      expectedRejected =  Set(makeSig("0x22")),
+      expectedFinalResult = 5
+    )
   }
 
   "multiple branches" should "reject deploy when mergeable number channels got overflow" in effectTest {
-    testOverFlowMergeadResult[Task]
+    testCase[Task](
+      baseTerms = Seq(rhoST, rhoChange(10)),
+      leftTerms = Seq(
+        DeployTestInfo(rhoChange(-5), 10L, "0x11") //  -5
+      ),
+      rightTerms = Seq(
+        DeployTestInfo(rhoChange(9223372036854775806L), 10L, "0x22") // + 9223372036854775802, reject this one
+      ),
+      expectedRejected = Set(makeSig("0x22")),
+      expectedFinalResult = 5
+    )
   }
 
   "multiple branches" should "merge number channels" in effectTest {
-    testCase[Task]
+    testCase[Task](
+      baseTerms = Seq(rhoST),
+      leftTerms = Seq(
+        DeployTestInfo(rhoChange(10), 10L, "0x10"),
+        DeployTestInfo(rhoChange(-5), 10L, "0x11")
+      ),
+      rightTerms = Seq(
+        DeployTestInfo(rhoChange(15), 10L, "0x20"), // +15
+        DeployTestInfo(rhoChange(10), 10L, "0x21"), // +10
+        DeployTestInfo(rhoChange(-20), 10L, "0x22") // -20
+      ),
+      expectedRejected = Set.empty,
+      expectedFinalResult = 10
+    )
   }
 
   "TEMP encode multiple values" should "show stored binary size" in {

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -103,7 +103,7 @@ class MergeNumberChannelSpec extends FlatSpec {
                                 evalResult <- runtime.evaluate(deploy.term)
                                 _ = assert(
                                   evalResult.errors.isEmpty,
-                                  s"${evalResult.errors}\n$deploy.term"
+                                  s"${evalResult.errors}\n ${deploy.term}"
                                 )
                                 // Get final values for mergeable (number) channels
                                 numChanFinal <- runtime

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -86,7 +86,6 @@ class MergeNumberChannelSpec extends FlatSpec {
       expectedFinalResult: Long
   ) = {
 
-
     Resources.mkRuntimeManager[F]("merging-test").use { rm =>
       for {
         runtime <- rm.spawnRuntime
@@ -224,8 +223,8 @@ class MergeNumberChannelSpec extends FlatSpec {
             )
 
         (finalHash, rejected) = r
-        rejectedSigs = rejected.flatMap(_.deploysWithCost.map(_.id))
-        _ = rejectedSigs shouldBe expectedRejected
+        rejectedSigs          = rejected.flatMap(_.deploysWithCost.map(_.id))
+        _                     = rejectedSigs shouldBe expectedRejected
 
         // Read merged value
 
@@ -250,9 +249,8 @@ class MergeNumberChannelSpec extends FlatSpec {
       ),
       rightTerms = Seq(
         DeployTestInfo(rhoChange(-6), 10L, "0x22") // -20
-
       ),
-      expectedRejected =  Set(makeSig("0x22")),
+      expectedRejected = Set(makeSig("0x22")),
       expectedFinalResult = 5
     )
   }

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -73,6 +73,8 @@ class MergeNumberChannelSpec extends FlatSpec {
                          |}
                          |""".stripMargin
 
+  def parRho(ori: String, appendRho: String) = Seq(ori, appendRho).mkString("|")
+
   def makeSig(hex: String) = {
     val bv = ByteVector.fromHex(hex).get
     ByteString.copyFrom(bv.toArray)
@@ -266,6 +268,22 @@ class MergeNumberChannelSpec extends FlatSpec {
       ),
       expectedRejected = Set(makeSig("0x22")),
       expectedFinalResult = 5
+    )
+  }
+
+  "multiple branches with normal rejection" should "choose from normal reject options" in effectTest {
+    testCase[Task](
+      baseTerms = Seq(rhoST, rhoChange(100)),
+      leftTerms = Seq(
+        DeployTestInfo(parRho(rhoChange(-20), "@\"X\"!(1)"), 10L, "0x11"),
+        DeployTestInfo(rhoChange(-10), 10L, "0x12")
+      ),
+      rightTerms = Seq(
+        DeployTestInfo(rhoChange(-60), 10L, "0x22"),
+        DeployTestInfo(parRho(rhoChange(-20), "for(_ <- @\"X\") {Nil}"), 11L, "0x21")
+      ),
+      expectedRejected = Set(makeSig("0x11")),
+      expectedFinalResult = 10
     )
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -213,7 +213,8 @@ class MergeNumberChannelSpec extends FlatSpec {
               stateChanges = r => r.stateChanges.pure,
               mergeableChannels = _.eventLogIndex.numberChannelsData,
               computeTrieActions = computeTrieActions,
-              applyTrieActions = applyTrieActions
+              applyTrieActions = applyTrieActions,
+              getData = baseReader.getData
             )
 
         (finalHash, rejected) = r
@@ -376,12 +377,13 @@ class MergeNumberChannelSpec extends FlatSpec {
               stateChanges = r => r.stateChanges.pure,
               mergeableChannels = _.eventLogIndex.numberChannelsData,
               computeTrieActions = computeTrieActions,
-              applyTrieActions = applyTrieActions
+              applyTrieActions = applyTrieActions,
+              getData = baseReader.getData
             )
 
         (finalHash, rejected) = r
 
-        _ = rejected shouldBe leftDeployChains.toSet
+        _ = rejected shouldBe rightDeployChains.toSet
 
         // Read merged value
 
@@ -471,7 +473,7 @@ class MergeNumberChannelSpec extends FlatSpec {
 
         // Branch 2 change
         rightTerms = Seq(
-          (rhoChange(9223372036854775802L), 10L, "0x22") // + 9223372036854775802
+          (rhoChange(9223372036854775806L), 10L, "0x22") // + 9223372036854775802
         )
         rightResult                      <- runRholang(rightTerms, baseCp.root)
         (rightEvIndices, rightPostState) = rightResult
@@ -535,12 +537,13 @@ class MergeNumberChannelSpec extends FlatSpec {
               stateChanges = r => r.stateChanges.pure,
               mergeableChannels = _.eventLogIndex.numberChannelsData,
               computeTrieActions = computeTrieActions,
-              applyTrieActions = applyTrieActions
+              applyTrieActions = applyTrieActions,
+              getData = baseReader.getData
             )
 
         (finalHash, rejected) = r
 
-        _ = rejected shouldBe leftDeployChains.toSet
+//        _ = rejected shouldBe rightDeployChains.toSet
 
         // Read merged value
 
@@ -554,11 +557,11 @@ class MergeNumberChannelSpec extends FlatSpec {
     }
   }
 
-  "multiple branches" should "reject deploy when mergeable number channels got negative number" ignore effectTest {
+  "multiple branches" should "reject deploy when mergeable number channels got negative number" in effectTest {
     testNegativeMergeadResult[Task]
   }
 
-  "multiple branches" should "reject deploy when mergeable number channels got overflow" ignore effectTest {
+  "multiple branches" should "reject deploy when mergeable number channels got overflow" in effectTest {
     testOverFlowMergeadResult[Task]
   }
 


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->
 Implement rejections for merged number channels which are negative or overflow. as what https://github.com/rchain/rchain/issues/3513 asked for

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
