### PR TITLE
CLI to getDataAtPar via gRPC node client

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -61,6 +61,17 @@ object DeployRuntime {
       }.map(kp("")).value
     }
 
+  def getDataAtPar[F[_]: Sync: DeployService](
+      par: Par,
+      blockHash: String,
+      usePreStateHash: Boolean
+  ): F[Unit] =
+    gracefulExit {
+      EitherT(
+        DeployService[F].getDataAtPar(DataAtNameByBlockQuery(par, blockHash, usePreStateHash))
+      ).map(kp("")).value
+    }
+
   def findDeploy[F[_]: Functor: Sync: Time: DeployService](
       deployId: Array[Byte]
   ): F[Unit] =

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/ListenAtPar.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/ListenAtPar.scala
@@ -1,0 +1,28 @@
+package coop.rchain.casper.util.comm
+
+import coop.rchain.models.GUnforgeable.UnfInstance.{GDeployIdBody, GDeployerIdBody, GPrivateBody}
+import coop.rchain.models.syntax.modelsSyntaxString
+import coop.rchain.models.{GDeployId, GDeployerId, GPrivate, GUnforgeable, Par}
+
+object ListenAtPar {
+  sealed trait Name
+  final case class UnforgPrivate(data: String)  extends Name
+  final case class UnforgDeploy(data: String)   extends Name
+  final case class UnforgDeployer(data: String) extends Name
+
+  def create(name: String, data: String): Option[Name] =
+    name match {
+      case "UnforgPrivate"  => Some(UnforgPrivate(data))
+      case "UnforgDeploy"   => Some(UnforgDeploy(data))
+      case "UnforgDeployer" => Some(UnforgDeployer(data))
+      case _                => None
+    }
+
+  def toPar(name: Name): Par = Par(unforgeables = Seq(GUnforgeable(unforgToUnforgProto(name))))
+
+  private def unforgToUnforgProto(name: Name): GUnforgeable.UnfInstance = name match {
+    case UnforgPrivate(data)  => GPrivateBody(GPrivate(data.unsafeHexToByteString))
+    case UnforgDeploy(data)   => GDeployIdBody(GDeployId(data.unsafeHexToByteString))
+    case UnforgDeployer(data) => GDeployerIdBody(GDeployerId(data.unsafeHexToByteString))
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -2,6 +2,7 @@ package coop.rchain.node.configuration
 
 import coop.rchain.casper.CasperConf
 import coop.rchain.casper.util.comm.ListenAtName.Name
+import coop.rchain.casper.util.comm.ListenAtPar
 import coop.rchain.comm.PeerNode
 import coop.rchain.comm.transport.TlsConf
 import coop.rchain.crypto.{PrivateKey, PublicKey}
@@ -122,4 +123,6 @@ final case class BondStatus(publicKey: PublicKey)                          exten
 final case object Help                                                     extends Command
 final case class DataAtName(name: Name)                                    extends Command
 final case class ContAtName(names: List[Name])                             extends Command
-final case object Status                                                   extends Command
+final case class DataAtPar(name: ListenAtPar.Name, blockHash: String, usePreStateHash: Boolean)
+    extends Command
+final case object Status extends Command


### PR DESCRIPTION
## Overview

One node, which is a gRPC client, can receive data from the validator node using the CLI. Example of call

```shell
./rnode data-at-par --block-hash <BLOCK_HASH_STRING> --content <CONTENT> --type <TYPE> --use-pre-state-hash
```
Where

* `<BLOCK_HASH_STRING>` - a hash string of block. Can be got from the output of `propose` command.
* `<CONTENT>` - the content of the command. For example, it is deploy signature string for deploys.
* `<TYPE>` - type of command. Can be one of UnforgPrivate, UnforgDeploy, UnforgDeployer.
* `--use-pre-state-hash` - flag that gives ability to query data on pre-state of the block 

### Notes

* Deploy should be done with such Rholang code
```
new return(`rho:rchain:deployId`) in { return!("data-at-par") }
```
* For now, the solution doesn't print any results to the console. This code produces the empty string. This is done in a similar way to the `listenForDataAtName` and `listenForContinuationAtName` methods. 
https://github.com/rchain/rchain/blob/b1b5fd2357983ca8863b95faa4dad3e1d6870045/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala#L69

* Please be noticed of CLI params descriptions.



### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
