### PR TITLE
Update dependencies (cats, fs2, https4s)

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -493,15 +493,15 @@ object TestNode {
     implicit val spanEff   = new NoopSpan[F]
     for {
       newStorageDir       <- Resources.copyStorage[F](storageDir)
-      kvm                 <- Resource.liftF(Resources.mkTestRNodeStoreManager(newStorageDir))
-      blockStore          <- Resource.liftF(KeyValueBlockStore(kvm))
-      blockDagStorage     <- Resource.liftF(BlockDagKeyValueStorage.create(kvm))
-      deployStorage       <- Resource.liftF(KeyValueDeployStorage[F](kvm))
-      casperBufferStorage <- Resource.liftF(CasperBufferKeyValueStorage.create[F](kvm))
-      rSpaceStore         <- Resource.liftF(kvm.rSpaceStores)
-      runtimeManager      <- Resource.liftF(RuntimeManager(rSpaceStore))
+      kvm                 <- Resource.eval(Resources.mkTestRNodeStoreManager(newStorageDir))
+      blockStore          <- Resource.eval(KeyValueBlockStore(kvm))
+      blockDagStorage     <- Resource.eval(BlockDagKeyValueStorage.create(kvm))
+      deployStorage       <- Resource.eval(KeyValueDeployStorage[F](kvm))
+      casperBufferStorage <- Resource.eval(CasperBufferKeyValueStorage.create[F](kvm))
+      rSpaceStore         <- Resource.eval(kvm.rSpaceStores)
+      runtimeManager      <- Resource.eval(RuntimeManager(rSpaceStore))
 
-      node <- Resource.liftF({
+      node <- Resource.eval({
                implicit val bs                         = blockStore
                implicit val bds                        = blockDagStorage
                implicit val ds                         = deployStorage

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
@@ -29,8 +29,8 @@ class MergingCases extends FlatSpec with Matchers {
 
   val runtimeManagerResource: Resource[Task, RuntimeManager[Task]] = for {
     dir <- Resources.copyStorage[Task](genesisContext.storageDirectory)
-    kvm <- Resource.liftF(Resources.mkTestRNodeStoreManager[Task](dir))
-    rm  <- Resource.liftF(Resources.mkRuntimeManagerAt[Task](kvm))
+    kvm <- Resource.eval(Resources.mkTestRNodeStoreManager[Task](dir))
+    rm  <- Resource.eval(Resources.mkRuntimeManagerAt[Task](kvm))
   } yield rm
 
   /**

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
@@ -470,7 +470,7 @@ object NodeRuntime {
           fa: TaskEnv[A],
           fb: TaskEnv[B]
       ): TaskEnv[Either[(A, Fiber[TaskEnv, B]), (Fiber[TaskEnv, A], B)]] = c.racePair(fa, fb)
-      override def suspend[A](thunk: => TaskEnv[A]): TaskEnv[A]          = c.suspend(thunk)
+      override def suspend[A](thunk: => TaskEnv[A]): TaskEnv[A]          = c.defer(thunk)
       override def bracketCase[A, B](acquire: TaskEnv[A])(use: A => TaskEnv[B])(
           release: (A, ExitCase[Throwable]) => TaskEnv[Unit]
       ): TaskEnv[B]                                        = c.bracketCase(acquire)(use)(release)

--- a/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
@@ -37,8 +37,8 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
 
   val runtimeManagerResource: Resource[Task, RuntimeManager[Task]] = for {
     dir <- Resources.copyStorage[Task](genesisContext.storageDirectory)
-    kvm <- Resource.liftF(Resources.mkTestRNodeStoreManager[Task](dir))
-    rm  <- Resource.liftF(Resources.mkRuntimeManagerAt[Task](kvm))
+    kvm <- Resource.eval(Resources.mkTestRNodeStoreManager[Task](dir))
+    rm  <- Resource.eval(Resources.mkRuntimeManagerAt[Task](kvm))
   } yield rm
 
   def makeTxAndCommitState(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,14 +4,15 @@ object Dependencies {
 
   val osClassifier: String = Detector.detect(Seq("fedora")).osClassifier
 
+  val catsVersion       = "2.7.0"
+  val catsEffectVersion = "2.5.4"
+  val catsMtlVersion    = "0.7.1"
+  val fs2Version        = "2.5.10"
+  val http4sVersion     = "0.21.24"
   val circeVersion      = "0.13.0"
   val enumeratumVersion = "1.5.13"
-  val http4sVersion     = "0.21.15"
-  val kamonVersion      = "1.1.5"
-  val catsVersion       = "2.3.1"
-  val catsEffectVersion = "2.3.1"
-  val catsMtlVersion    = "0.7.1"
-  val slf4jVersion      = "1.7.25"
+  val slf4jVersion      = "1.7.30"
+  val kamonVersion      = "1.1.6"
 
   // format: off
   val bouncyProvCastle    = "org.bouncycastle"            % "bcprov-jdk15on"            % "1.68"
@@ -30,10 +31,10 @@ object Dependencies {
   val circeGenericExtras  = "io.circe"                   %% "circe-generic-extras"      % circeVersion
   val circeLiteral        = "io.circe"                   %% "circe-literal"             % circeVersion
   val circeParser         = "io.circe"                   %% "circe-parser"              % circeVersion
-  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.1.3"
+  val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.4.0"
   val enumeratum          = "com.beachape"               %% "enumeratum"                % enumeratumVersion
-  val fs2Core             = "co.fs2"                     %% "fs2-core"                  % "2.5.0"
-  val fs2Io               = "co.fs2"                     %% "fs2-io"                    % "2.5.0"
+  val fs2Core             = "co.fs2"                     %% "fs2-core"                  % fs2Version
+  val fs2Io               = "co.fs2"                     %% "fs2-io"                    % fs2Version
   val guava               = "com.google.guava"            % "guava"                     % "30.1-jre"
   val hasher              = "com.roundeights"            %% "hasher"                    % "1.2.0"
   val http4sBlazeClient   = "org.http4s"                 %% "http4s-blaze-client"       % http4sVersion
@@ -82,7 +83,7 @@ object Dependencies {
   val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.23"
   // see https://jitpack.io/#rchain/secp256k1-java
   val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"
-  val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.3"
+  val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.8"
   val slf4j               = "org.slf4j"                   % "slf4j-api"                 % slf4jVersion
   val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.4"
   // format: on
@@ -91,15 +92,14 @@ object Dependencies {
     catsCore,
     catsEffect,
     catsLawsTest,
-    disciplineCore,
     fs2Core,
+    fs2Io,
     guava,
     scalacheck,
     scodecBits,
-    shapeless,
     // Added to resolve conflicts with kamon, cats, http4s
     slf4j,
-    "org.typelevel" % "jawn-parser_2.12" % "1.0.0",
+    "org.typelevel" % "jawn-parser_2.12" % "1.0.1",
     // Added to resolve conflicts in scalapb plugin v0.10.8
     "org.codehaus.mojo"      % "animal-sniffer-annotations" % "1.18",
     "com.google.protobuf"    % "protobuf-java"              % "3.12.0",
@@ -121,6 +121,8 @@ object Dependencies {
 
   private val kindProjector = compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 
+  // In Scala 2.13, the plugin's functionality has been included in the compiler directly under the -Ymacro-annotations flag.
+  // https://github.com/scalamacros/paradise
   private val macroParadise = compilerPlugin(
     "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
   )

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PParNormalizer.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PParNormalizer.scala
@@ -11,7 +11,7 @@ object PParNormalizer {
   def normalize[F[_]: Sync](p: PPar, input: ProcVisitInputs)(
       implicit env: Map[String, Par]
   ): F[ProcVisitOutputs] =
-    Sync[F].suspend {
+    Sync[F].defer {
       for {
         result       <- normalizeMatch[F](p.proc_1, input)
         chainedInput = input.copy(knownFree = result.knownFree, par = result.par)

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/StreamT.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/StreamT.scala
@@ -239,7 +239,7 @@ private trait StreamTSync[F[_]] extends Sync[StreamT[F, ?]] with StreamTMonadErr
     }
 
   def suspend[A](thunk: => StreamT[F, A]): StreamT[F, A] =
-    StreamT(F.suspend(thunk.next))
+    StreamT(F.defer(thunk.next))
 
 }
 

--- a/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/effect/implicits/package.scala
@@ -19,7 +19,7 @@ package object implicits {
       ): Id[Either[(A, Fiber[Id, B]), (Fiber[Id, A], B)]]                          = ???
       override def async[A](k: (Either[Throwable, A] => Unit) => Unit): Id[A]      = ???
       override def asyncF[A](k: (Either[Throwable, A] => Unit) => Id[Unit]): Id[A] = ???
-      override def suspend[A](thunk: => Id[A]): Id[A]                              = syncId.suspend(thunk)
+      override def suspend[A](thunk: => Id[A]): Id[A]                              = syncId.defer(thunk)
       override def bracketCase[A, B](acquire: Id[A])(use: A => Id[B])(
           release: (A, ExitCase[Throwable]) => Id[Unit]
       ): Id[B]                                                           = syncId.bracketCase(acquire)(use)(release)

--- a/shared/src/test/scala/coop/rchain/catscontrib/BooleanFSpec.scala
+++ b/shared/src/test/scala/coop/rchain/catscontrib/BooleanFSpec.scala
@@ -77,7 +77,7 @@ class BooleanFSpec extends FunSpec with Matchers with ToBooleanF {
     it("NOT should be eager to evaluate argument") {
       traceExecution[Id](true, true, (x, y) => {
         val _ = (~^(x), y.not)
-        true.pure
+        true.pure[Id]
       }) shouldBe (1, 1)
     }
   }


### PR DESCRIPTION
## Overview

This PR updates the core library dependencies: cats, cats effect, fs2, http4s, shapeless. Also slf4j-api, discipline-core and kamon.

These updates are preparation for WebAPI upgrade with OpenAPI schema using endpoints4s.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
