### PR TITLE
Fringe processor to check fringes consistency on each finalization step

### DIFF
--- a/node/src/test/scala/coop/rchain/finalization/FinalizationSpec.scala
+++ b/node/src/test/scala/coop/rchain/finalization/FinalizationSpec.scala
@@ -7,7 +7,7 @@ import cats.{Applicative, Foldable, Monad}
 import coop.rchain.casper.api.GraphzGenerator.{DagInfo, ValidatorsBlocks}
 import coop.rchain.casper.api.ValidatorBlock
 import coop.rchain.graphz._
-import coop.rchain.casper.pcasper.sim.Simulation._
+import coop.rchain.casper.sim.Simulation._
 import monix.eval.Task
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/shared/src/main/scala/coop/rchain/casper/pcasper/sim/Simulation.scala
+++ b/shared/src/main/scala/coop/rchain/casper/pcasper/sim/Simulation.scala
@@ -411,18 +411,11 @@ object Simulation {
         .getOrElse(sender -> Vector(fringe))
 
       // Check if new fringe is consistent with existing fringes
+      val newFringeIndex       = newFringes(sender).length - 1
+      val fringesWithSameIndex = newFringes.values.flatMap(_.lift(newFringeIndex))
 
-      // intersectingFringes is a sequence of messages which each sender has
-      // Example:
-      //  Sender1: [0 - 1 - 2] - 3 - 4
-      //  Sender2: [0 - 1 - 2]
-      //  Sender3: [0 - 1 - 2] - 3
-      val minFringeLength     = newFringes.values.map(_.length).min
-      val intersectingFringes = newFringes.values.map(_.take(minFringeLength))
-
-      // All intersecting fringes must be the same
       assert(
-        intersectingFringes.forall(_ == intersectingFringes.head),
+        fringesWithSameIndex.forall(_ == fringesWithSameIndex.head),
         "Fringes of senders are not equals"
       )
 

--- a/shared/src/main/scala/coop/rchain/casper/pcasper/sim/Simulation.scala
+++ b/shared/src/main/scala/coop/rchain/casper/pcasper/sim/Simulation.scala
@@ -416,10 +416,22 @@ object Simulation {
 
       assert(
         fringesWithSameIndex.forall(_ == fringesWithSameIndex.head),
-        "Fringes of senders are not equals"
+        s"Fringes of senders are not equals. The current state is:\n${dump(newFringes)}"
       )
 
       FringeProcessor(newFringes)
     }
+    private def dump(fringesState: Map[Sender, Vector[Set[Msg]]]): String =
+      fringesState
+        .map {
+          case (sender, vec) =>
+            val senderFringesStr = vec.zipWithIndex
+              .map {
+                case (fringe, index) => s" $index: ${fringe.map(_.id).mkString(", ")}"
+              }
+              .mkString("\n")
+            s"Sender ${sender.id}\n$senderFringesStr"
+        }
+        .mkString("\n")
   }
 }

--- a/shared/src/main/scala/coop/rchain/casper/sim/Simulation.scala
+++ b/shared/src/main/scala/coop/rchain/casper/sim/Simulation.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper.pcasper.sim
+package coop.rchain.casper.sim
 
 import cats.effect.concurrent.Ref
 import cats.syntax.all._


### PR DESCRIPTION
## Overview
Check is performed at each finalization step. If a check is not correct (fringes differ) assert with a detailed dump is performed. Already checked fringes removed to reduce storage space which is useful in infinite tests.

### Notes
This code has a smell. It can be written better?
https://github.com/rchain/rchain/blob/812ed5fe6b240b2ef77177fec9bcbacda0048134/shared/src/main/scala/coop/rchain/casper/pcasper/sim/Simulation.scala#L194-L197

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
