### PR TITLE
Fix rholang treeHashMap `get`, `set` on the same key at the same time bug

### DIFF
--- a/casper/src/main/resources/Registry.rho
+++ b/casper/src/main/resources/Registry.rho
@@ -182,8 +182,15 @@ in {
                         // Re-test value
                         if ((val/powers.nth(nybList.nth(n))) % 2 == 0) {
                           // Child node still missing
-                          // Create node, set node to 0
-                          MakeNode!(0, (map, nybList.slice(0, n + 1))) |
+                          // Create node
+                          // if child node is leaf node
+                          // set node to empty {} 
+                          // else set node to 0
+                          if (n + 1 == len){
+                            MakeNode!({}, (map, nybList.slice(0, n + 1)))
+                          }  else {
+                            MakeNode!(0, (map, nybList.slice(0, n + 1)))
+                          } |
                           // Update current node to val | (1 << nybList.nth(n))
                           match nybList.nth(n) {
                             bit => {

--- a/casper/src/test/resources/TreeHashMapTest.rho
+++ b/casper/src/test/resources/TreeHashMapTest.rho
@@ -10,22 +10,24 @@ new
   test_contains_after_set,
   test_get_after_set_to_nil,
   test_contains_after_set_to_nil,
-  test_contention
+  test_contention,
+  test_set_and_get_on_same_key
 in {
   rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
   for(@(_, RhoSpec) <- RhoSpecCh) {
     @RhoSpec!("testSuite",
       [
-        ("Get before set returns Nil", *test_get_before_set),
-        ("Get after set returns the new value", *test_get_after_set),
-        ("Get after updating a nonexistent key should return Nil", *test_get_after_update_nil),
-        ("Get after updating an existing key should return the right value", *test_get_after_update),
-        ("Fast unsafe get after set returns the new value", *test_fast_unsafe_get_after_set),
-        ("Contains before set returns false", *test_contains_before_set),
-        ("Contains after set returns true", *test_contains_after_set),
-        ("Get after set to Nil returns Nil", *test_get_after_set_to_nil),
-        ("Contains after set to Nil returns true", *test_contains_after_set_to_nil),
-        ("Works under contention", *test_contention)
+        // ("Get before set returns Nil", *test_get_before_set),
+        // ("Get after set returns the new value", *test_get_after_set),
+        // ("Get after updating a nonexistent key should return Nil", *test_get_after_update_nil),
+        // ("Get after updating an existing key should return the right value", *test_get_after_update),
+        // ("Fast unsafe get after set returns the new value", *test_fast_unsafe_get_after_set),
+        // ("Contains before set returns false", *test_contains_before_set),
+        // ("Contains after set returns true", *test_contains_after_set),
+        // ("Get after set to Nil returns Nil", *test_get_after_set_to_nil),
+        // ("Contains after set to Nil returns true", *test_contains_after_set_to_nil),
+        // ("Works under contention", *test_contention),
+        ("Get and set on the same key at the same time", *test_set_and_get_on_same_key)
       ])
   } |
 
@@ -206,6 +208,40 @@ in {
                       } else {
                         tryIt!(n+1, flag and (val3 != Nil))
                       }
+                    }
+                  }
+                }
+              }
+            }
+          } |
+          tryIt!(0, true)
+        }
+      } |
+      contract test_set_and_get_on_same_key(rhoSpec, _, ackCh) = {
+        new tryIt in {
+          contract tryIt(@n, @flag) = {
+            new out(`rho:io:stdlog`), mapCh, dummyCh in {
+              TreeHashMap!("init", 1, *mapCh) |
+              for (@map <- mapCh) {
+                new ret1, ret2, ret3, ret4, ret5, ret6, ret7, ret8, ret9, ret10, ret11, ret12 in {
+                  TreeHashMap!("set", map, "XspL2n7hsd", "object", *ret1) |
+                  out!("info", "get and set in the same key")|
+                  for (_ <- ret1) {
+                    TreeHashMap!("set", map, "VbqWeRbRoT", "object", *ret3) |
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret4)|
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret5)|
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret6)|
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret7)|
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret8)|
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret9)|
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret10)|
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret11)|
+                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret12)|
+                    for (_ <- ret4& _ <- ret5& _ <- ret6& _ <- ret7){
+                      rhoSpec!("assertMany",
+                          [
+                            ((true, "==", true), "not happen")
+                          ], *ackCh)
                     }
                   }
                 }

--- a/casper/src/test/resources/TreeHashMapTest.rho
+++ b/casper/src/test/resources/TreeHashMapTest.rho
@@ -17,16 +17,16 @@ in {
   for(@(_, RhoSpec) <- RhoSpecCh) {
     @RhoSpec!("testSuite",
       [
-        // ("Get before set returns Nil", *test_get_before_set),
-        // ("Get after set returns the new value", *test_get_after_set),
-        // ("Get after updating a nonexistent key should return Nil", *test_get_after_update_nil),
-        // ("Get after updating an existing key should return the right value", *test_get_after_update),
-        // ("Fast unsafe get after set returns the new value", *test_fast_unsafe_get_after_set),
-        // ("Contains before set returns false", *test_contains_before_set),
-        // ("Contains after set returns true", *test_contains_after_set),
-        // ("Get after set to Nil returns Nil", *test_get_after_set_to_nil),
-        // ("Contains after set to Nil returns true", *test_contains_after_set_to_nil),
-        // ("Works under contention", *test_contention),
+        ("Get before set returns Nil", *test_get_before_set),
+        ("Get after set returns the new value", *test_get_after_set),
+        ("Get after updating a nonexistent key should return Nil", *test_get_after_update_nil),
+        ("Get after updating an existing key should return the right value", *test_get_after_update),
+        ("Fast unsafe get after set returns the new value", *test_fast_unsafe_get_after_set),
+        ("Contains before set returns false", *test_contains_before_set),
+        ("Contains after set returns true", *test_contains_after_set),
+        ("Get after set to Nil returns Nil", *test_get_after_set_to_nil),
+        ("Contains after set to Nil returns true", *test_contains_after_set_to_nil),
+        ("Works under contention", *test_contention),
         ("Get and set on the same key at the same time", *test_set_and_get_on_same_key)
       ])
   } |
@@ -217,6 +217,8 @@ in {
           tryIt!(0, true)
         }
       } |
+      // introduce this test because of https://github.com/rchain/rchain/pull/3629
+      // get and set and the same time would throw exception
       contract test_set_and_get_on_same_key(rhoSpec, _, ackCh) = {
         new tryIt in {
           contract tryIt(@n, @flag) = {
@@ -227,6 +229,7 @@ in {
                   TreeHashMap!("set", map, "XspL2n7hsd", "object", *ret1) |
                   out!("info", "get and set in the same key")|
                   for (_ <- ret1) {
+                    // create a lot of set and get operation to increase the possibility of reproducing the bug
                     TreeHashMap!("set", map, "VbqWeRbRoT", "object", *ret3) |
                     TreeHashMap!("get", map, "VbqWeRbRoT", *ret4)|
                     TreeHashMap!("get", map, "VbqWeRbRoT", *ret5)|

--- a/casper/src/test/resources/TreeHashMapTest.rho
+++ b/casper/src/test/resources/TreeHashMapTest.rho
@@ -220,40 +220,36 @@ in {
       // introduce this test because of https://github.com/rchain/rchain/pull/3629
       // get and set and the same time would throw exception
       contract test_set_and_get_on_same_key(rhoSpec, _, ackCh) = {
-        new tryIt in {
-          contract tryIt(@n, @flag) = {
-            new out(`rho:io:stdlog`), mapCh, dummyCh in {
-              TreeHashMap!("init", 1, *mapCh) |
-              for (@map <- mapCh) {
-                new ret1, ret2, ret3, ret4, ret5, ret6, ret7, ret8, ret9, ret10, ret11, ret12 in {
-                  TreeHashMap!("set", map, "XspL2n7hsd", "object", *ret1) |
-                  out!("info", "get and set in the same key")|
-                  for (_ <- ret1) {
-                    // create a lot of set and get operation to increase the possibility of reproducing the bug
-                    TreeHashMap!("set", map, "VbqWeRbRoT", "object", *ret3) |
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret4)|
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret5)|
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret6)|
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret7)|
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret8)|
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret9)|
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret10)|
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret11)|
-                    TreeHashMap!("get", map, "VbqWeRbRoT", *ret12)|
-                    for (_ <- ret4& _ <- ret5& _ <- ret6& _ <- ret7){
-                      rhoSpec!("assertMany",
-                          [
-                            ((true, "==", true), "not happen")
-                          ], *ackCh)
-                    }
+          new out(`rho:io:stdlog`), mapCh in {
+            TreeHashMap!("init", 1, *mapCh) |
+            for (@map <- mapCh) {
+              new ret1, ret2, ret3, ret4, ret5, ret6, ret7, ret8, ret9, ret10, ret11, ret12 in {
+                TreeHashMap!("set", map, "XspL2n7hsd", "object", *ret1) |
+                out!("info", "get and set in the same key")|
+                for (_ <- ret1) {
+                  // create a lot of set and get operation to increase the possibility of reproducing the bug
+                  TreeHashMap!("set", map, "VbqWeRbRoT", "object", *ret3) |
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret4)|
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret5)|
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret6)|
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret7)|
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret8)|
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret9)|
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret10)|
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret11)|
+                  TreeHashMap!("get", map, "VbqWeRbRoT", *ret12)|
+                  for (_ <- ret3 & _ <- ret4 & _ <- ret5 & _ <- ret6 & _ <- ret7 & _ <- ret8 & 
+                       _ <- ret9 &  _ <- ret10 & _ <- ret11 & _ <- ret12 ){
+                    rhoSpec!("assertMany",
+                        [
+                          ((true, "==", true), "not happen")
+                        ], *ackCh)
                   }
                 }
               }
             }
-          } |
-          tryIt!(0, true)
-        }
-      }
+          }
+        } 
     }
   }
 }


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

https://github.com/rchain/rchain/runs/5525318221?check_suite_focus=true#step:8:549 
https://github.com/rchain/rchain/actions/runs/1973196591
https://github.com/rchain/rchain/runs/5508273694?check_suite_focus=true#step:8:220
Non-determined bug in ci .

```
08:46:30.456 [scala-execution-context-global-18] ERROR coop.rchain.rholang.Resources - Exception thrown while using the tempDir '/tmp/casper-test-9092862397679176338'. Temporary dir NOT deleted.
coop.rchain.rholang.interpreter.errors$MethodNotDefined: Error: Method `get` is not defined on Int.
	at coop.rchain.rholang.interpreter.DebruijnInterpreter$$anon$11.get(Reduce.scala:1116)
	at coop.rchain.rholang.interpreter.DebruijnInterpreter$$anon$11.$anonfun$apply$48(Reduce.scala:1127)
	at traverse @ coop.rchain.store.KeyValueTypedStoreCodec.get(KeyValueTypedStoreCodec.scala:52)
	at map @ coop.rchain.rholang.interpreter.Substitute$$anon$2.$anonfun$substituteNoSort$13(Substitute.scala:152)
	at map @ coop.rchain.rholang.interpreter.Substitute$$anon$2.$anonfun$substituteNoSort$13(Substitute.scala:152)
	at traverse @ coop.rchain.store.KeyValueTypedStoreCodec.get(KeyValueTypedStoreCodec.scala:52)
	at flatMap @ coop.rchain.rholang.interpreter.Substitute$$anon$2.$anonfun$substituteNoSort$11(Substitute.scala:151)
	at traverse @ coop.rchain.store.KeyValueTypedStoreCodec.get(KeyValueTypedStoreCodec.scala:52)
	at flatMap @ coop.rchain.rholang.interpreter.Substitute$$anon$2.$anonfun$substituteNoSort$9(Substitute.scala:150)
	at traverse @ coop.rchain.store.KeyValueTypedStoreCodec.get(KeyValueTypedStoreCodec.scala:52)
	at flatMap @ coop.rchain.rholang.interpreter.Substitute$$anon$2.$anonfun$substituteNoSort$7(Substitute.scala:149)
	at traverse @ coop.rchain.store.KeyValueTypedStoreCodec.get(KeyValueTypedStoreCodec.scala:52)
	at flatMap @ coop.rchain.rholang.interpreter.Substitute$$anon$2.$anonfun$substituteNoSort$5(Substitute.scala:148)
	at tailRecM$extension @ coop.rchain.rspace.history.RadixTree$RadixTreeImpl.read(RadixTree.scala:664)
	at flatMap @ coop.rchain.rholang.interpreter.Substitute$$anon$2.$anonfun$substituteNoSort$4(Substitute.scala:147)
	at tailRecM$extension @ coop.rchain.rspace.history.RadixTree$RadixTreeImpl.read(RadixTree.scala:664)
	at map @ coop.rchain.rholang.interpreter.Substitute$$anon$2.$anonfun$subExp$1(Substitute.scala:110)
```

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
