### PR TITLE
Cleanup/preparation for a new radix history

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/ByteStringKVStoreSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/ByteStringKVStoreSyntax.scala
@@ -27,6 +27,6 @@ final class ByteStringKVStoreOps[F[_], V](
   ): F[V] = {
     def source = s"${file.value}:${line.value} ${enclosing.value}"
     def errMsg = s"ByteStringKVStore is missing key ${PrettyPrinter.buildString(key)}\n $source"
-    store.get(key) >>= (_.liftTo(ByteStringKVInconsistencyError(errMsg)))
+    store.get1(key) >>= (_.liftTo(ByteStringKVInconsistencyError(errMsg)))
   }
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/casperbuffer/CasperBufferKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/casperbuffer/CasperBufferKeyValueStorage.scala
@@ -33,7 +33,7 @@ final class CasperBufferKeyValueStorage[F[_]: Concurrent: Log] private (
   override def addRelation(parent: BlockHash, child: BlockHash): F[Unit] =
     lock.withPermit(
       for {
-        parents <- parentsStore.get(child).map(_.getOrElse(Set.empty[BlockHash]))
+        parents <- parentsStore.get1(child).map(_.getOrElse(Set.empty[BlockHash]))
         _       <- parentsStore.put(child, parents + parent)
         _ <- blockDependencyDag.update(
               curState => DoublyLinkedDagOperations.add(curState, parent, child)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagKeyValueStorage.scala
@@ -113,7 +113,7 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
     }
 
     def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] =
-      deployIndex.get(deployId)
+      deployIndex.get1(deployId)
   }
 
   private object KeyValueStoreEquivocationsTracker extends EquivocationsTracker[F] {
@@ -183,7 +183,7 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
     def shouldAddAsLatest: F[Boolean] =
       latestMessagesIndex
       // Try get sender's latest message
-        .get(block.sender)
+        .get1(block.sender)
         // Get metadata from index
         .flatMap(_.traverse(blockMetadataIndex.getUnsafe))
         // Check if seq number is greater that existing

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
@@ -110,7 +110,7 @@ object BlockMetadataStore {
       } yield ()
     }
 
-    def get(hash: BlockHash): F[Option[BlockMetadata]] = store.get(hash)
+    def get(hash: BlockHash): F[Option[BlockMetadata]] = store.get1(hash)
 
     def getUnsafe(hash: BlockHash)(
         implicit f: Sync[F],

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedKeyValueStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/finality/LastFinalizedKeyValueStorage.scala
@@ -24,7 +24,7 @@ class LastFinalizedKeyValueStorage[F[_]: Sync] private (
     lastFinalizedBlockDb.put(Seq((fixedKey, blockHash)))
 
   override def get(): F[Option[BlockHash]] =
-    lastFinalizedBlockDb.get(fixedKey)
+    lastFinalizedBlockDb.get1(fixedKey)
 
   val DONE = ByteString.copyFrom(Array.fill[Byte](32)(-1))
 
@@ -48,7 +48,7 @@ class LastFinalizedKeyValueStorage[F[_]: Sync] private (
       approvedBlockHashOpt <- blockStore.getApprovedBlock.map(_.map(_.candidate.block.blockHash))
       // record hash stored in LastFinalizedStorage, or ApprovedBlock or throw error
       lfb  <- persistedLfbOpt.orElse(approvedBlockHashOpt).liftTo(new Exception(errNoLfbInStorage))
-      curV <- blockMetadataDb.get(lfb).flatMap(_.liftTo[F](new Exception(errNoMetadataForLfb)))
+      curV <- blockMetadataDb.get1(lfb).flatMap(_.liftTo[F](new Exception(errNoMetadataForLfb)))
       _    <- blockMetadataDb.put(lfb, curV.copy(directlyFinalized = true, finalized = true))
       blocksInfoMap <- blockMetadataDb
                         .collect {

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/casperbuffer/CasperBufferStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/casperbuffer/CasperBufferStorageTest.scala
@@ -55,9 +55,9 @@ class CasperBufferStorageTest extends FlatSpecLike with Matchers {
   }
 
   "when removed hash A is the last parent for hash B, key B" should "be removed from parents store" in {
-    underlyingStore.get(B).runSyncUnsafe() shouldBe Some(Set(A))
+    underlyingStore.get1(B).runSyncUnsafe() shouldBe Some(Set(A))
     casperBuffer.remove(A).runSyncUnsafe()
-    underlyingStore.get(B).runSyncUnsafe() shouldBe None
+    underlyingStore.get1(B).runSyncUnsafe() shouldBe None
   }
 
   "when removed hash A is the last parent for hash B, B" should "become pendant" in {

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockReportAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockReportAPI.scala
@@ -60,7 +60,7 @@ class BlockReportAPI[F[_]: Concurrent: Metrics: EngineCell: Log: SafetyOracle: B
       lock      = blockLockMap.getOrElseUpdate(b.blockHash, semaphore)
       result <- lock.withPermit(
                  for {
-                   cached <- reportStore.get(b.blockHash)
+                   cached <- reportStore.get1(b.blockHash)
                    res <- if (cached.isEmpty || forceReplay)
                            replayBlock(b).flatTap(reportStore.put(b.blockHash, _))
                          else

--- a/node/src/main/scala/coop/rchain/node/web/Transaction.scala
+++ b/node/src/main/scala/coop/rchain/node/web/Transaction.scala
@@ -156,7 +156,7 @@ final case class CacheTransactionAPI[F[_]: Concurrent](
   private val blockDeferMap: TrieMap[String, Deferred[F, TransactionResponse]] = TrieMap.empty
 
   def getTransaction(blockHash: String): F[TransactionResponse] =
-    store.get(blockHash) >>= { transactionOpt =>
+    store.get1(blockHash) >>= { transactionOpt =>
       transactionOpt.fold {
         for {
           defNew <- Deferred[F, TransactionResponse]

--- a/rspace/src/it/scala/coop/rchain/rspace/history/HistoryGenerativeSpec.scala
+++ b/rspace/src/it/scala/coop/rchain/rspace/history/HistoryGenerativeSpec.scala
@@ -28,7 +28,7 @@ class HistoryGenerativeSpec
     distinctListOf(arbitraryRandomThreeBytes)
   ) { keys: List[Key] =>
     val actions             = keys.map(k => (k, TestData.randomBlake))
-    val emptyMergingHistory = HistoryInstances.merging[Task](emptyRootHash, inMemHistoryStore)
+    val emptyMergingHistory = HistoryMergingInstances.merging[Task](emptyRootHash, inMemHistoryStore)
 
     val emptySimplisticHistory: HistoryWithFind[Task] =
       SimplisticHistory.noMerging[Task](emptyRootHash, inMemHistoryStore)
@@ -75,7 +75,7 @@ class HistoryGenerativeSpec
   "process" should "accept new leafs in bulk" in forAll(distinctListOf(arbitraryRandomThreeBytes)) {
     keys: List[Key] =>
       val actions             = keys.map(k => (k, TestData.randomBlake))
-      val emptyMergingHistory = HistoryInstances.merging[Task](emptyRootHash, inMemHistoryStore)
+      val emptyMergingHistory = HistoryMergingInstances.merging[Task](emptyRootHash, inMemHistoryStore)
 
       val emptySimplisticHistory: HistoryWithFind[Task] =
         SimplisticHistory.noMerging[Task](emptyRootHash, inMemHistoryStore)

--- a/rspace/src/it/scala/coop/rchain/rspace/history/HistoryGenerativeSpec.scala
+++ b/rspace/src/it/scala/coop/rchain/rspace/history/HistoryGenerativeSpec.scala
@@ -1,4 +1,5 @@
 package coop.rchain.rspace.history
+
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
 import History._
 import coop.rchain.rspace.hashing.Blake2b256Hash
@@ -29,10 +30,10 @@ class HistoryGenerativeSpec
     val actions             = keys.map(k => (k, TestData.randomBlake))
     val emptyMergingHistory = HistoryInstances.merging[Task](emptyRootHash, inMemHistoryStore)
 
-    val emptySimplisticHistory: History[Task] =
+    val emptySimplisticHistory: HistoryWithFind[Task] =
       SimplisticHistory.noMerging[Task](emptyRootHash, inMemHistoryStore)
 
-    val emptyState = Map.empty[Key, (Data, History[Task], History[Task])] // accumulate actions performed on the trie
+    val emptyState = Map.empty[Key, (Data, HistoryWithFind[Task], HistoryWithFind[Task])] // accumulate actions performed on the trie
 
     val (resultMergingHistory, resultSimplisticHistory, map) =
       actions.foldLeft((emptyMergingHistory, emptySimplisticHistory, emptyState)) {
@@ -76,7 +77,7 @@ class HistoryGenerativeSpec
       val actions             = keys.map(k => (k, TestData.randomBlake))
       val emptyMergingHistory = HistoryInstances.merging[Task](emptyRootHash, inMemHistoryStore)
 
-      val emptySimplisticHistory: History[Task] =
+      val emptySimplisticHistory: HistoryWithFind[Task] =
         SimplisticHistory.noMerging[Task](emptyRootHash, inMemHistoryStore)
 
       val inserts                  = actions.map { case (k, v) => InsertAction(k, v) }
@@ -105,10 +106,10 @@ class HistoryGenerativeSpec
     )
 
   def insertAndVerify(
-      history: History[Task],
+      history: HistoryWithFind[Task],
       toBeProcessed: List[Data],
       pastData: List[Data]
-  ): (History[Task], List[Data]) = {
+  ): (HistoryWithFind[Task], List[Data]) = {
     val inserts      = toBeProcessed.map(v => InsertAction(v._1, v._2))
     val insertResult = runEffect(history.process(inserts))
     insertResult.root should not be history.root
@@ -129,9 +130,9 @@ class HistoryGenerativeSpec
     (insertResult, allUniqueData.toList)
   }
 
-  def fetchData(h: History[Task], data: Data): (TriePointer, Vector[Trie]) =
+  def fetchData(h: HistoryWithFind[Task], data: Data): (TriePointer, Vector[Trie]) =
     fetchData(h, data._1)
 
-  def fetchData(h: History[Task], k: Key): (TriePointer, Vector[Trie]) =
+  def fetchData(h: HistoryWithFind[Task], k: Key): (TriePointer, Vector[Trie]) =
     runEffect(h.find(k))
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/channelStore/instances/ChannelStoreImpl.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/channelStore/instances/ChannelStoreImpl.scala
@@ -55,7 +55,7 @@ object ChannelStoreImpl {
         _                <- store.put(eventKey, ContinuationHash(continuationHash))
       } yield ()
 
-    override def getChannelHash(hash: Blake2b256Hash): F[Option[ChannelHash]] = store.get(hash)
+    override def getChannelHash(hash: Blake2b256Hash): F[Option[ChannelHash]] = store.get1(hash)
 
     // Get lexical Ordering for ByteString
     implicit val bsLexicalOrdering: Ordering[ByteString] =

--- a/rspace/src/main/scala/coop/rchain/rspace/hashing/Blake2b256Hash.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/hashing/Blake2b256Hash.scala
@@ -60,6 +60,9 @@ object Blake2b256Hash {
   def create(byteVector: ByteVector): Blake2b256Hash =
     new Blake2b256Hash(ByteVector(Blake2b256.hash(byteVector)))
 
+  def fromByteVector(bytes: ByteVector): Blake2b256Hash =
+    new Blake2b256Hash(bytes)
+
   def fromHex(string: String): Blake2b256Hash =
     new Blake2b256Hash(ByteVector(Base16.unsafeDecode(string)))
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/History.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/History.scala
@@ -11,7 +11,7 @@ import scodec.bits.{BitVector, ByteVector}
   *
   * Used to extend History with old _find_ method in [[HistoryWithFind]].
   *
-  * TODO: Delete when old ("merging") [[HistoryInstances.MergingHistory]] is removed.
+  * TODO: Delete when old ("merging") [[HistoryMergingInstances.MergingHistory]] is removed.
   */
 trait HistorySelf[F[_]] {
   type HistoryF <: HistorySelf[F]
@@ -51,7 +51,7 @@ trait History[F[_]] extends HistorySelf[F] {
 /**
   * Support for old ("merging") History
   *
-  * TODO: Delete when old ("merging") [[HistoryInstances.MergingHistory]] is removed.
+  * TODO: Delete when old ("merging") [[HistoryMergingInstances.MergingHistory]] is removed.
   */
 trait HistoryWithFind[F[_]] extends History[F] {
   override type HistoryF <: HistoryWithFind[F]
@@ -64,9 +64,7 @@ trait HistoryWithFind[F[_]] extends History[F] {
 
 object History {
 
-  val emptyRoot: Trie               = EmptyTrie
-  private[this] def encodeEmptyRoot = codecTrie.encode(emptyRoot).getUnsafe.toByteVector
-  val emptyRootHash: Blake2b256Hash = Blake2b256Hash.create(encodeEmptyRoot)
+  val emptyRootHash: Blake2b256Hash = HistoryMergingInstances.emptyRootHash
 
   // this mapping is kept explicit on purpose
   @inline

--- a/rspace/src/main/scala/coop/rchain/rspace/history/History.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/History.scala
@@ -2,9 +2,7 @@ package coop.rchain.rspace.history
 
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.History._
-import coop.rchain.rspace.serializers.ScodecSerialize.{RichAttempt, _}
-import coop.rchain.shared.Base16
-import scodec.bits.{BitVector, ByteVector}
+import scodec.bits.ByteVector
 
 /**
   * Helper trait to be able to return self type for _process_ and _reset_ methods.
@@ -66,119 +64,5 @@ object History {
 
   val emptyRootHash: Blake2b256Hash = HistoryMergingInstances.emptyRootHash
 
-  // this mapping is kept explicit on purpose
-  @inline
-  private[history] def toInt(b: Byte): Int =
-    java.lang.Byte.toUnsignedInt(b)
-
-  // this mapping is kept explicit on purpose
-  @inline
-  private[history] def toByte(i: Int): Byte =
-    i.toByte
-
-  def commonPrefix(l: KeyPath, r: KeyPath): KeyPath =
-    (l.view, r.view).zipped.takeWhile { case (ll, rr) => ll == rr }.map(_._1).toSeq
-
   type KeyPath = Seq[Byte]
-}
-
-/*
- * Type definitions for Merkle Trie implementation (History)
- */
-
-sealed trait Trie
-
-sealed trait NonEmptyTrie extends Trie
-
-case object EmptyTrie extends Trie
-
-final case class Skip(affix: ByteVector, ptr: ValuePointer) extends NonEmptyTrie {
-  lazy val encoded: BitVector = codecSkip.encode(this).getUnsafe
-
-  lazy val hash: Blake2b256Hash = Blake2b256Hash.create(encoded.toByteVector)
-
-  override def toString: String =
-    s"Skip(${hash}, ${affix.toHex}\n  ${ptr})"
-}
-
-final case class PointerBlock private (toVector: Vector[TriePointer]) extends NonEmptyTrie {
-  def updated(tuples: List[(Int, TriePointer)]): PointerBlock =
-    new PointerBlock(tuples.foldLeft(toVector) { (vec, curr) =>
-      vec.updated(curr._1, curr._2)
-    })
-
-  def countNonEmpty: Int = toVector.count(_ != EmptyPointer)
-
-  lazy val encoded: BitVector = codecPointerBlock.encode(this).getUnsafe
-
-  lazy val hash: Blake2b256Hash = Blake2b256Hash.create(encoded.toByteVector)
-
-  override def toString: String = {
-    // TODO: this is difficult to visualize, maybe XML representation would be useful?
-    val pbs =
-      toVector.zipWithIndex
-        .filter { case (v, _) => v != EmptyPointer }
-        .map { case (v, n) => s"<$v, ${Base16.encode(Array(n.toByte))}>" }
-        .mkString(",\n  ")
-    s"PB(${hash}\n  $pbs)"
-  }
-}
-
-object Trie {
-
-  /**
-    * Creates hash of Merkle Trie
-    *
-    * TODO: Fix encoding to use codec for the whole [[Trie]] and not for specific inherited variant.
-    */
-  def hash(trie: Trie): Blake2b256Hash =
-    trie match {
-      case pb: PointerBlock  => pb.hash
-      case s: Skip           => s.hash
-      case _: EmptyTrie.type => History.emptyRootHash
-    }
-}
-
-object PointerBlock {
-  val length = 256
-
-  val empty: PointerBlock = new PointerBlock(Vector.fill(length)(EmptyPointer))
-
-  def apply(first: (Int, TriePointer), second: (Int, TriePointer)): PointerBlock =
-    PointerBlock.empty.updated(List(first, second))
-
-  def unapply(arg: PointerBlock): Option[Vector[TriePointer]] = Option(arg.toVector)
-}
-
-/*
- * Trie pointer definitions
- */
-
-sealed trait TriePointer
-
-sealed trait NonEmptyTriePointer extends TriePointer {
-  def hash: Blake2b256Hash
-}
-
-case object EmptyPointer extends TriePointer
-
-sealed trait ValuePointer extends NonEmptyTriePointer
-
-final case class LeafPointer(hash: Blake2b256Hash) extends ValuePointer
-
-final case class SkipPointer(hash: Blake2b256Hash) extends NonEmptyTriePointer
-
-final case class NodePointer(hash: Blake2b256Hash) extends ValuePointer
-
-/*
- * Trie path used as a helper for traversal in History implementation
- */
-
-final case class TriePath(nodes: Vector[Trie], conflicting: Option[Trie], edges: KeyPath) {
-  def append(affix: KeyPath, t: Trie): TriePath =
-    this.copy(nodes = this.nodes :+ t, edges = this.edges ++ affix)
-}
-
-object TriePath {
-  def empty: TriePath = TriePath(Vector(), None, Nil)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryMergingInstances.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryMergingInstances.scala
@@ -5,8 +5,14 @@ import cats.syntax.all._
 import cats.{Applicative, FlatMap, Parallel}
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.History._
-import coop.rchain.rspace.serializers.ScodecSerialize.{codecTrie, RichAttempt}
-import scodec.bits.ByteVector
+import coop.rchain.rspace.serializers.ScodecSerialize.{
+  codecPointerBlock,
+  codecSkip,
+  codecTrie,
+  RichAttempt
+}
+import coop.rchain.shared.Base16
+import scodec.bits.{BitVector, ByteVector}
 
 import scala.Function.tupled
 import scala.Ordering.Implicits.seqDerivedOrdering
@@ -23,6 +29,19 @@ object HistoryMergingInstances {
   val emptyRoot: Trie               = EmptyTrie
   private[this] def encodeEmptyRoot = codecTrie.encode(emptyRoot).getUnsafe.toByteVector
   val emptyRootHash: Blake2b256Hash = Blake2b256Hash.create(encodeEmptyRoot)
+
+  // this mapping is kept explicit on purpose
+  @inline
+  private[history] def toInt(b: Byte): Int =
+    java.lang.Byte.toUnsignedInt(b)
+
+  // this mapping is kept explicit on purpose
+  @inline
+  private[history] def toByte(i: Int): Byte =
+    i.toByte
+
+  def commonPrefix(l: KeyPath, r: KeyPath): KeyPath =
+    (l.view, r.view).zipped.takeWhile { case (ll, rr) => ll == rr }.map(_._1).toSeq
 
   final case class MergingHistory[F[_]: Parallel: Concurrent: Sync](
       root: Blake2b256Hash,
@@ -651,4 +670,105 @@ object HistoryMergingInstances {
     }
 
   }
+}
+
+/*
+ * Type definitions for Merkle Trie implementation (History)
+ */
+
+sealed trait Trie
+
+sealed trait NonEmptyTrie extends Trie
+
+case object EmptyTrie extends Trie
+
+final case class Skip(affix: ByteVector, ptr: ValuePointer) extends NonEmptyTrie {
+  lazy val encoded: BitVector = codecSkip.encode(this).getUnsafe
+
+  lazy val hash: Blake2b256Hash = Blake2b256Hash.create(encoded.toByteVector)
+
+  override def toString: String =
+    s"Skip(${hash}, ${affix.toHex}\n  ${ptr})"
+}
+
+final case class PointerBlock private (toVector: Vector[TriePointer]) extends NonEmptyTrie {
+  def updated(tuples: List[(Int, TriePointer)]): PointerBlock =
+    new PointerBlock(tuples.foldLeft(toVector) { (vec, curr) =>
+      vec.updated(curr._1, curr._2)
+    })
+
+  def countNonEmpty: Int = toVector.count(_ != EmptyPointer)
+
+  lazy val encoded: BitVector = codecPointerBlock.encode(this).getUnsafe
+
+  lazy val hash: Blake2b256Hash = Blake2b256Hash.create(encoded.toByteVector)
+
+  override def toString: String = {
+    // TODO: this is difficult to visualize, maybe XML representation would be useful?
+    val pbs =
+      toVector.zipWithIndex
+        .filter { case (v, _) => v != EmptyPointer }
+        .map { case (v, n) => s"<$v, ${Base16.encode(Array(n.toByte))}>" }
+        .mkString(",\n  ")
+    s"PB(${hash}\n  $pbs)"
+  }
+}
+
+object Trie {
+
+  /**
+    * Creates hash of Merkle Trie
+    *
+    * TODO: Fix encoding to use codec for the whole [[Trie]] and not for specific inherited variant.
+    */
+  def hash(trie: Trie): Blake2b256Hash =
+    trie match {
+      case pb: PointerBlock  => pb.hash
+      case s: Skip           => s.hash
+      case _: EmptyTrie.type => HistoryMergingInstances.emptyRootHash
+    }
+}
+
+object PointerBlock {
+  val length = 256
+
+  val empty: PointerBlock = new PointerBlock(Vector.fill(length)(EmptyPointer))
+
+  def apply(first: (Int, TriePointer), second: (Int, TriePointer)): PointerBlock =
+    PointerBlock.empty.updated(List(first, second))
+
+  def unapply(arg: PointerBlock): Option[Vector[TriePointer]] = Option(arg.toVector)
+}
+
+/*
+ * Trie pointer definitions
+ */
+
+sealed trait TriePointer
+
+sealed trait NonEmptyTriePointer extends TriePointer {
+  def hash: Blake2b256Hash
+}
+
+case object EmptyPointer extends TriePointer
+
+sealed trait ValuePointer extends NonEmptyTriePointer
+
+final case class LeafPointer(hash: Blake2b256Hash) extends ValuePointer
+
+final case class SkipPointer(hash: Blake2b256Hash) extends NonEmptyTriePointer
+
+final case class NodePointer(hash: Blake2b256Hash) extends ValuePointer
+
+/*
+ * Trie path used as a helper for traversal in History implementation
+ */
+
+final case class TriePath(nodes: Vector[Trie], conflicting: Option[Trie], edges: KeyPath) {
+  def append(affix: KeyPath, t: Trie): TriePath =
+    this.copy(nodes = this.nodes :+ t, edges = this.edges ++ affix)
+}
+
+object TriePath {
+  def empty: TriePath = TriePath(Vector(), None, Nil)
 }

--- a/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepository.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/HistoryRepository.scala
@@ -72,7 +72,7 @@ object HistoryRepositoryInstances {
       currentRoot <- rootsRepository.currentRoot()
       // History store
       historyStore = HistoryStoreInstances.historyStore[F](historyKeyValueStore)
-      history      = HistoryInstances.merging(currentRoot, historyStore)
+      history      = HistoryMergingInstances.merging(currentRoot, historyStore)
       // Cold store
       coldStore = ColdStoreInstances.coldStore[F](coldKeyValueStore)
       // RSpace importer/exporter / directly operates on Store (lmdb)

--- a/rspace/src/main/scala/coop/rchain/rspace/history/instances/RSpaceHistoryReaderImpl.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/instances/RSpaceHistoryReaderImpl.scala
@@ -59,14 +59,9 @@ class RSpaceHistoryReaderImpl[F[_]: Concurrent, C, P, A, K](
   def fetchData(
       key: Blake2b256Hash
   ): F[Option[PersistedData]] =
-    targetHistory.find(key.bytes.toSeq.toList).flatMap {
-      case (trie, _) =>
-        trie match {
-          case LeafPointer(dataHash) => leafStore.get(dataHash)
-          case EmptyPointer          => none[PersistedData].pure[F]
-          case _                     => new RuntimeException(s"unexpected data at key $key, data: $trie").raiseError
-        }
-    }
+    targetHistory
+      .read(key.bytes)
+      .flatMap(_.map(Blake2b256Hash.fromByteVector).flatTraverse(leafStore.get1))
 
   override def base: HistoryReaderBase[F, C, P, A, K] = {
     val historyReader = this

--- a/rspace/src/test/scala/coop/rchain/rspace/history/CachingHistorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/CachingHistorySpec.scala
@@ -1,13 +1,9 @@
 package coop.rchain.rspace.history
 
-import cats.implicits.catsSyntaxApplicativeId
-import coop.rchain.rspace.history.HistoryInstances.{CachingHistoryStore, MergingHistory}
+import coop.rchain.rspace.history.HistoryMergingInstances.{CachingHistoryStore, MergingHistory}
 import coop.rchain.rspace.history.TestData._
 import monix.eval.Task
-import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Matchers, OptionValues}
-
-import scala.concurrent.duration._
 
 class CachingHistorySpec
     extends FlatSpec

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
@@ -44,7 +44,7 @@ class LMDBHistoryRepositoryGenerativeSpec
       rootRepository     = new RootRepository[Task](rootsStore)
       channelKVStore     <- kvm.store("channels")
       channelStore       = ChannelStoreImpl(channelKVStore, stringSerialize)
-      emptyHistory       = HistoryInstances.merging(History.emptyRootHash, historyStore)
+      emptyHistory       = HistoryMergingInstances.merging(History.emptyRootHash, historyStore)
       exporter           = RSpaceExporterStore[Task](historyLmdbKVStore, coldLmdbKVStore, rootsLmdbKVStore)
       importer           = RSpaceImporterStore[Task](historyLmdbKVStore, coldLmdbKVStore, rootsLmdbKVStore)
       repository: HistoryRepository[Task, String, Pattern, String, StringsCaptor] = HistoryRepositoryImpl
@@ -73,7 +73,7 @@ class InmemHistoryRepositoryGenerativeSpec
 
   override def repo: Task[HistoryRepository[Task, String, Pattern, String, StringsCaptor]] = {
     val emptyHistory =
-      HistoryInstances.merging[Task](History.emptyRootHash, inMemHistoryStore)
+      HistoryMergingInstances.merging[Task](History.emptyRootHash, inMemHistoryStore)
     implicit val log: Log[Task]   = new Log.NOPLog[Task]
     implicit val span: Span[Task] = new NoopSpan[Task]
     val kvm                       = InMemoryStoreManager[Task]

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
@@ -175,7 +175,8 @@ class HistoryRepositorySpec
     Datum[String]("data-" + s, false, Produce(randomBlake, randomBlake, false))
 
   protected def withEmptyRepository(f: TestHistoryRepository => Task[Unit]): Unit = {
-    val emptyHistory              = HistoryInstances.merging[Task](History.emptyRootHash, inMemHistoryStore)
+    val emptyHistory =
+      HistoryMergingInstances.merging[Task](History.emptyRootHash, inMemHistoryStore)
     val pastRoots                 = rootRepository
     implicit val log: Log[Task]   = new NOPLog()
     implicit val span: Span[Task] = new NoopSpan[Task]()

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistorySpec.scala
@@ -186,7 +186,7 @@ class HistorySpec extends FlatSpec with Matchers with OptionValues with InMemory
         _ <- (1 to 10).toList.foldLeftM[
               Task,
               (
-                  History[Task],
+                  HistoryWithFind[Task],
                   List[InsertAction],
                   TrieMap[KeyPath, Blake2b256Hash]
               )
@@ -229,7 +229,7 @@ class HistorySpec extends FlatSpec with Matchers with OptionValues with InMemory
       } yield ()
   }
 
-  protected def withEmptyTrie(f: History[Task] => Task[Unit]): Unit = {
+  protected def withEmptyTrie(f: HistoryWithFind[Task] => Task[Unit]): Unit = {
     val emptyHistory =
       HistoryInstances.merging[Task](History.emptyRootHash, inMemHistoryStore)
     f(emptyHistory).runSyncUnsafe(20.seconds)

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistorySpec.scala
@@ -231,7 +231,7 @@ class HistorySpec extends FlatSpec with Matchers with OptionValues with InMemory
 
   protected def withEmptyTrie(f: HistoryWithFind[Task] => Task[Unit]): Unit = {
     val emptyHistory =
-      HistoryInstances.merging[Task](History.emptyRootHash, inMemHistoryStore)
+      HistoryMergingInstances.merging[Task](History.emptyRootHash, inMemHistoryStore)
     f(emptyHistory).runSyncUnsafe(20.seconds)
   }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/history/SimplisticHistory.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/SimplisticHistory.scala
@@ -4,8 +4,13 @@ import cats.effect.Sync
 import cats.syntax.all._
 import cats.{Applicative, FlatMap}
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.history.History.{commonPrefix, toByte, toInt, KeyPath}
-import coop.rchain.rspace.history.HistoryMergingInstances.MalformedTrieError
+import coop.rchain.rspace.history.History.KeyPath
+import coop.rchain.rspace.history.HistoryMergingInstances.{
+  commonPrefix,
+  toByte,
+  toInt,
+  MalformedTrieError
+}
 import scodec.bits.ByteVector
 
 import scala.Ordering.Implicits.seqDerivedOrdering

--- a/rspace/src/test/scala/coop/rchain/rspace/history/SimplisticHistory.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/SimplisticHistory.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 import cats.{Applicative, FlatMap}
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.History.{commonPrefix, toByte, toInt, KeyPath}
-import coop.rchain.rspace.history.HistoryInstances.MalformedTrieError
+import coop.rchain.rspace.history.HistoryMergingInstances.MalformedTrieError
 import scodec.bits.ByteVector
 
 import scala.Ordering.Implicits.seqDerivedOrdering

--- a/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreSyntax.scala
+++ b/shared/src/main/scala/coop/rchain/store/KeyValueTypedStoreSyntax.scala
@@ -17,7 +17,7 @@ final class KeyValueTypedStoreOps[F[_], K, V](
   def errKVStoreExpectValue(hash: String) =
     s"Error when unsafe reading from KeyValueStore: value for key ${hash} not found."
 
-  def get(key: K)(implicit f: Functor[F]): F[Option[V]] = store.get(Seq(key)).map(_.head)
+  def get1(key: K)(implicit f: Functor[F]): F[Option[V]] = store.get(Seq(key)).map(_.head)
 
   def getUnsafeBatch(keys: Seq[K])(implicit f: Sync[F], show: Show[K]): F[List[V]] =
     store
@@ -27,7 +27,7 @@ final class KeyValueTypedStoreOps[F[_], K, V](
       })
 
   def getUnsafe(key: K)(implicit f: Sync[F], show: Show[K]): F[V] =
-    get(key).flatMap(_.liftTo[F](new Exception(errKVStoreExpectValue(key.show))))
+    get1(key).flatMap(_.liftTo[F](new Exception(errKVStoreExpectValue(key.show))))
 
   def put(key: K, value: V): F[Unit] = store.put(Seq((key, value)))
 
@@ -44,5 +44,5 @@ final class KeyValueTypedStoreOps[F[_], K, V](
   def contains(key: K)(implicit f: Functor[F]): F[Boolean] = store.contains(Seq(key)).map(_.head)
 
   def getOrElse(key: K, elseValue: V)(implicit f: Functor[F]): F[V] =
-    get(key).map(_.getOrElse(elseValue))
+    get1(key).map(_.getOrElse(elseValue))
 }


### PR DESCRIPTION
## Overview

This PR prepares existing "merging" history implementation for update with a new radix history. Common changes are extracted to be applied to dev branch to minimize changes on feature/radix-history branch.

Main change is to separate _find_ method on History trait which returns internal structure of existing "merging" history which is not used in the new history.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
