### PR TITLE
New WebAPI implementation with OpenAPI generation

### DIFF
--- a/node/src/main/scala/coop/rchain/node/api/json/JsonSchemaDerivation.scala
+++ b/node/src/main/scala/coop/rchain/node/api/json/JsonSchemaDerivation.scala
@@ -11,11 +11,17 @@ import coop.rchain.casper.protocol.{
   LightBlockInfo,
   RejectedDeployInfo
 }
-import coop.rchain.models.Par
+import coop.rchain.models.Connective.ConnectiveInstance
+import coop.rchain.models.Expr.ExprInstance
+import coop.rchain.models.GUnforgeable.UnfInstance
+import coop.rchain.models.Var.{VarInstance, WildcardMsg}
 import coop.rchain.models.syntax._
+import coop.rchain.models._
 import coop.rchain.node.api.WebApi._
-import coop.rchain.node.web.TransactionInfo
 import endpoints4s.{Invalid, Valid}
+import monix.eval.Coeval
+
+import scala.collection.immutable.{BitSet, HashMap, HashSet}
 
 /**
   * JsonSchema derivations for Web API request/response objects (Scala sealed traits and case classes)
@@ -51,6 +57,90 @@ trait JsonSchemaDerivations extends JsonSchemaDerivationsBase {
   // Protobuf generated Rholang types (from models project)
 //  implicit lazy val parSchema: JsonSchema[Par] = lazySchema("ParRef", schemaRecord[Par])
   /** TODO: add all referenced types in Par type, see [[coop.rchain.node.encode.JsonEncoder]] as example for circe derivations */
+  // Par
+  implicit lazy val parSchema: JsonSchema[Par] = schemaRecord[Par]
+
+  // Send
+  implicit val sendSchema: JsonSchema[Send] = schemaRecord[Send]
+
+  // Receive
+  implicit val wildcardMsgSchema: JsonSchema[WildcardMsg] = schemaRecord[WildcardMsg]
+  implicit val varInstanceSchema: JsonSchema[VarInstance] = schemaTagged[VarInstance]
+  implicit val varSchema        : JsonSchema[Var]         = schemaRecord[Var]
+  implicit val receiveBindSchema: JsonSchema[ReceiveBind] = schemaRecord[ReceiveBind]
+  implicit val receiveSchema    : JsonSchema[Receive]     = schemaRecord[Receive]
+
+  // New
+  implicit val newSchema: JsonSchema[New] = schemaRecord[New]
+
+  // Expr
+  implicit val eNotSchema  : JsonSchema[ENot]   = schemaRecord[ENot]
+  implicit val eNegSchema  : JsonSchema[ENeg]   = schemaRecord[ENeg]
+  implicit val eMultSchema : JsonSchema[EMult]  = schemaRecord[EMult]
+  implicit val eDivSchema  : JsonSchema[EDiv]   = schemaRecord[EDiv]
+  implicit val ePlusSchema : JsonSchema[EPlus]  = schemaRecord[EPlus]
+  implicit val eMinusSchema: JsonSchema[EMinus] = schemaRecord[EMinus]
+  implicit val eLtSchema   : JsonSchema[ELt]    = schemaRecord[ELt]
+  implicit val eLteSchema  : JsonSchema[ELte]   = schemaRecord[ELte]
+  implicit val eGtSchema   : JsonSchema[EGt]    = schemaRecord[EGt]
+  implicit val eGteSchema  : JsonSchema[EGte]   = schemaRecord[EGte]
+  implicit val eEqSchema   : JsonSchema[EEq]    = schemaRecord[EEq]
+  implicit val eNeqSchema  : JsonSchema[ENeq]   = schemaRecord[ENeq]
+  implicit val eAndSchema  : JsonSchema[EAnd]   = schemaRecord[EAnd]
+  implicit val eOrSchema   : JsonSchema[EOr]    = schemaRecord[EOr]
+  implicit val eVarSchema  : JsonSchema[EVar]   = schemaRecord[EVar]
+  implicit val eListSchema : JsonSchema[EList]  = schemaRecord[EList]
+  implicit val eTupleSchema: JsonSchema[ETuple] = schemaRecord[ETuple]
+  
+  implicit val hashSetParSchema      : JsonSchema[HashSet[Par]]     = schemaRecord[HashSet[Par]]
+  implicit val listParSchema         : JsonSchema[List[Par]]        = schemaRecord[List[Par]]
+  implicit val sortedParHashSetSchema: JsonSchema[SortedParHashSet] = schemaRecord[SortedParHashSet]
+  implicit val coevalBitSetSchema    : JsonSchema[Coeval[BitSet]]   = schemaRecord[Coeval[BitSet]]
+  implicit val optionVarSchema       : JsonSchema[Option[Var]]      = schemaRecord[Option[Var]]
+  implicit val parSetSchema          : JsonSchema[ParSet]           = schemaRecord[ParSet]
+  
+  implicit val mapParParSchema    : JsonSchema[Map[Par, Par]]     = schemaRecord[Map[Par, Par]]
+  implicit val listParParSchema   : JsonSchema[List[(Par, Par)]]  = schemaRecord[List[(Par, Par)]]
+  implicit val hashMapParParSchema: JsonSchema[HashMap[Par, Par]] = schemaRecord[HashMap[Par, Par]]
+  implicit val sortedParMapSchema : JsonSchema[SortedParMap]      = schemaRecord[SortedParMap]
+  implicit val parMapSchema       : JsonSchema[ParMap]            = schemaRecord[ParMap]
+  
+  // implicit val eSetSchema   : JsonSchema[ESet]    = schemaRecord[ESet]
+  // implicit val eMapSchema   : JsonSchema[EMap]    = schemaRecord[EMap]
+  implicit val eMethodSchema: JsonSchema[EMethod] = schemaRecord[EMethod]
+
+  implicit val eMatchesSchema       : JsonSchema[EMatches]        = schemaRecord[EMatches]
+  implicit val ePercentPercentSchema: JsonSchema[EPercentPercent] = schemaRecord[EPercentPercent]
+  implicit val ePlusPlusSchema      : JsonSchema[EPlusPlus]       = schemaRecord[EPlusPlus]
+  implicit val eMinusMinusSchema    : JsonSchema[EMinusMinus]     = schemaRecord[EMinusMinus]
+  implicit val eModSchema           : JsonSchema[EMod]            = schemaRecord[EMod]
+  implicit val exprInstanceSchema   : JsonSchema[ExprInstance]    = schemaTagged[ExprInstance]
+  implicit val exprSchema           : JsonSchema[Expr]            = schemaRecord[Expr]
+
+  // Match
+  implicit val matchCaseSchema: JsonSchema[MatchCase] = schemaRecord[MatchCase]
+  implicit val matchSchema    : JsonSchema[Match]     = schemaRecord[Match]
+
+  // GUnforgeable
+  implicit val gPrivateSchema     : JsonSchema[GPrivate]      = schemaRecord[GPrivate]
+  implicit val gDeployIdSchema    : JsonSchema[GDeployId]     = schemaRecord[GDeployId]
+  implicit val gDeployerIdSchema  : JsonSchema[GDeployerId]   = schemaRecord[GDeployerId]
+  implicit val gSysAuthTokenSchema: JsonSchema[GSysAuthToken] = schemaRecord[GSysAuthToken]
+  implicit val unfInstanceSchema  : JsonSchema[UnfInstance]   = schemaTagged[UnfInstance]
+  implicit val gUnforgeableSchema : JsonSchema[GUnforgeable]  = schemaRecord[GUnforgeable]
+
+  // Bundle
+  implicit val bundleSchema: JsonSchema[Bundle] = schemaRecord[Bundle]
+
+  // Connective
+  implicit val varRefSchema            : JsonSchema[VarRef]             = schemaRecord[VarRef]
+  implicit val connectiveBodySchema    : JsonSchema[ConnectiveBody]     = schemaRecord[ConnectiveBody]
+  implicit val connectiveInstanceSchema: JsonSchema[ConnectiveInstance] = schemaTagged[ConnectiveInstance]
+  implicit val connectiveSchema        : JsonSchema[Connective]         = schemaRecord[Connective]
+  
+  // AlwaysEqual[BitSet]
+  implicit val bitSetSchema           : JsonSchema[BitSet]              = schemaTagged[BitSet]
+  implicit val alwaysEqualBitSetSchema: JsonSchema[AlwaysEqual[BitSet]] = schemaRecord[AlwaysEqual[BitSet]]
 
   // format: on
 

--- a/node/src/main/scala/coop/rchain/node/api/json/JsonSchemaDerivation.scala
+++ b/node/src/main/scala/coop/rchain/node/api/json/JsonSchemaDerivation.scala
@@ -32,24 +32,29 @@ trait JsonSchemaDerivations extends JsonSchemaDerivationsBase {
 
   // format: off
 
-  implicit lazy val deployDataSchema      : JsonSchema[DeployData]                   = schemaRecord
-  implicit lazy val deployRequestSchema   : JsonSchema[DeployRequest]                = schemaRecord
-  implicit lazy val versionInfoSchema     : JsonSchema[VersionInfo]                  = schemaRecord
-  implicit lazy val apiStatusSchema       : JsonSchema[ApiStatus]                    = schemaRecord
-  implicit lazy val exploreDeployReqSchema: JsonSchema[ExploreDeployRequest]         = schemaRecord
-  implicit lazy val dataAtNameReqSchema   : JsonSchema[DataAtNameByBlockHashRequest] = schemaRecord
-  implicit lazy val rhoResponseSchema     : JsonSchema[RhoDataResponse]              = schemaRecord
-  implicit lazy val bondInfoSchema        : JsonSchema[BondInfo]                     = schemaRecord
-  implicit lazy val justInfoSchema        : JsonSchema[JustificationInfo]            = schemaRecord
-  implicit lazy val rejectedInfoSchema    : JsonSchema[RejectedDeployInfo]           = schemaRecord
-  implicit lazy val lightBlockInfoSchema  : JsonSchema[LightBlockInfo]               = schemaRecord
-  implicit lazy val deployInfoSchema      : JsonSchema[DeployInfo]                   = schemaRecord
-  implicit lazy val blockInfoSchema       : JsonSchema[BlockInfo]                    = schemaRecord
-  implicit lazy val transactionTypeSchema : JsonSchema[TransactionType]              = schemaTagged
-  implicit lazy val sysTranTypeSchema     : JsonSchema[SystemTransaction]            = schemaTagged
-  implicit lazy val transactionSchema     : JsonSchema[Transaction]                  = schemaRecord
-  implicit lazy val transactionInfoSchema : JsonSchema[TransactionInfo]              = schemaRecord
-  implicit lazy val transactionRespSchema : JsonSchema[TransactionResponse]          = schemaRecord
+  implicit lazy val deployDataSchema               : JsonSchema[DeployData]                   = schemaRecord
+  implicit lazy val deployRequestSchema            : JsonSchema[DeployRequest]                = schemaRecord
+  implicit lazy val versionInfoSchema              : JsonSchema[VersionInfo]                  = schemaRecord
+  implicit lazy val apiStatusSchema                : JsonSchema[ApiStatus]                    = schemaRecord
+  implicit lazy val exploreDeployReqSchema         : JsonSchema[ExploreDeployRequest]         = schemaRecord
+  implicit lazy val dataAtNameByBlockHashReqSchema : JsonSchema[DataAtNameByBlockHashRequest] = schemaRecord
+  implicit lazy val rhoResponseSchema              : JsonSchema[RhoDataResponse]              = schemaRecord
+  implicit lazy val bondInfoSchema                 : JsonSchema[BondInfo]                     = schemaRecord
+  implicit lazy val justInfoSchema                 : JsonSchema[JustificationInfo]            = schemaRecord
+  implicit lazy val rejectedInfoSchema             : JsonSchema[RejectedDeployInfo]           = schemaRecord
+  implicit lazy val lightBlockInfoSchema           : JsonSchema[LightBlockInfo]               = schemaRecord
+  implicit lazy val deployInfoSchema               : JsonSchema[DeployInfo]                   = schemaRecord
+  implicit lazy val blockInfoSchema                : JsonSchema[BlockInfo]                    = schemaRecord
+  implicit lazy val transactionTypeSchema          : JsonSchema[TransactionType]              = schemaTagged
+  implicit lazy val sysTranTypeSchema              : JsonSchema[SystemTransaction]            = schemaTagged
+  implicit lazy val transactionSchema              : JsonSchema[Transaction]                  = schemaRecord
+  implicit lazy val transactionInfoSchema          : JsonSchema[TransactionInfo]              = schemaRecord
+  implicit lazy val transactionRespSchema          : JsonSchema[TransactionResponse]          = schemaRecord
+  implicit lazy val prepareRespSchema              : JsonSchema[PrepareResponse]              = schemaRecord
+  implicit lazy val prepareReqSchema               : JsonSchema[PrepareRequest]               = schemaRecord
+  implicit lazy val dataAtNameReqSchema            : JsonSchema[DataAtNameRequest]            = schemaRecord
+  implicit lazy val rhoExprWithBlockSchema         : JsonSchema[RhoExprWithBlock]             = schemaRecord
+  implicit lazy val dataAtNameRespSchema           : JsonSchema[DataAtNameResponse]           = schemaRecord
 
   // Web API Rholang types (subset of protobuf generated types)
   implicit lazy val rhoExprSchema: JsonSchema[RhoExpr] =

--- a/node/src/main/scala/coop/rchain/node/api/v1/WebApiEndpoints.scala
+++ b/node/src/main/scala/coop/rchain/node/api/v1/WebApiEndpoints.scala
@@ -11,6 +11,7 @@ import coop.rchain.node.api.WebApi.{
 import coop.rchain.node.api.json.JsonSchemaDerivations
 import endpoints4s.algebra
 import cats.syntax.all._
+import coop.rchain.node.web.TransactionResponse
 
 /**
   * Defines the HTTP endpoints description of Web API v1.
@@ -66,10 +67,10 @@ trait WebApiEndpoints
     ok(jsonResponse[BlockInfo])
   )
 
-  //    val getTransaction: Endpoint[String, TransactionResponse] = endpoint(
-  //      get(path / "transactions" / hashString),
-  //      ok(jsonResponse[TransactionResponse])
-  //    )
+  val getTransaction: Endpoint[String, TransactionResponse] = endpoint(
+    get(path / "transactions" / hashString),
+    ok(jsonResponse[TransactionResponse])
+  )
 
   // Segments
 

--- a/node/src/main/scala/coop/rchain/node/web/WebApiDocsV1.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiDocsV1.scala
@@ -19,7 +19,16 @@ object WebApiDocs
     with openapi.JsonEntitiesFromSchemas {
 
   val public =
-    Seq(status, deploy, exploreDeploy, exploreDeployByBlockHash, dataAtName, getBlocks, getBlock)
+    Seq(
+      status,
+      deploy,
+      exploreDeploy,
+      exploreDeployByBlockHash,
+      dataAtName,
+      getBlocks,
+      getBlock,
+      getTransaction
+    )
 
   val admin = Seq(propose)
 

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutesV1.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutesV1.scala
@@ -72,7 +72,9 @@ final case class WebApiRoutesV1[F[_]: Concurrent: Log](
     deploy.implementedByEffect(webApi.deploy),
     // Blocks
     getBlocks.implementedByEffect(const(webApi.getBlocks(1))),
-    getBlock.implementedByEffect(webApi.getBlock)
+    getBlock.implementedByEffect(webApi.getBlock),
+    // Transactions
+    getTransaction.implementedByEffect(webApi.getTransaction)
   )
 }
 

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutesV1.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutesV1.scala
@@ -64,15 +64,34 @@ final case class WebApiRoutesV1[F[_]: Concurrent: Log](
   val publicRoutes = routesFromEndpoints(
     // Status
     status.implementedByEffect(const(webApi.status)),
-    // Get data
+    // Prepare deploy
+    prepareDeployGet.implementedByEffect(const(webApi.prepareDeploy(none))),
+    prepareDeployPost.implementedByEffect(req => webApi.prepareDeploy(req.some)),
+    // Deploy
+    deploy.implementedByEffect(webApi.deploy),
     exploreDeploy.implementedByEffect(
       webApi.exploratoryDeploy(_, blockHash = none, usePreStateHash = false)
     ),
-    // Deploy
-    deploy.implementedByEffect(webApi.deploy),
+    exploreDeployByBlockHash.implementedByEffect(
+      req =>
+        if (req.blockHash.isEmpty)
+          webApi.exploratoryDeploy(req.term, none[String], req.usePreStateHash)
+        else
+          webApi.exploratoryDeploy(req.term, Some(req.blockHash), req.usePreStateHash)
+    ),
+    // Get data
+    dataAtName.implementedByEffect(webApi.listenForDataAtName),
+    dataAtNameByBlockHash.implementedByEffect(webApi.getDataAtPar),
     // Blocks
-    getBlocks.implementedByEffect(const(webApi.getBlocks(1))),
+    lastFinalizedBlock.implementedByEffect(const(webApi.lastFinalizedBlock)),
     getBlock.implementedByEffect(webApi.getBlock),
+    getBlocks.implementedByEffect(const(webApi.getBlocks(1))),
+    getBlocksByHeights.implementedByEffect {
+      case (start, end) => webApi.getBlocksByHeights(start, end)
+    },
+    getBlocksByDepth.implementedByEffect(webApi.getBlocks),
+    findDeploy.implementedByEffect(webApi.findDeploy),
+    isFinalized.implementedByEffect(webApi.isFinalized),
     // Transactions
     getTransaction.implementedByEffect(webApi.getTransaction)
   )


### PR DESCRIPTION
## Overview

This solution uses [`endpoints4s` library](https://endpoints4s.github.io/index.html).

The new implementation is located under `/api/v1`, the old one under `/api` for compatibility. 

It is possible to generate OpenAPI directly from the code, which guarantees the relevance of the documentation. Documentation is available on http://localhost:40403/api/v1/openapi.json. To visualize it you can use [Swagger Editor](https://editor.swagger.io/). Just copy raw JSON data and paste it into editor field.

<img src="https://user-images.githubusercontent.com/1443855/157623154-3e36658a-87ab-4912-b264-67d674c7b161.png" alt="OpenAPI screenshot" width="500">

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
