### PR TITLE
Web API v1 (with OpenAPI schema)

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/ReportingProtoTransformer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/ReportingProtoTransformer.scala
@@ -29,11 +29,11 @@ class ReportingProtoTransformer
     )
 
   override def serializeProduce(rp: RhoReportingProduce): ReportProduceProto =
-    ReportProduceProto(channel = rp.channel.some, data = rp.data.some)
+    ReportProduceProto(channel = rp.channel, data = rp.data)
 
   override def serializeComm(rcm: RhoReportingComm): ReportCommProto =
     ReportCommProto(
-      consume = serializeConsume(rcm.consume).some,
+      consume = serializeConsume(rcm.consume),
       produces = rcm.produces.map(serializeProduce).toList
     )
 

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockAPI.scala
@@ -270,7 +270,7 @@ object BlockAPI {
       for {
         data      <- runtimeManager.getData(stateHash)(sortedListeningName)
         blockInfo <- getLightBlockInfo[F](block)
-      } yield Option[DataWithBlockInfo](DataWithBlockInfo(data, Some(blockInfo)))
+      } yield Option[DataWithBlockInfo](DataWithBlockInfo(data, blockInfo))
     } else {
       none[DataWithBlockInfo].pure[F]
     }
@@ -285,11 +285,11 @@ object BlockAPI {
       for {
         continuations <- runtimeManager.getContinuation(stateHash)(sortedListeningNames)
         continuationInfos = continuations.map(
-          continuation => WaitingContinuationInfo(continuation._1, Some(continuation._2))
+          continuation => WaitingContinuationInfo(continuation._1, continuation._2)
         )
         blockInfo <- getLightBlockInfo[F](block)
       } yield Option[ContinuationsWithBlockInfo](
-        ContinuationsWithBlockInfo(continuationInfos, Some(blockInfo))
+        ContinuationsWithBlockInfo(continuationInfos, blockInfo)
       )
     } else {
       none[ContinuationsWithBlockInfo].pure[F]
@@ -598,10 +598,7 @@ object BlockAPI {
   ): BlockInfo = {
     val lightBlockInfo = constructLightBlockInfo(block, faultTolerance)
     val deploys        = block.body.deploys.map(_.toDeployInfo)
-    BlockInfo(
-      blockInfo = Some(lightBlockInfo),
-      deploys = deploys
-    )
+    BlockInfo(blockInfo = lightBlockInfo, deploys = deploys)
   }
 
   private def constructLightBlockInfo(
@@ -813,7 +810,7 @@ object BlockAPI {
         sortedPar      <- parSortable.sortMatch[F](par).map(_.term)
         runtimeManager <- casper.getRuntimeManager
         data           <- getDataWithBlockInfo(runtimeManager, sortedPar, block).map(_.get)
-      } yield (data.postBlockData, data.getBlock).asRight[Error]
+      } yield (data.postBlockData, data.block).asRight[Error]
 
     val errorMessage =
       "Could not get data at par, casper instance was not available yet."

--- a/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/comm/DeployRuntime.scala
@@ -46,7 +46,7 @@ object DeployRuntime {
   ): F[Unit] =
     gracefulExit {
       listenAtNameUntilChanges(name) { par: Par =>
-        val request = DataAtNameQuery(Int.MaxValue, Some(par))
+        val request = DataAtNameQuery(Int.MaxValue, par)
         EitherT(DeployService[F].listenForDataAtName(request))
       }.map(kp("")).value
     }

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -91,39 +91,36 @@ class BlockQueryResponseAPITest
             blockInfo.deploys should be(
               randomDeploys.map(_.toDeployInfo)
             )
-            blockInfo.blockInfo match {
-              case Some(b) =>
-                b.blockHash should be(secondBlock.blockHash.toHexString)
-                b.sender should be(secondBlock.sender.toHexString)
-                b.blockSize should be(secondBlock.toProto.serializedSize.toString)
-                b.seqNum should be(secondBlock.toProto.seqNum)
-                b.sig should be(secondBlock.sig.toHexString)
-                b.sigAlgorithm should be(secondBlock.sigAlgorithm)
-                b.shardId should be(secondBlock.toProto.shardId)
-                b.extraBytes should be(secondBlock.toProto.extraBytes)
-                b.version should be(secondBlock.header.version)
-                b.timestamp should be(secondBlock.header.timestamp)
-                b.headerExtraBytes should be(secondBlock.header.extraBytes)
-                b.parentsHashList should be(
-                  secondBlock.header.parentsHashList.map(_.toHexString)
-                )
-                b.blockNumber should be(secondBlock.body.state.blockNumber)
-                b.preStateHash should be(
-                  secondBlock.body.state.preStateHash.toHexString
-                )
-                b.postStateHash should be(
-                  secondBlock.body.state.postStateHash.toHexString
-                )
-                b.bodyExtraBytes should be(secondBlock.body.extraBytes)
-                b.bonds should be(secondBlock.body.state.bonds.map(ProtoUtil.bondToBondInfo))
-                b.blockSize should be(secondBlock.toProto.serializedSize.toString)
-                b.deployCount should be(secondBlock.body.deploys.length)
-                b.faultTolerance should be(faultTolerance)
-                b.justifications should be(
-                  secondBlock.justifications.map(ProtoUtil.justificationsToJustificationInfos)
-                )
-              case None => assert(false)
-            }
+            val b = blockInfo.blockInfo
+            b.blockHash should be(secondBlock.blockHash.toHexString)
+            b.sender should be(secondBlock.sender.toHexString)
+            b.blockSize should be(secondBlock.toProto.serializedSize.toString)
+            b.seqNum should be(secondBlock.toProto.seqNum)
+            b.sig should be(secondBlock.sig.toHexString)
+            b.sigAlgorithm should be(secondBlock.sigAlgorithm)
+            b.shardId should be(secondBlock.toProto.shardId)
+            b.extraBytes should be(secondBlock.toProto.extraBytes)
+            b.version should be(secondBlock.header.version)
+            b.timestamp should be(secondBlock.header.timestamp)
+            b.headerExtraBytes should be(secondBlock.header.extraBytes)
+            b.parentsHashList should be(
+              secondBlock.header.parentsHashList.map(_.toHexString)
+            )
+            b.blockNumber should be(secondBlock.body.state.blockNumber)
+            b.preStateHash should be(
+              secondBlock.body.state.preStateHash.toHexString
+            )
+            b.postStateHash should be(
+              secondBlock.body.state.postStateHash.toHexString
+            )
+            b.bodyExtraBytes should be(secondBlock.body.extraBytes)
+            b.bonds should be(secondBlock.body.state.bonds.map(ProtoUtil.bondToBondInfo))
+            b.blockSize should be(secondBlock.toProto.serializedSize.toString)
+            b.deployCount should be(secondBlock.body.deploys.length)
+            b.faultTolerance should be(faultTolerance)
+            b.justifications should be(
+              secondBlock.justifications.map(ProtoUtil.justificationsToJustificationInfos)
+            )
         }
       } yield ()
   }

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -176,7 +176,7 @@ class ListeningNameAPITest extends FlatSpec with Matchers with Inside {
             BindPattern(Vector(Par().copy(exprs = Vector(Expr(GInt(1))))), None, 0),
             BindPattern(Vector(Par().copy(exprs = Vector(Expr(GInt(0))))), None, 0)
           ),
-          Some(Par().copy(exprs = Vector(Expr(GInt(0)))))
+          Par().copy(exprs = Vector(Expr(GInt(0))))
         )
         listeningNameResponse1 <- BlockAPI.getListeningNameContinuationResponse[Effect](
                                    Int.MaxValue,

--- a/models/src/main/protobuf/CasperMessage.proto
+++ b/models/src/main/protobuf/CasperMessage.proto
@@ -2,6 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
+
 package casper;
 
 // If you are building for other languages "scalapb.proto"
@@ -22,17 +23,17 @@ option (scalapb.options) = {
 
 message HasBlockRequestProto {
   option (scalapb.message).extends = "CasperMessageProto";
-  bytes  hash       = 1;
+  bytes  hash = 1;
 }
 
 message HasBlockProto {
   option (scalapb.message).extends = "CasperMessageProto";
-  bytes  hash       = 1;
+  bytes  hash = 1;
 }
 
 message BlockRequestProto {
   option (scalapb.message).extends = "CasperMessageProto";
-  bytes  hash       = 1;
+  bytes  hash = 1;
 }
 
 message ForkChoiceTipRequestProto {
@@ -42,13 +43,13 @@ message ForkChoiceTipRequestProto {
 // ---------- Signing Protocol ---------
 message ApprovedBlockCandidateProto {
   option (scalapb.message).extends = "CasperMessageProto";
-  BlockMessageProto block        = 1;
-  int32        requiredSigs = 2;
+  BlockMessageProto block  = 1 [(scalapb.field).no_box = true];
+  int32 requiredSigs       = 2;
 }
 
 message UnapprovedBlockProto {
   option (scalapb.message).extends = "CasperMessageProto";
-  ApprovedBlockCandidateProto candidate = 1;
+  ApprovedBlockCandidateProto candidate = 1 [(scalapb.field).no_box = true];
   int64                       timestamp = 2;
   int64                       duration  = 3;
 }
@@ -61,25 +62,25 @@ message Signature {
 
 message BlockApprovalProto {
   option (scalapb.message).extends = "CasperMessageProto";
-  ApprovedBlockCandidateProto candidate = 1;
-  Signature              sig       = 2;
+  ApprovedBlockCandidateProto candidate = 1 [(scalapb.field).no_box = true];
+  Signature sig                         = 2 [(scalapb.field).no_box = true];
 }
 
 message ApprovedBlockProto  {
   option (scalapb.message).extends = "CasperMessageProto";
-  ApprovedBlockCandidateProto candidate = 1;
-  repeated Signature     sigs      = 2;
+  ApprovedBlockCandidateProto candidate = 1 [(scalapb.field).no_box = true];
+  repeated Signature sigs               = 2;
 }
 
 message ApprovedBlockRequestProto {
   option (scalapb.message).extends = "CasperMessageProto";
   string identifier = 1;
-  bool trimState = 2;
+  bool trimState    = 2;
 }
 
 message NoApprovedBlockAvailableProto {
   option (scalapb.message).extends = "CasperMessageProto";
-  string identifier = 1;
+  string identifier    = 1;
   string nodeIdentifer = 2;
 }
 
@@ -89,8 +90,8 @@ message NoApprovedBlockAvailableProto {
 message BlockMessageProto {
   option (scalapb.message).extends = "CasperMessageProto";
   bytes                       blockHash      = 1; // obtained by hashing the information in the header
-  HeaderProto                 header         = 2;
-  BodyProto                   body           = 3;
+  HeaderProto                 header         = 2 [(scalapb.field).no_box = true];
+  BodyProto                   body           = 3 [(scalapb.field).no_box = true];
   repeated JustificationProto justifications = 4; // map of all validators to latest blocks based on current view
   bytes                       sender         = 5; // public key of the validator that created the block
   int32                       seqNum         = 6; // number of blocks created by the validator
@@ -111,22 +112,22 @@ message BlockMetadataInternal {
   // bonds.
   option (scalapb.message).type = "coop.rchain.models.BlockMetadata";
 
-  bytes blockHash                       = 1;
-  repeated bytes parents                = 2 [(scalapb.field).collection_type="collection.immutable.List"];
-  bytes sender                          = 3;
+  bytes blockHash                            = 1;
+  repeated bytes parents                     = 2 [(scalapb.field).collection_type="collection.immutable.List"];
+  bytes sender                               = 3;
   repeated JustificationProto justifications = 4 [(scalapb.field).collection_type="collection.immutable.List"];
   repeated BondProto bonds                   = 5 [(scalapb.field).collection_type="collection.immutable.List"];
-  int64 blockNum                        = 6;
-  int32 seqNum                          = 7;
-  bool invalid                          = 8; // whether the block was marked as invalid
-  bool directlyFinalized                = 9; // whether the block has been last finalized block (LFB)
-  bool finalized                        = 10;// whether the block is finalized
+  int64 blockNum                             = 6;
+  int32 seqNum                               = 7;
+  bool invalid                               = 8; // whether the block was marked as invalid
+  bool directlyFinalized                     = 9; // whether the block has been last finalized block (LFB)
+  bool finalized                             = 10;// whether the block is finalized
 }
 
 message HeaderProto {
   repeated bytes parentsHashList = 1; //list of parent block hashes
-  int64 timestamp = 5;
-  int64 version = 6;
+  int64 timestamp  = 5;
+  int64 version    = 6;
   bytes extraBytes = 7;
 }
 
@@ -136,22 +137,22 @@ message HeaderProto {
  * **TODO**: details of signatures and payment. See RHOL-781
  */
 message DeployDataProto {
-  bytes  deployer     = 1; //public key
-  string term         = 2; //rholang source code to deploy (will be parsed into `Par`)
-  int64  timestamp    = 3; //millisecond timestamp
-  bytes  sig          = 4; //signature of (hash(term) + timestamp) using private key
-  string sigAlgorithm = 5; //name of the algorithm used to sign
-  int64 phloPrice     = 7; //phlo price
-  int64 phloLimit     = 8; //phlo limit for the deployment
+  bytes  deployer             = 1; //public key
+  string term                 = 2; //rholang source code to deploy (will be parsed into `Par`)
+  int64  timestamp            = 3; //millisecond timestamp
+  bytes  sig                  = 4; //signature of (hash(term) + timestamp) using private key
+  string sigAlgorithm         = 5; //name of the algorithm used to sign
+  int64 phloPrice             = 7; //phlo price
+  int64 phloLimit             = 8; //phlo limit for the deployment
   int64 validAfterBlockNumber = 10;
 }
 
 message ProcessedDeployProto {
-    DeployDataProto deploy = 1;
-    PCost cost = 2 ;
+    DeployDataProto deploy        = 1 [(scalapb.field).no_box = true];
+    PCost cost                    = 2 [(scalapb.field).no_box = true];
     repeated EventProto deployLog = 3; //the new terms and comm. rule reductions from this deploy
-    bool errored = 5; //true if deploy encountered a user error
-    string systemDeployError = 6;
+    bool errored                  = 5; //true if deploy encountered a user error
+    string systemDeployError      = 6;
 }
 
 message SlashSystemDeployDataProto {
@@ -170,17 +171,17 @@ message SystemDeployDataProto{
 }
 
 message ProcessedSystemDeployProto {
-    SystemDeployDataProto systemDeploy = 1;
-    repeated EventProto deployLog = 2;
-    string errorMsg = 3;
+    SystemDeployDataProto systemDeploy = 1 [(scalapb.field).no_box = true];
+    repeated EventProto deployLog      = 2;
+    string errorMsg                    = 3;
 }
 
 message BodyProto {
-  RChainStateProto              state    = 1;
-  repeated ProcessedDeployProto deploys      = 2;
+  RChainStateProto state                            = 1 [(scalapb.field).no_box = true];
+  repeated ProcessedDeployProto deploys             = 2;
   repeated ProcessedSystemDeployProto systemDeploys = 3;
-  bytes                    extraBytes   = 4;
-  repeated RejectedDeployProto rejectedDeploys = 5;
+  bytes extraBytes                                  = 4;
+  repeated RejectedDeployProto rejectedDeploys      = 5;
 }
 
 message RejectedDeployProto{
@@ -193,40 +194,40 @@ message JustificationProto {
 }
 
 message RChainStateProto {
-  bytes preStateHash = 1; //hash of the tuplespace contents before new deploys
+  bytes preStateHash  = 1; //hash of the tuplespace contents before new deploys
   bytes postStateHash = 2; //hash of the tuplespace contents after new deploys
 
   //Internals of what will be the "blessed" PoS contract
   //(which will be part of the tuplespace in the real implementation).
-  repeated BondProto bonds        = 3;
-  int64         blockNumber  = 4;
+  repeated BondProto bonds = 3;
+  int64 blockNumber        = 4;
 }
 
 message EventProto {
   oneof event_instance {
     ProduceEventProto produce = 1;
     ConsumeEventProto consume = 2;
-    CommEventProto comm = 3;
+    CommEventProto comm       = 3;
   }
 }
 
 message ProduceEventProto {
-  bytes channelsHash = 1;
-  bytes hash = 2;
-  bool persistent = 3;
+  bytes channelsHash  = 1;
+  bytes hash          = 2;
+  bool persistent     = 3;
   int32 timesRepeated = 4;
 }
 
 message ConsumeEventProto {
   repeated bytes channelsHashes = 1;
-  bytes hash = 2;
-  bool persistent = 3;
+  bytes hash                    = 2;
+  bool persistent               = 3;
 }
 
 message CommEventProto {
-  ConsumeEventProto consume = 1;
+  ConsumeEventProto consume           = 1 [(scalapb.field).no_box = true];
   repeated ProduceEventProto produces = 2;
-  repeated PeekProto peeks = 3;
+  repeated PeekProto peeks            = 3;
 }
 
 message PeekProto {

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -2,6 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
+
 package casper;
 
 import "CasperMessage.proto";
@@ -31,7 +32,7 @@ message BlockQuery {
 }
 
 message ReportQuery{
-  string hash = 1;
+  string hash      = 1;
   bool forceReplay = 2;
 }
 
@@ -41,12 +42,12 @@ message BlocksQuery {
 
 message BlocksQueryByHeight{
   int64 startBlockNumber = 1;
-  int64 endBlockNumber = 2;
+  int64 endBlockNumber   = 2;
 }
 
 message DataAtNameQuery {
   int32 depth = 1;
-  Par name = 2;
+  Par name    = 2 [(scalapb.field).no_box = true];
 }
 
 message DataAtNameByBlockQuery {
@@ -56,7 +57,7 @@ message DataAtNameByBlockQuery {
 }
 
 message ContinuationAtNameQuery {
-  int32 depth = 1;
+  int32 depth        = 1;
   repeated Par names = 2;
 }
 
@@ -70,9 +71,9 @@ message MachineVerifyQuery {
 }
 
 message PrivateNamePreviewQuery {
-  bytes  user         = 1; // public key a la DeployData
-  int64  timestamp    = 2; // millisecond timestamp
-  int32  nameQty      = 3; // how many names to preview? (max: 1024)
+  bytes  user      = 1; // public key a la DeployData
+  int64  timestamp = 2; // millisecond timestamp
+  int32  nameQty   = 3; // how many names to preview? (max: 1024)
 }
 
 message LastFinalizedBlockQuery {
@@ -87,64 +88,64 @@ message BondStatusQuery {
 }
 
 message ExploratoryDeployQuery{
-  string term = 1;
-  string blockHash = 2;
+  string term          = 1;
+  string blockHash     = 2;
   bool usePreStateHash = 3;
 }
 
 message BondInfo{
   string validator = 1;
-  int64  stake = 2;
+  int64  stake     = 2;
 }
 
 message JustificationInfo{
-  string validator = 1;
+  string validator       = 1;
   string latestBlockHash = 2;
 }
 
 message DeployInfo{
-  string deployer     = 1;
-  string term         = 2;
-  int64  timestamp    = 3;
-  string  sig         = 4;
-  string sigAlgorithm = 5;
-  int64 phloPrice     = 7;
-  int64 phloLimit     = 8;
+  string deployer             = 1;
+  string term                 = 2;
+  int64  timestamp            = 3;
+  string  sig                 = 4;
+  string sigAlgorithm         = 5;
+  int64 phloPrice             = 7;
+  int64 phloLimit             = 8;
   int64 validAfterBlockNumber = 9;
-  uint64 cost         = 10;
-  bool errored         = 11;
-  string systemDeployError = 12;
+  uint64 cost                 = 10;
+  bool errored                = 11;
+  string systemDeployError    = 12;
 }
 
 message LightBlockInfo {
   // BlockMessageProto message
-  string blockHash = 1;
-  string sender = 2;
-  int64 seqNum = 3;
-  string sig = 4;
+  string blockHash    = 1;
+  string sender       = 2;
+  int64 seqNum        = 3;
+  string sig          = 4;
   string sigAlgorithm = 5;
-  string shardId = 6;
-  bytes  extraBytes = 7;
+  string shardId      = 6;
+  bytes  extraBytes   = 7;
 
   // HeaderProto message
-  int64 version = 8;
-  int64 timestamp = 9;
-  bytes headerExtraBytes = 10;
+  int64 version                   = 8;
+  int64 timestamp                 = 9;
+  bytes headerExtraBytes          = 10;
   repeated string parentsHashList = 11;
 
   // BodyProto message
-  int64 blockNumber = 12;
-  string preStateHash = 13;
-  string postStateHash = 14;
-  bytes bodyExtraBytes = 15;
+  int64 blockNumber       = 12;
+  string preStateHash     = 13;
+  string postStateHash    = 14;
+  bytes bodyExtraBytes    = 15;
   repeated BondInfo bonds = 16;
 
   // extra
-  string blockSize = 17;
-  int32 deployCount = 18;
+  string blockSize     = 17;
+  int32 deployCount    = 18;
   float faultTolerance = 19;
 
-  repeated JustificationInfo justifications = 20;
+  repeated JustificationInfo justifications   = 20;
   repeated RejectedDeployInfo rejectedDeploys = 21;
 }
 
@@ -154,47 +155,47 @@ message RejectedDeployInfo{
 
 // For node clients, see BlockMessage for actual Casper protocol Block representation
 message BlockInfo {
-  LightBlockInfo blockInfo = 1;
+  LightBlockInfo blockInfo    = 1 [(scalapb.field).no_box = true];
   repeated DeployInfo deploys = 2;
 }
 
 message DataWithBlockInfo {
   repeated Par postBlockData = 1;
-  LightBlockInfo block = 2;
+  LightBlockInfo block       = 2 [(scalapb.field).no_box = true];
 }
 
 message ContinuationsWithBlockInfo {
   repeated WaitingContinuationInfo postBlockContinuations = 1;
-  LightBlockInfo block = 2;
+  LightBlockInfo block                                    = 2 [(scalapb.field).no_box = true];
 }
 
 message WaitingContinuationInfo {
   repeated BindPattern postBlockPatterns = 1;
-  Par postBlockContinuation = 2;
+  Par postBlockContinuation              = 2 [(scalapb.field).no_box = true];
 }
 
 
 message ReportProduceProto{
   option (scalapb.message).extends = "ReportEventProto";
 
-  Par channel = 1;
-  ListParWithRandom data = 2;
+  Par channel            = 1 [(scalapb.field).no_box = true];
+  ListParWithRandom data = 2 [(scalapb.field).no_box = true];
 }
 
 message ReportConsumeProto{
   option (scalapb.message).extends = "ReportEventProto";
 
-  repeated Par channels = 1;
-  repeated BindPattern patterns=2;
+  repeated Par channels         = 1;
+  repeated BindPattern patterns = 2;
   // disable because can not work and it is not important actually
 //  TaggedContinuation continuation=3;
-  repeated PeekProto peeks=4;
+  repeated PeekProto peeks = 4;
 }
 
 message ReportCommProto{
   option (scalapb.message).extends = "ReportEventProto";
 
-  ReportConsumeProto consume = 1;
+  ReportConsumeProto consume           = 1 [(scalapb.field).no_box = true];
   repeated ReportProduceProto produces = 2;
 }
 
@@ -202,7 +203,7 @@ message ReportProto{
   oneof report {
     ReportProduceProto produce = 1;
     ReportConsumeProto consume = 2;
-    ReportCommProto comm = 3;
+    ReportCommProto comm       = 3;
   }
 }
 
@@ -211,20 +212,20 @@ message SingleReport{
 }
 
 message DeployInfoWithEventData{
-  DeployInfo deployInfo = 1;
-  repeated SingleReport report =2;
+  DeployInfo deployInfo        = 1 [(scalapb.field).no_box = true];
+  repeated SingleReport report = 2;
 }
 
 message SystemDeployInfoWithEventData{
-  SystemDeployDataProto systemDeploy = 1;
-  repeated SingleReport report =2;
+  SystemDeployDataProto systemDeploy = 1 [(scalapb.field).no_box = true];
+  repeated SingleReport report       = 2;
 }
 
 message BlockEventInfo{
-  LightBlockInfo blockInfo = 1;
-  repeated DeployInfoWithEventData deploys= 2;
+  LightBlockInfo blockInfo                             = 1 [(scalapb.field).no_box = true];
+  repeated DeployInfoWithEventData deploys             = 2;
   repeated SystemDeployInfoWithEventData systemDeploys = 3;
-  bytes postStateHash = 4;
+  bytes postStateHash                                  = 4;
 }
 
 message Status {

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -2,6 +2,7 @@
  * The main API is `DeployService`.
  */
 syntax = "proto3";
+
 package casper.v1;
 
 import "CasperMessage.proto";

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -170,8 +170,7 @@ object DeployGrpcServiceV1 {
 
       def listenForDataAtName(request: DataAtNameQuery): Task[ListeningNameDataResponse] =
         defer(
-          BlockAPI
-            .getListeningNameDataResponse[F](request.depth, request.name.get, apiMaxBlocksLimit)
+          BlockAPI.getListeningNameDataResponse[F](request.depth, request.name, apiMaxBlocksLimit)
         ) { r =>
           import ListeningNameDataResponse.Message
           import ListeningNameDataResponse.Message._
@@ -182,20 +181,16 @@ object DeployGrpcServiceV1 {
           )
         }
 
-      def getDataAtName(
-          request: DataAtNameByBlockQuery
-      ): Task[RhoDataResponse] =
-        defer(
-          BlockAPI
-            .getDataAtPar[F](request.par, request.blockHash, request.usePreStateHash)
-        ) { r =>
-          import RhoDataResponse.Message
-          import RhoDataResponse.Message._
-          RhoDataResponse(
-            r.fold[Message](
-              Error, { case (par, block) => Payload(RhoDataPayload(par, block)) }
+      def getDataAtName(request: DataAtNameByBlockQuery): Task[RhoDataResponse] =
+        defer(BlockAPI.getDataAtPar[F](request.par, request.blockHash, request.usePreStateHash)) {
+          r =>
+            import RhoDataResponse.Message
+            import RhoDataResponse.Message._
+            RhoDataResponse(
+              r.fold[Message](
+                Error, { case (par, block) => Payload(RhoDataPayload(par, block)) }
+              )
             )
-          )
         }
 
       def listenForContinuationAtName(
@@ -274,7 +269,7 @@ object DeployGrpcServiceV1 {
           import ExploratoryDeployResponse.Message
           import ExploratoryDeployResponse.Message._
           ExploratoryDeployResponse(r.fold[Message](Error, {
-            case (par, block) => Result(DataWithBlockInfo(par, Some(block)))
+            case (par, block) => Result(DataWithBlockInfo(par, block))
           }))
         }
 

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -384,7 +384,7 @@ object WebApi {
       val exprs = data.postBlockData.flatMap(exprFromParProto)
       // Implements semantic of Par with Unit: P | Nil ==> P
       val expr  = if (exprs.size == 1) exprs.head else ExprPar(exprs.toList)
-      val block = data.block.get
+      val block = data.block
       RhoExprWithBlock(expr, block) +: acc
     }
     DataAtNameResponse(exprsWithBlock, length)

--- a/node/src/main/scala/coop/rchain/node/api/json/JsonEntitiesCirceFromSchema.scala
+++ b/node/src/main/scala/coop/rchain/node/api/json/JsonEntitiesCirceFromSchema.scala
@@ -1,0 +1,51 @@
+package coop.rchain.node.api.json
+
+import endpoints4s.algebra.circe.CirceCodec
+import endpoints4s.{algebra, Invalid}
+import org.http4s.circe
+import org.http4s.circe.jsonEncoderOf
+
+/**
+  * Interpreter for circe JSON encoding from JSON schema
+  */
+trait JsonEntitiesCirceFromSchema
+    extends algebra.JsonEntities
+    with endpoints4s.http4s.server.EndpointsWithCustomErrors
+    with endpoints4s.circe.JsonSchemas {
+
+  def jsonRequest[A](implicit schema: JsonSchema[A]): RequestEntity[A] = {
+    val decoder = JsonSchema.toCirceCodec(schema)
+    JsonEntitiesCirce.decodeJsonRequest(this)(decoder)
+  }
+
+  def jsonResponse[A](implicit schema: JsonSchema[A]): ResponseEntity[A] = {
+    val encoder = JsonSchema.toCirceCodec(schema)
+    JsonEntitiesCirce.encodeJsonResponse(this)(encoder)
+  }
+}
+
+private object JsonEntitiesCirce {
+
+  def decodeJsonRequest[A](
+      endpoints: endpoints4s.http4s.server.EndpointsWithCustomErrors
+  )(codec: CirceCodec[A]): endpoints.RequestEntity[A] = {
+    val cDecoder      = codec.decoder
+    val entityDecoder = circe.jsonOf[endpoints.Effect, A](endpoints.Effect, cDecoder)
+    req => {
+      entityDecoder
+        .decode(req, strict = false)
+        .leftSemiflatMap { fail =>
+          val invalid = Invalid(Seq(fail.message))
+          endpoints.handleClientErrors(req, invalid)
+        }(endpoints.Effect)
+        .value
+    }
+  }
+
+  def encodeJsonResponse[A](
+      endpoints: endpoints4s.http4s.server.EndpointsWithCustomErrors
+  )(codec: CirceCodec[A]): endpoints.ResponseEntity[A] = {
+    val cEncoder = codec.encoder
+    jsonEncoderOf[endpoints.Effect, A](cEncoder)
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/api/json/JsonSchemaDerivation.scala
+++ b/node/src/main/scala/coop/rchain/node/api/json/JsonSchemaDerivation.scala
@@ -1,0 +1,81 @@
+package coop.rchain.node.api.json
+
+import com.google.protobuf.ByteString
+import coop.rchain.casper.PrettyPrinter
+import coop.rchain.casper.protocol.{
+  BlockInfo,
+  BondInfo,
+  DeployData,
+  DeployInfo,
+  JustificationInfo,
+  LightBlockInfo,
+  RejectedDeployInfo
+}
+import coop.rchain.models.Par
+import coop.rchain.models.syntax._
+import coop.rchain.node.api.WebApi._
+import coop.rchain.node.web.TransactionInfo
+import endpoints4s.{Invalid, Valid}
+
+/**
+  * JsonSchema derivations for Web API request/response objects (Scala sealed traits and case classes)
+  */
+trait JsonSchemaDerivations extends JsonSchemaDerivationsBase {
+
+  // format: off
+
+  implicit lazy val deployDataSchema      : JsonSchema[DeployData]                   = schemaRecord
+  implicit lazy val deployRequestSchema   : JsonSchema[DeployRequest]                = schemaRecord
+  implicit lazy val versionInfoSchema     : JsonSchema[VersionInfo]                  = schemaRecord
+  implicit lazy val apiStatusSchema       : JsonSchema[ApiStatus]                    = schemaRecord
+  implicit lazy val exploreDeployReqSchema: JsonSchema[ExploreDeployRequest]         = schemaRecord
+  implicit lazy val dataAtNameReqSchema   : JsonSchema[DataAtNameByBlockHashRequest] = schemaRecord
+  implicit lazy val rhoResponseSchema     : JsonSchema[RhoDataResponse]              = schemaRecord
+  implicit lazy val bondInfoSchema        : JsonSchema[BondInfo]                     = schemaRecord
+  implicit lazy val justInfoSchema        : JsonSchema[JustificationInfo]            = schemaRecord
+  implicit lazy val rejectedInfoSchema    : JsonSchema[RejectedDeployInfo]           = schemaRecord
+  implicit lazy val lightBlockInfoSchema  : JsonSchema[LightBlockInfo]               = schemaRecord
+  implicit lazy val deployInfoSchema      : JsonSchema[DeployInfo]                   = schemaRecord
+  implicit lazy val blockInfoSchema       : JsonSchema[BlockInfo]                    = schemaRecord
+//  implicit lazy val transactionInfoSchema : JsonSchema[TransactionInfo]              = schemaRecord
+
+  // Web API Rholang types (subset of protobuf generated types)
+  implicit lazy val rhoExprSchema: JsonSchema[RhoExpr] =
+    lazySchema("RhoExprRef")(schemaTagged[RhoExpr]).withDescription("Rholang expression (Par type)")
+  // TODO: add ExprXXX types (not necessary for derivation but for short type name without a namespace)
+  implicit lazy val rhoUnforgSchema     : JsonSchema[RhoUnforg]      = schemaTagged
+  implicit lazy val unforgPrivateSchema : JsonSchema[UnforgPrivate]  = schemaRecord
+  implicit lazy val unforgDeploySchema  : JsonSchema[UnforgDeploy]   = schemaRecord
+  implicit lazy val unforgDeployerSchema: JsonSchema[UnforgDeployer] = schemaRecord
+
+  // Protobuf generated Rholang types (from models project)
+//  implicit lazy val parSchema: JsonSchema[Par] = lazySchema("ParRef", schemaRecord[Par])
+  /** TODO: add all referenced types in Par type, see [[coop.rchain.node.encode.JsonEncoder]] as example for circe derivations */
+
+  // format: on
+
+  // Json Schema encoding for ByteString as String base 16
+  implicit lazy val byteStringSchema: JsonSchema[ByteString] =
+    defaultStringJsonSchema.xmapPartial { str =>
+      val bytesOpt = str.hexToByteString
+      bytesOpt.map(Valid(_)).getOrElse(Invalid(s"Invalid hex format '$str'"))
+    }(PrettyPrinter.buildStringNoLimit)
+}
+
+/**
+  * Helpers JSON schema derivation functions with short type name without a namespace.
+  */
+trait JsonSchemaDerivationsBase extends endpoints4s.generic.JsonSchemas {
+  import scala.reflect.runtime.universe
+  import scala.reflect.runtime.universe._
+
+  def schemaRecord[T: TypeTag: GenericJsonSchema.GenericRecord]: JsonSchema[T] = {
+    val tpeName = universe.typeOf[T].typeSymbol.name.decodedName.toString
+    genericRecord[T].named(tpeName)
+  }
+
+  def schemaTagged[T: TypeTag: GenericJsonSchema.GenericTagged]: JsonSchema[T] = {
+    val tpeName = universe.typeOf[T].typeSymbol.name.decodedName.toString
+    genericTagged[T].named(tpeName)
+  }
+}

--- a/node/src/main/scala/coop/rchain/node/api/v1/WebApiAdminEndpoints.scala
+++ b/node/src/main/scala/coop/rchain/node/api/v1/WebApiAdminEndpoints.scala
@@ -1,0 +1,20 @@
+package coop.rchain.node.api.v1
+
+import cats.syntax.all._
+import coop.rchain.node.api.json.JsonSchemaDerivations
+import endpoints4s.algebra
+
+/**
+  * Defines the HTTP endpoints description of Admin Web API v1.
+  */
+trait WebApiAdminEndpoints
+    extends algebra.Endpoints
+    with algebra.JsonEntitiesFromSchemas
+    with JsonSchemaDerivations {
+
+  val propose: Endpoint[Unit, String] = endpoint(
+    get(path / "propose"),
+    ok(jsonResponse[String]),
+    docs = EndpointDocs().withDescription("Create and propose block".some)
+  )
+}

--- a/node/src/main/scala/coop/rchain/node/api/v1/WebApiEndpoints.scala
+++ b/node/src/main/scala/coop/rchain/node/api/v1/WebApiEndpoints.scala
@@ -1,0 +1,77 @@
+package coop.rchain.node.api.v1
+
+import coop.rchain.casper.protocol.{BlockInfo, LightBlockInfo}
+import coop.rchain.node.api.WebApi.{
+  ApiStatus,
+  DataAtNameByBlockHashRequest,
+  DeployRequest,
+  ExploreDeployRequest,
+  RhoDataResponse
+}
+import coop.rchain.node.api.json.JsonSchemaDerivations
+import endpoints4s.algebra
+import cats.syntax.all._
+
+/**
+  * Defines the HTTP endpoints description of Web API v1.
+  */
+trait WebApiEndpoints
+    extends algebra.Endpoints
+    with algebra.JsonEntitiesFromSchemas
+    with JsonSchemaDerivations {
+
+  val status: Endpoint[Unit, ApiStatus] = endpoint(
+    get(path / "status"),
+    ok(jsonResponse[ApiStatus]),
+    docs = EndpointDocs().withDescription("API status data".some)
+  )
+
+  // Prepare deploy
+
+  // Deploy
+
+  val deploy: Endpoint[DeployRequest, String] = endpoint(
+    post(path / "deploy", jsonRequest[DeployRequest]),
+    ok(jsonResponse[String])
+  )
+
+  val exploreDeploy: Endpoint[String, RhoDataResponse] = endpoint(
+    post(path / "explore-deploy", jsonRequest[String]),
+    ok(jsonResponse[RhoDataResponse]),
+    docs = EndpointDocs().withDescription("Exploratory deploy on last finalized state".some)
+  )
+
+  val exploreDeployByBlockHash: Endpoint[ExploreDeployRequest, RhoDataResponse] = endpoint(
+    post(path / "explore-deploy-by-block-hash", jsonRequest[ExploreDeployRequest]),
+    ok(jsonResponse[RhoDataResponse]),
+    docs = EndpointDocs().withDescription("Exploratory deploy".some)
+  )
+
+  // Get data
+
+  val dataAtName: Endpoint[DataAtNameByBlockHashRequest, RhoDataResponse] = endpoint(
+    post(path / "data-at-name-by-block-hash", jsonRequest[DataAtNameByBlockHashRequest]),
+    ok(jsonResponse[RhoDataResponse])
+  )
+
+  // Blocks
+
+  val getBlocks: Endpoint[Unit, List[LightBlockInfo]] = endpoint(
+    get(path / "blocks"),
+    ok(jsonResponse[List[LightBlockInfo]])
+  )
+
+  val getBlock: Endpoint[String, BlockInfo] = endpoint(
+    get(path / "block" / hashString),
+    ok(jsonResponse[BlockInfo])
+  )
+
+  //    val getTransaction: Endpoint[String, TransactionResponse] = endpoint(
+  //      get(path / "transactions" / hashString),
+  //      ok(jsonResponse[TransactionResponse])
+  //    )
+
+  // Segments
+
+  lazy val hashString = segment[String](name = "hash", docs = "Hex encoded string".some)
+}

--- a/node/src/main/scala/coop/rchain/node/encode/JsonEncoder.scala
+++ b/node/src/main/scala/coop/rchain/node/encode/JsonEncoder.scala
@@ -155,16 +155,4 @@ object JsonEncoder {
   // FIXME blake2b512Random decode. Question Is that really neccessary?
   implicit val decodeDummyBlake2b512Random: Decoder[Blake2b512Random] =
     Decoder.decodeUnit.map[Blake2b512Random](_ => Blake2b512Random(1))
-
-  // convert the circe codec into scodec
-  def convertCcodecToScodec[A](encoder: Encoder[A], decoder: Decoder[A]): SCodec[A] = {
-    val fromString = (s: String) =>
-      Attempt.fromEither(
-        parse(s)
-          .flatMap(j => decoder.decodeJson(j))
-          .leftMap(e => Err.General(e.getMessage, e.getStackTrace.map(_.toString).toList))
-      )
-    val toString = (value: A) => Attempt.successful(encoder.apply(value).noSpaces)
-    utf8.exmap(fromString, toString)
-  }
 }

--- a/node/src/main/scala/coop/rchain/node/runtime/ServersInstances.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/ServersInstances.scala
@@ -160,6 +160,7 @@ object ServersInstances {
                                 nodeConf.apiServer.host,
                                 nodeConf.apiServer.portAdminHttp,
                                 nodeConf.apiServer.maxConnectionIdle,
+                                webApi,
                                 adminWebApi,
                                 reportingRoutes
                               )

--- a/node/src/main/scala/coop/rchain/node/web/WebApiDocsV1.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiDocsV1.scala
@@ -1,0 +1,47 @@
+package coop.rchain.node.web
+
+import cats.effect.Sync
+import coop.rchain.node.api.v1.{WebApiAdminEndpoints, WebApiEndpoints}
+import endpoints4s.http4s.server
+import endpoints4s.http4s.server.Endpoints
+import endpoints4s.openapi
+import endpoints4s.openapi.model.{Info, OpenApi}
+
+import scala.Function.const
+
+/**
+  * OpenAPI schema definition for RNode Web API v1.
+  */
+object WebApiDocs
+    extends WebApiEndpoints
+    with WebApiAdminEndpoints
+    with openapi.Endpoints
+    with openapi.JsonEntitiesFromSchemas {
+
+  val public =
+    Seq(status, deploy, exploreDeploy, exploreDeployByBlockHash, dataAtName, getBlocks, getBlock)
+
+  val admin = Seq(propose)
+
+  // Public API Open API schema
+  val publicApi: OpenApi = openApi(Info(title = "RNode API", version = "1.0"))(public: _*)
+
+  // Admin API includes the whole public API schema
+  val adminApi: OpenApi =
+    openApi(Info(title = "RNode API (admin)", version = "1.0"))(public ++ admin: _*)
+}
+
+/**
+  * OpenAPI endpoint definition (GET /openapi.json).
+  */
+final case class WebApiDocServer[F[_]: Sync]()
+    extends Endpoints[F]
+    with server.JsonEntitiesFromEncodersAndDecoders {
+  implicit val jCodec: endpoints4s.Encoder[OpenApi, String] = OpenApi.stringEncoder
+
+  val publicRoutes = endpoint(get(path / "openapi.json"), ok(jsonResponse[OpenApi]))
+    .implementedBy(const(WebApiDocs.publicApi))
+
+  val adminRoutes = endpoint(get(path / "openapi.json"), ok(jsonResponse[OpenApi]))
+    .implementedBy(const(WebApiDocs.adminApi))
+}

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutesV1.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutesV1.scala
@@ -1,0 +1,92 @@
+package coop.rchain.node.web
+
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import coop.rchain.node.api.json.JsonEntitiesCirceFromSchema
+import coop.rchain.node.api.v1.{WebApiAdminEndpoints, WebApiEndpoints}
+import coop.rchain.node.api.{AdminWebApi, WebApi}
+import coop.rchain.shared.Log
+import endpoints4s.http4s.server.Endpoints
+import org.http4s.HttpRoutes
+
+import scala.Function.const
+
+/**
+  * Definition for RNode Web API v1 HTTP routes (https4s).
+  */
+object WebApiRoutesV1 {
+
+  /**
+    * Creates routes for Web API v1.
+    *
+    * @param webApi Web API implementation
+    * @return http4s routes (including OpenAPI schema _openapi.json_)
+    */
+  def create[F[_]: Concurrent: Log](webApi: WebApi[F]): HttpRoutes[F] = {
+    // RNode WebApi v1 routes
+    val apiRoutes = HttpRoutes.of[F](WebApiRoutesV1(webApi).publicRoutes)
+    // OpenAPI schema route
+    val docRoutes = HttpRoutes.of[F](WebApiDocServer[F]().publicRoutes)
+
+    apiRoutes <+> docRoutes
+  }
+
+  /**
+    * Creates routes for Admin Web API v1 (includes the whole public Web API).
+    *
+    * @param adminWebApi Admin Web API implementation
+    * @return http4s routes (including OpenAPI schema _openapi.json_)
+    */
+  def createAdmin[F[_]: Concurrent: Log](
+      webApi: WebApi[F],
+      adminWebApi: AdminWebApi[F]
+  ): HttpRoutes[F] = {
+    // RNode WebApi v1 routes
+    val publicRoutes = HttpRoutes.of[F](WebApiRoutesV1(webApi).publicRoutes)
+    // RNode Admin WebApi v1 routes
+    val adminRoutes = HttpRoutes.of[F](AdminWebApiRoutesV1(adminWebApi).adminRoutes)
+    // OpenAPI schema route
+    val docRoutes = HttpRoutes.of[F](WebApiDocServer[F]().adminRoutes)
+
+    publicRoutes <+> adminRoutes <+> docRoutes
+  }
+}
+
+/**
+  * Defines implementation (interpreter) for Web API endpoints.
+  */
+final case class WebApiRoutesV1[F[_]: Concurrent: Log](
+    webApi: WebApi[F]
+) extends Endpoints[F]
+    with JsonEntitiesCirceFromSchema
+    with WebApiEndpoints {
+
+  val publicRoutes = routesFromEndpoints(
+    // Status
+    status.implementedByEffect(const(webApi.status)),
+    // Get data
+    exploreDeploy.implementedByEffect(
+      webApi.exploratoryDeploy(_, blockHash = none, usePreStateHash = false)
+    ),
+    // Deploy
+    deploy.implementedByEffect(webApi.deploy),
+    // Blocks
+    getBlocks.implementedByEffect(const(webApi.getBlocks(1))),
+    getBlock.implementedByEffect(webApi.getBlock)
+  )
+}
+
+/**
+  * Defines implementation (interpreter) for Admin Web API endpoints.
+  */
+final case class AdminWebApiRoutesV1[F[_]: Sync](
+    adminWebApi: AdminWebApi[F]
+) extends Endpoints[F]
+    with JsonEntitiesCirceFromSchema
+    with WebApiAdminEndpoints {
+
+  val adminRoutes = routesFromEndpoints(
+    // Propose
+    propose.implementedByEffect(const(adminWebApi.propose))
+  )
+}

--- a/node/src/main/scala/coop/rchain/node/web/https4s/RouterFix.scala
+++ b/node/src/main/scala/coop/rchain/node/web/https4s/RouterFix.scala
@@ -1,0 +1,61 @@
+package coop.rchain.node.web.https4s
+
+import cats.data.Kleisli
+import cats.syntax.all._
+import cats.{Functor, Monad}
+import org.http4s.server.Router
+import org.http4s.{HttpRoutes, Request}
+
+/**
+  * Original code from http4s [[Router]] with the fix for mappings to work with endpoints4s Path decoder.
+  * The difference is in the [[RouterFix.translate]] function.
+  *
+  * https4s [[Router]] uses [[Request.attributes]] to set uri caret position
+  *  which is not supported by _endpoints4s_ Path decoder.
+  * This fix changes [[Request.uri]] instead by removing path prefix defined
+  *  in mapping.
+  */
+object RouterFix {
+
+  /**
+    * Defines an [[HttpRoutes]] based on list of mappings.
+    */
+  def apply[F[_]: Monad](mappings: (String, HttpRoutes[F])*): HttpRoutes[F] =
+    define(mappings: _*)(HttpRoutes.empty[F])
+
+  /**
+    * Defines an [[HttpRoutes]] based on list of mappings and
+    * a default Service to be used when none in the list match incoming requests.
+    *
+    * The mappings are processed in descending order (longest first) of prefix length.
+    */
+  def define[F[_]: Monad](
+      mappings: (String, HttpRoutes[F])*
+  )(default: HttpRoutes[F]): HttpRoutes[F] =
+    mappings.sortBy(_._1.length).foldLeft(default) {
+      case (acc, (prefix, routes)) =>
+        val prefixSegments = toSegments(prefix)
+        if (prefixSegments.isEmpty) routes <+> acc
+        else
+          Kleisli { req =>
+            (
+              if (toSegments(req.pathInfo).startsWith(prefixSegments))
+                routes.local(translate(prefix)) <+> acc
+              else
+                acc
+            )(req)
+          }
+    }
+
+  private def translate[F[_]: Functor](prefix: String)(req: Request[F]): Request[F] = {
+
+    /**
+      * Difference from original http4s [[Router]] is here, prefix is removed from request uri.
+      */
+    val path = req.uri.path.replaceAll(s"^$prefix", "")
+    req.withUri(req.uri.copy(path = path))
+  }
+
+  private def toSegments(path: String): List[String] =
+    path.split("/").filterNot(_.trim.isEmpty).toList
+}

--- a/node/src/main/scala/coop/rchain/node/web/package.scala
+++ b/node/src/main/scala/coop/rchain/node/web/package.scala
@@ -1,6 +1,6 @@
 package coop.rchain.node
 
-import cats.effect.{ConcurrentEffect, ExitCode, Timer}
+import cats.effect.{ConcurrentEffect, ExitCode, Sync, Timer}
 import cats.syntax.all._
 import coop.rchain.comm.discovery.NodeDiscovery
 import coop.rchain.comm.rp.Connect.{ConnectionsCell, RPConfAsk}
@@ -8,64 +8,74 @@ import coop.rchain.node.api.{AdminWebApi, WebApi}
 import coop.rchain.node.diagnostics.NewPrometheusReporter
 import coop.rchain.node.effects.EventConsumer
 import coop.rchain.node.web.ReportingRoutes.ReportingHttpRoutes
+import coop.rchain.node.web.https4s.RouterFix
 import coop.rchain.shared.Log
 import monix.execution.Scheduler
 import org.http4s.HttpRoutes
 import org.http4s.implicits._
-import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 import org.http4s.server.middleware.CORS
 
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 package object web {
+  // https://github.com/http4s/http4s/security/advisories/GHSA-52cf-226f-rhr6
+  //  val corsPolicy = CORS.policy.withAllowCredentials(false) // after http4s v0.22.x
+  def corsPolicy[F[_]: Sync](routes: HttpRoutes[F]) =
+    CORS(routes, CORS.DefaultCORSConfig.copy(allowCredentials = false))
+
   def aquireHttpServer[F[_]: ConcurrentEffect: Timer: RPConfAsk: NodeDiscovery: ConnectionsCell: EventConsumer: Log](
       reporting: Boolean,
       host: String = "0.0.0.0",
       httpPort: Int,
       prometheusReporter: NewPrometheusReporter,
       connectionIdleTimeout: FiniteDuration,
-      webApiRoutes: WebApi[F],
+      webApi: WebApi[F],
       reportingRoutes: ReportingHttpRoutes[F]
   )(implicit scheduler: Scheduler): F[fs2.Stream[F, ExitCode]] =
     for {
       event              <- EventsInfo.service[F]
       reportingRoutesOpt = if (reporting) reportingRoutes else HttpRoutes.empty
       baseRoutes = Map(
-        "/metrics"   -> CORS(NewPrometheusReporter.service[F](prometheusReporter)),
-        "/version"   -> CORS(VersionInfo.service[F]),
-        "/status"    -> CORS(StatusInfo.service[F]),
-        "/ws/events" -> CORS(event),
-        "/api"       -> CORS(WebApiRoutes.service[F](webApiRoutes) <+> reportingRoutesOpt)
+        "/metrics"   -> corsPolicy(NewPrometheusReporter.service[F](prometheusReporter)),
+        "/version"   -> corsPolicy(VersionInfo.service[F]),
+        "/status"    -> corsPolicy(StatusInfo.service[F]),
+        "/ws/events" -> corsPolicy(event),
+        "/api"       -> corsPolicy(WebApiRoutes.service[F](webApi) <+> reportingRoutesOpt),
+        // Web API v1 with OpenAPI schema
+        "/api/v1" -> corsPolicy(WebApiRoutesV1.create[F](webApi))
       )
       // Legacy reporting routes
       extraRoutes = if (reporting)
-        Map("/reporting" -> CORS(reportingRoutes))
+        Map("/reporting" -> corsPolicy(reportingRoutes))
       else
         Map.empty
       allRoutes = baseRoutes ++ extraRoutes
     } yield BlazeServerBuilder[F](scheduler)
       .bindHttp(httpPort, host)
-      .withHttpApp(Router(allRoutes.toList: _*).orNotFound)
+      .withHttpApp(RouterFix(allRoutes.toList: _*).orNotFound)
       .withIdleTimeout(connectionIdleTimeout)
       .withResponseHeaderTimeout(connectionIdleTimeout - 1.second)
       .serve
 
-  def aquireAdminHttpServer[F[_]: ConcurrentEffect: Timer: EventConsumer](
+  def aquireAdminHttpServer[F[_]: ConcurrentEffect: Timer: EventConsumer: Log](
       host: String = "0.0.0.0",
       httpPort: Int,
       connectionIdleTimeout: FiniteDuration,
+      webApi: WebApi[F],
       adminWebApiRoutes: AdminWebApi[F],
       reportingRoutes: ReportingHttpRoutes[F]
   )(implicit scheduler: Scheduler): F[fs2.Stream[F, ExitCode]] =
     for {
       event <- EventsInfo.service[F]
       baseRoutes = Map(
-        "/api" -> CORS(AdminWebApiRoutes.service[F](adminWebApiRoutes) <+> reportingRoutes)
+        "/api" -> corsPolicy(AdminWebApiRoutes.service[F](adminWebApiRoutes) <+> reportingRoutes),
+        // Web API v1 (admin) with OpenAPI schema
+        "/api/v1" -> corsPolicy(WebApiRoutesV1.createAdmin[F](webApi, adminWebApiRoutes))
       )
     } yield BlazeServerBuilder[F](scheduler)
       .bindHttp(httpPort, host)
-      .withHttpApp(Router(baseRoutes.toList: _*).orNotFound)
+      .withHttpApp(RouterFix(baseRoutes.toList: _*).orNotFound)
       .withResponseHeaderTimeout(connectionIdleTimeout - 1.second)
       .withIdleTimeout(connectionIdleTimeout)
       .serve

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,6 +9,7 @@ object Dependencies {
   val catsMtlVersion    = "0.7.1"
   val fs2Version        = "2.5.10"
   val http4sVersion     = "0.21.24"
+  val endpointsVersion  = "1.4.0"
   val circeVersion      = "0.13.0"
   val enumeratumVersion = "1.5.13"
   val slf4jVersion      = "1.7.30"
@@ -33,6 +34,13 @@ object Dependencies {
   val circeParser         = "io.circe"                   %% "circe-parser"              % circeVersion
   val disciplineCore      = "org.typelevel"              %% "discipline-core"           % "1.4.0"
   val enumeratum          = "com.beachape"               %% "enumeratum"                % enumeratumVersion
+  val endpoints           = "org.endpoints4s"            %% "algebra"                   % endpointsVersion
+  val endpointsAlgCirce   = "org.endpoints4s"            %% "algebra-circe"             % endpointsVersion
+  val endpointsAlgJson    = "org.endpoints4s"            %% "algebra-json-schema"       % endpointsVersion
+  val endpointsGeneric    = "org.endpoints4s"            %% "json-schema-generic"       % endpointsVersion
+  val endpointsCirce      = "org.endpoints4s"            %% "json-schema-circe"         % endpointsVersion
+  val endpointsHttp4s     = "org.endpoints4s"            %% "http4s-server"             % "6.0.0"
+  val endpointsOpenApi    = "org.endpoints4s"            %% "openapi"                   % "3.0.0"
   val fs2Core             = "co.fs2"                     %% "fs2-core"                  % fs2Version
   val fs2Io               = "co.fs2"                     %% "fs2-io"                    % fs2Version
   val guava               = "com.google.guava"            % "guava"                     % "30.1-jre"
@@ -95,6 +103,7 @@ object Dependencies {
     fs2Core,
     fs2Io,
     guava,
+    shapeless,
     scalacheck,
     scodecBits,
     // Added to resolve conflicts with kamon, cats, http4s
@@ -114,6 +123,7 @@ object Dependencies {
     "com.github.jnr"           % "jnr-ffi"                 % "2.1.15",
     "com.google.errorprone"    % "error_prone_annotations" % "2.3.4",
     "com.google.code.findbugs" % "jsr305"                  % "3.0.2",
+    "com.lihaoyi"              %% "geny"                   % "0.6.10",
     "com.lihaoyi"              %% "sourcecode"             % "0.2.1",
     "org.scala-lang.modules"   %% "scala-xml"              % "1.3.0",
     "com.typesafe"             % "config"                  % "1.4.0"
@@ -134,8 +144,19 @@ object Dependencies {
   private val circeDependencies: Seq[ModuleID] =
     Seq(circeGeneric, circeParser)
 
+  private val endpointsDependencies: Seq[ModuleID] =
+    Seq(
+      endpoints,
+      endpointsAlgCirce,
+      endpointsAlgJson,
+      endpointsGeneric,
+      endpointsCirce,
+      endpointsHttp4s,
+      endpointsOpenApi
+    )
+
   private val http4sDependencies: Seq[ModuleID] =
-    Seq(http4sDSL, http4sBlazeServer, http4sCirce)
+    Seq(http4sDSL, http4sBlazeServer, http4sCirce) ++ endpointsDependencies
 
   val protobufDependencies: Seq[ModuleID] =
     Seq(scalapbRuntime)


### PR DESCRIPTION
## Overview

This PR adds a new Web API implementation with the support to generate OpenAPI schema. Circe serializer is also generated from JsonSchema and it has different format then the current implementation.

**Existing API which is accessible on `/api` endpoint will not be changed but may not be updated with the new features.**

Current format has field names as a discriminator for types.
```js
{ ExprInt: 42 }
```
New format which is more JS friendly.
```js
{ type: "ExprInt", data: 42 }
```
By default the OpenAPI schema is accessible on
http://localhost:40403/api/v1/openapi.json
and for admin API (+ propose)
http://localhost:40405/api/v1/openapi.json.

NOTE: This PR contains the whole solution but it's mission definition for all methods on Web API with corresponding derivations of JsonSchema especially for Rholang types generated from protobuf (Par). Preparation and helper functions are added and the rest should be done in a new PR.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
