### PR TITLE
Implemented gRPC binding for `getDataAtPar` method

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -27,7 +27,9 @@ trait DeployService[F[_]] {
   def listenForContinuationAtName(
       request: ContinuationAtNameQuery
   ): F[Either[Seq[String], Seq[ContinuationsWithBlockInfo]]]
-  def getDataAtPar(request: DataAtParQuery): F[Either[Seq[String], (Seq[Par], LightBlockInfo)]]
+  def getDataAtPar(
+      request: DataAtNameByBlockQuery
+  ): F[Either[Seq[String], (Seq[Par], LightBlockInfo)]]
   def lastFinalizedBlock: F[Either[Seq[String], String]]
   def isFinalized(q: IsFinalizedQuery): F[Either[Seq[String], String]]
   def bondStatus(q: BondStatusQuery): F[Either[Seq[String], String]]
@@ -147,7 +149,7 @@ class GrpcDeployService[F[_]: Monixable: Sync](host: String, port: Int, maxMessa
       )
 
   def getDataAtPar(
-      request: DataAtParQuery
+      request: DataAtNameByBlockQuery
   ): F[Either[Seq[String], (Seq[Par], LightBlockInfo)]] =
     stub
       .getDataAtName(request)

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployService.scala
@@ -150,7 +150,7 @@ class GrpcDeployService[F[_]: Monixable: Sync](host: String, port: Int, maxMessa
       request: DataAtParQuery
   ): F[Either[Seq[String], (Seq[Par], LightBlockInfo)]] =
     stub
-      .getDataAtPar(request)
+      .getDataAtName(request)
       .fromTask
       .toEitherF(
         _.message.error,

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -49,7 +49,7 @@ message DataAtNameQuery {
   Par name = 2;
 }
 
-message DataAtParQuery {
+message DataAtNameByBlockQuery {
   Par par              = 1 [(scalapb.field).no_box = true];
   string blockHash     = 2;
   bool usePreStateHash = 3;

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -49,6 +49,12 @@ message DataAtNameQuery {
   Par name = 2;
 }
 
+message DataAtParQuery {
+  Par par              = 1 [(scalapb.field).no_box = true];
+  string blockHash     = 2;
+  bool usePreStateHash = 3;
+}
+
 message ContinuationAtNameQuery {
   int32 depth = 1;
   repeated Par names = 2;

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -14,6 +14,7 @@ import "DeployServiceCommon.proto";
 // make a scalapb directory in this file's location and place it inside
 
 import "scalapb/scalapb.proto";
+import "RhoTypes.proto";
 
 import "google/protobuf/empty.proto";
 
@@ -43,6 +44,8 @@ service DeployService {
   rpc getBlocks(BlocksQuery) returns (stream BlockInfoResponse) {}
   // Find data sent to a name.
   rpc listenForDataAtName(DataAtNameQuery) returns (ListeningNameDataResponse) {}
+  // Find data sent to a par.
+  rpc getDataAtPar(DataAtParQuery) returns (RhoDataResponse) {}
   // Find processes receiving on a name.
   rpc listenForContinuationAtName(ContinuationAtNameQuery) returns (ContinuationAtNameResponse) {}
   // Find block containing a deploy.
@@ -131,6 +134,19 @@ message ListeningNameDataResponse {
 message ListeningNameDataPayload {
   repeated DataWithBlockInfo blockInfo = 1;
   int32 length                         = 2;
+}
+
+// listenForDataAtPar
+message RhoDataResponse {
+  oneof message {
+    ServiceError error     = 1;
+    RhoDataPayload payload = 2;
+  }
+}
+
+message RhoDataPayload {
+  repeated Par par     = 1;
+  LightBlockInfo block = 2 [(scalapb.field).no_box = true];
 }
 
 // listenForContinuationAtName

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -45,8 +45,8 @@ service DeployService {
   // Find data sent to a name.
   // OBSOLETE: Use getDataAtName instead. This method will be removed in the future version of RNode.
   rpc listenForDataAtName(DataAtNameQuery) returns (ListeningNameDataResponse) {}
-  // Find data sent to a par.
-  rpc getDataAtName(DataAtParQuery) returns (RhoDataResponse) {}
+  // Find data sent to a name.
+  rpc getDataAtName(DataAtNameByBlockQuery) returns (RhoDataResponse) {}
   // Find processes receiving on a name.
   rpc listenForContinuationAtName(ContinuationAtNameQuery) returns (ContinuationAtNameResponse) {}
   // Find block containing a deploy.

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -43,9 +43,10 @@ service DeployService {
   // Get a summary of blocks on the blockchain.
   rpc getBlocks(BlocksQuery) returns (stream BlockInfoResponse) {}
   // Find data sent to a name.
+  // OBSOLETE: Use getDataAtName instead. This method will be removed in the future version of RNode.
   rpc listenForDataAtName(DataAtNameQuery) returns (ListeningNameDataResponse) {}
   // Find data sent to a par.
-  rpc getDataAtPar(DataAtParQuery) returns (RhoDataResponse) {}
+  rpc getDataAtName(DataAtParQuery) returns (RhoDataResponse) {}
   // Find processes receiving on a name.
   rpc listenForContinuationAtName(ContinuationAtNameQuery) returns (ContinuationAtNameResponse) {}
   // Find block containing a deploy.

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -181,7 +181,7 @@ object DeployGrpcServiceV1 {
         }
 
       def getDataAtName(
-          request: DataAtParQuery
+          request: DataAtNameByBlockQuery
       ): Task[RhoDataResponse] =
         defer(
           BlockAPI

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -180,7 +180,7 @@ object DeployGrpcServiceV1 {
           )
         }
 
-      def getDataAtPar(
+      def getDataAtName(
           request: DataAtParQuery
       ): Task[RhoDataResponse] =
         defer(

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -180,6 +180,22 @@ object DeployGrpcServiceV1 {
           )
         }
 
+      def getDataAtPar(
+          request: DataAtParQuery
+      ): Task[RhoDataResponse] =
+        defer(
+          BlockAPI
+            .getDataAtPar[F](request.par, request.blockHash, request.usePreStateHash)
+        ) { r =>
+          import RhoDataResponse.Message
+          import RhoDataResponse.Message._
+          RhoDataResponse(
+            r.fold[Message](
+              Error, { case (par, block) => Payload(RhoDataPayload(par, block)) }
+            )
+          )
+        }
+
       def listenForContinuationAtName(
           request: ContinuationAtNameQuery
       ): Task[ContinuationAtNameResponse] =


### PR DESCRIPTION
## Overview

Added support for method `getDataAtPar` from `gRPC`. This method allows getting deploy results more effectively than `getDataAtName` because doesn't use the `depth` parameter.

Sample output (from pyrchain client):
```
payload {
  par {
    exprs {
      g_string: "data-at-par"
    }
  }
  block {
    blockHash: "70dedde39127f3bb9c4c0bbd8b51b6bf7235d170ee052f4bb2a6d4ad27f007ee"
    sender: "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3"
    seqNum: 25
    sig: "3044022074f0ff8a4467bbc596166baa0283da5d75ab6fc4d1ebb149e0a0bee8ad686f3902201f90275bbaad719c6af6379e5e30b188e811a7ae33d0191ea932b8f4866b3677"
    sigAlgorithm: "secp256k1"
    shardId: "root"
    version: 1
    timestamp: 1643799057630
    parentsHashList: "5106c5a44b5b5a9888f02a3b9d90ac85afa0dd7aaa73c24abb9f58fd6dce848f"
    blockNumber: 25
    preStateHash: "00b4d835e6e37978cacc368a3f1ff8adaeb47d5f56d2c2e69e056b70a42cff94"
    postStateHash: "1651c6a64778a005d2f2188ca85b4ab91de46a7e75552c7800e9093e885432a8"
    bonds {
      validator: "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3"
      stake: 150500000000000
    }
    blockSize: "127859"
    deployCount: 1
    faultTolerance: 1.0
    justifications {
      validator: "04415d35d799325f7784d7fbae15a3c4d0a24ff97429c7512b877b34bf3b7c801d220c38877e9a8a0736d168000ac5139cf505d9c030d1b7714dce4128ca3771b3"
      latestBlockHash: "5106c5a44b5b5a9888f02a3b9d90ac85afa0dd7aaa73c24abb9f58fd6dce848f"
    }
  }
}
```

### Notes

* Deploy should be done with such Rholang code
```
new return(`rho:rchain:deployId`) in { return!("data-at-par") }
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
