### PR TITLE
Fix sorting match case (freeCount field)

### DIFF
--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/MatchSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/MatchSortMatcher.scala
@@ -9,11 +9,12 @@ private[sorter] object MatchSortMatcher extends Sortable[Match] {
 
     def sortCase(matchCase: MatchCase): F[ScoredTerm[MatchCase]] =
       for {
-        sortedPattern <- Sortable.sortMatch(matchCase.pattern)
-        sortedBody    <- Sortable.sortMatch(matchCase.source)
+        sortedPattern  <- Sortable.sortMatch(matchCase.pattern)
+        sortedBody     <- Sortable.sortMatch(matchCase.source)
+        freeCountScore = Leaf(matchCase.freeCount.toLong)
       } yield ScoredTerm(
         MatchCase(sortedPattern.term, sortedBody.term, matchCase.freeCount),
-        Node(Seq(sortedPattern.score) ++ Seq(sortedBody.score))
+        Node(Seq(sortedPattern.score, sortedBody.score, freeCountScore))
       )
     for {
       sortedValue         <- Sortable.sortMatch(m.target)

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -69,6 +69,16 @@ class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
     check[Send]
     check[Var]
   }
+  // Specific Match terms created from previous test failed on CI (freeCount was not part of sorting)
+  // https://github.com/rchain/rchain/pull/3616
+  it should "sort different Match terms (MatchCase.freeCount)" in {
+    val nil = Par(locallyFree = AlwaysEqual(BitSet()))
+
+    val match1 = Match(nil, List(MatchCase(nil, nil, 0)))
+    val match2 = Match(nil, List(MatchCase(nil, nil, 1)))
+
+    match1 == match2 shouldBe sort(match1).score == sort(match2).score
+  }
 
   it should "sort so that whenever scores or result terms differ then the initial terms differ and the other way around" in {
     def check[A: Sortable: Arbitrary]: Unit =


### PR DESCRIPTION
## Overview

This PR contains the fix for observed error in CI runs.
https://github.com/rchain/rchain/runs/5332635482?check_suite_focus=true#step:8:1175
```
[info] - should sort so that whenever scores differ then result terms have to differ and the other way around *** FAILED *** (2 seconds, 493 milliseconds)
[info]   TestFailedException was thrown during property evaluation.
[info]     Message: false did not equal true
[info]     Location: (SortTest.scala:60)
[info]     Occurred when passed generated values (
[info]       arg0 = List(Match(Par(List(),List(),List(),List(),List(),List(),List(),List(),AlwaysEqual(BitSet()),true),List(MatchCase(Par(List(),List(),List(),List(),List(),List(),List(),List(),AlwaysEqual(BitSet()),true),Par(List(),List(),List(),List(),List(),List(),List(),List(),AlwaysEqual(BitSet()),true),0)),AlwaysEqual(BitSet(1, 2, 5, 7, 8, 9, 13, 14, 15, 16, 17, 18, 20, 21, 22, 23, 26, 27, 28, 29, 31, 32, 36, 41, 42, 43, 44, 46, 49, 50, 51, 57, 60, 61, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127)),false), Match(Par(List(),List(),List(),List(),List(),List(),List(),List(),AlwaysEqual(BitSet()),true),List(MatchCase(Par(List(),List(),List(),List(),List(),List(),List(),List(),AlwaysEqual(BitSet()),true),Par(List(),List(),List(),List(),List(),List(),List(),List(),AlwaysEqual(BitSet()),true),1)),AlwaysEqual(BitSet(1, 3, 9, 13, 14, 17, 18, 19, 21, 26, 27, 28, 29, 30, 31, 33, 34, 35, 36, 37, 39, 41, 42, 43, 44, 48, 50, 51, 53, 55, 56, 61, 62, 63, 64, 66, 67, 69, 77, 81, 83, 84, 85, 86, 88, 89, 91, 94, 97, 98, 102, 103, 104, 105, 106, 107, 111, 113, 114, 115, 118, 121)),false)) // 2 shrinks
```
Although this is a bug in Match sorter it's not practically important. Sorting of MatchCase was not including its field _freeCount_ which was generated differently in the test. This made the testing terms different with equal sorting score but these kind of terms are not possible to construct in Rholang directly.
**Fix should be applied anyway to prevent tests to fail again randomly but it will not change the behavior of the Rholang execution.**

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
