### PR TITLE
Transaction balance fix

### DIFF
--- a/node/src/main/scala/coop/rchain/node/revvaultexport/reporting/TransactionBalances.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/reporting/TransactionBalances.scala
@@ -173,16 +173,22 @@ object TransactionBalances {
       block: BlockMessage
   ): F[GlobalVaultsInfo] =
     for {
-      vaultMap  <- generateRevAccountFromWalletAndBond(walletPath, bondsPath)
-      coopVault = RevAccount(RevAddress.parse(CoopVaultAddr).right.get, 0, CoopPosMultiSigVault)
+      vaultMap <- generateRevAccountFromWalletAndBond(walletPath, bondsPath)
+      coopVault = vaultMap.getOrElse(
+        CoopVaultAddr,
+        RevAccount(RevAddress.parse(CoopVaultAddr).right.get, 0, CoopPosMultiSigVault)
+      )
       perValidatorVaults <- getPerValidatorVaults(runtime, block).map(
                              addrs =>
                                addrs.map(
                                  addr =>
-                                   RevAccount(
-                                     RevAddress.parse(addr).right.get,
-                                     0,
-                                     PerValidatorVault
+                                   vaultMap.getOrElse(
+                                     addr,
+                                     RevAccount(
+                                       RevAddress.parse(addr).right.get,
+                                       0,
+                                       PerValidatorVault
+                                     )
                                    )
                                )
                            )


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

https://github.com/rchain/rchain/blob/dev/node/src/main/scala/coop/rchain/node/revvaultexport/reporting/TransactionBalances.scala#L57
would be calculated wrong if genesis wallet contains more than 0 on it.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
