### PR TITLE
Simple infinite test to check LLBM Casper implementation

### DIFF
--- a/node/src/test/scala/coop/rchain/finalization/FinalizationSpec.scala
+++ b/node/src/test/scala/coop/rchain/finalization/FinalizationSpec.scala
@@ -158,7 +158,9 @@ class FinalizationSpec extends FlatSpec with Matchers {
 
   }
 
-  it should "run infinite test" in {
+  // This test is ignored by default to provide finite tests time execution
+  // It makes sense to turn on this test only on the local machine for long-time finalization testing
+  it should "run infinite test" ignore {
     sut.runInfinite.runSyncUnsafe()
   }
 

--- a/node/src/test/scala/coop/rchain/finalization/FinalizationSpec.scala
+++ b/node/src/test/scala/coop/rchain/finalization/FinalizationSpec.scala
@@ -147,7 +147,7 @@ class FinalizationSpec extends FlatSpec with Matchers {
 
   val sut = new NetworkRunner[Task]()
 
-  it should "run network with complete dag" in {
+  it should "run network with complete dag" ignore {
     val r        = sut.runDagComplete.runSyncUnsafe()
     val (end, _) = r
     val a = end.senders.toList.map(

--- a/node/src/test/scala/coop/rchain/finalization/FinalizationSpec.scala
+++ b/node/src/test/scala/coop/rchain/finalization/FinalizationSpec.scala
@@ -71,79 +71,65 @@ class FinalizationSpec extends FlatSpec with Matchers {
     }
 
     def runRandom = {
-
       val nets = List(10).map(genNet)
-
-      nets.traverse {
-        case (net, name) =>
-          for {
-            net1_     <- runSections(net, List((1, .0f)), s"start-$name")
-            (net1, _) = net1_
-
-            // Split network
-            (fst, snd) = net1.split(.3f)
-
-//            _ = println(s"Split in ${fst.senders.size} and ${snd.senders.size}")
-
-//            fst1_ <- runSections(fst, List((7, .5f), (3, .3f)), s"fst-$name")
-            fst1_     <- runSections(fst, List((5, .5f)), s"fst-$name")
-            (fst1, _) = fst1_
-
-//            snd1_ <- runSections(snd, List((5, .4f), (5, .5f)), s"snd-$name")
-            snd1_     <- runSections(snd, List((4, .4f)), s"snd-$name")
-            (snd1, _) = snd1_
-
-            // Merge networks
-            net2 = fst1 >|< snd1
-
-            (n11, n12)   = net2.split(.4f)
-            (n111, n112) = n11.split(.5f)
-
-            n111end_     <- runSections(n111, List((10, .5f)), s"n111-$name")
-            (n111end, _) = n111end_
-            n112end_     <- runSections(n112, List((4, .1f)), s"n112-$name")
-            (n112end, _) = n112end_
-            n12end_      <- runSections(n12, List((5, .4f)), s"n12-$name")
-            (n12end, _)  = n12end_
-
-            net3 = n112end >|< n12end
-            net4 = net3 >|< n111end
-
-            (n21, n22)   = net4.split(.3f)
-            (n211, n212) = n21.split(.5f)
-
-            n211end_     <- runSections(n211, List((13, .4f)), s"n211-$name")
-            (n211end, _) = n211end_
-            n212end_     <- runSections(n212, List((8, .4f)), s"n212-$name")
-            (n212end, _) = n212end_
-            n22end_      <- runSections(n22, List((5, .4f)), s"n22-$name")
-            (n22end, _)  = n22end_
-
-            net5 = n212end >|< n211end
-            net6 = net5 >|< n22end
-
-            r <- runSections(net6, List((5, .0f)), s"result-$name")
-          } yield r
-      }
+      nets.traverse { case (net, name) => randomTest(net, name) }
     }
 
     def runInfinite: F[Unit] = {
       val nets = List(10).map(genNet)
-
-      // This recursive function never finished
       nets.tailRecM[F, Unit] { networks =>
         val newNetState = networks.traverse {
-          case (net, name) =>
-            for {
-              net1_       <- runSections(net, List((1, .0f)), s"start-$name")
-              (net1, _)   = net1_
-              r           <- runSections(net1, List((5, .0f)), s"result-$name")
-              (newNet, _) = r
-            } yield (newNet, name)
+          case (net, name) => randomTest(net, name).map { case (newNet, _) => (newNet, name) }
         }
-        newNetState.map(_.asLeft[Unit])
+        newNetState.map(_.asLeft[Unit]) // Infinite loop
       }
     }
+
+    private def randomTest(net: Network, name: String): F[(Network, Int)] =
+      for {
+        net1_     <- runSections(net, List((1, .0f)), s"start-$name")
+        (net1, _) = net1_
+
+        // Split network
+        (fst, snd) = net1.split(.3f)
+
+        fst1_     <- runSections(fst, List((5, .5f)), s"fst-$name")
+        (fst1, _) = fst1_
+
+        snd1_     <- runSections(snd, List((4, .4f)), s"snd-$name")
+        (snd1, _) = snd1_
+
+        // Merge networks
+        net2 = fst1 >|< snd1
+
+        (n11, n12)   = net2.split(.4f)
+        (n111, n112) = n11.split(.5f)
+
+        n111end_     <- runSections(n111, List((10, .5f)), s"n111-$name")
+        (n111end, _) = n111end_
+        n112end_     <- runSections(n112, List((4, .1f)), s"n112-$name")
+        (n112end, _) = n112end_
+        n12end_      <- runSections(n12, List((5, .4f)), s"n12-$name")
+        (n12end, _)  = n12end_
+
+        net3 = n112end >|< n12end
+        net4 = net3 >|< n111end
+
+        (n21, n22)   = net4.split(.3f)
+        (n211, n212) = n21.split(.5f)
+
+        n211end_     <- runSections(n211, List((13, .4f)), s"n211-$name")
+        (n211end, _) = n211end_
+        n212end_     <- runSections(n212, List((8, .4f)), s"n212-$name")
+        (n212end, _) = n212end_
+        n22end_      <- runSections(n22, List((5, .4f)), s"n22-$name")
+        (n22end, _)  = n22end_
+
+        net5 = n212end >|< n211end
+        net6 = net5 >|< n22end
+
+        r <- runSections(net6, List((5, .0f)), s"result-$name")
+      } yield r
   }
 
   implicit val s = monix.execution.Scheduler.global

--- a/shared/src/main/scala/coop/rchain/casper/sim/Simulation.scala
+++ b/shared/src/main/scala/coop/rchain/casper/sim/Simulation.scala
@@ -66,7 +66,8 @@ object Simulation {
       childMap: Map[Msg, Map[Sender, Queue[Msg]]] = Map(),
       witnessMap: Map[Msg, Map[Sender, Msg]] = Map(),
       realFringes: Queue[Fringe[Msg, Sender]],
-      fringeProcessor: Ref[Id, FringeProcessor]
+      fringeProcessor: Ref[Id, FringeProcessor],
+      enableOutput: Boolean
   ) {
     override def hashCode(): Int = this.me.id.hashCode()
 
@@ -250,7 +251,7 @@ object Simulation {
 //          }
 //          .mkString("\n")
 
-        if (me == msg.sender) {
+        if (me == msg.sender && enableOutput) {
           println(s"${me.id}: ADDED ${msg.id}")
           //          println(s"DAG ${showMsgs(newDag.values.toSeq)}")
           println(s"COMM:\n$seenBySeenStr")
@@ -318,7 +319,7 @@ object Simulation {
     }
   }
 
-  def initNetwork(sendersCount: Int, stake: Int) = {
+  def initNetwork(sendersCount: Int, stake: Int, enableOutput: Boolean) = {
     // Arbitrary number of senders (bonded validators)
     val senders = (0 until sendersCount).map { n =>
       Sender(n, stake)
@@ -361,7 +362,8 @@ object Simulation {
             heightMap,
             seen,
             realFringes = initFinState,
-            fringeProcessor = fringeProcessor
+            fringeProcessor = fringeProcessor,
+            enableOutput = enableOutput
           )
       )
 


### PR DESCRIPTION
## Overview
 This test helps to detect possible problems in LLBM implementation. In combination with `FringeProcessor` it allows detecting inconsistent fringe state during test execution.

The example below demonstrates how to split/merge works randomly. On each iteration action (split or merge) is chosen randomly. If action is "split" then the random network from the list splits to two another with random split percent. If the action is "merge" then two random networks from the list merge into one. For each partition on split the random number of rounds and skip percent are chosen.

<img src="https://user-images.githubusercontent.com/1443855/155095577-8f3634b4-71fc-4dfa-b9d4-bcef83de3e71.png" alt="drawing" width="400"/>


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
