### PR TITLE
Added configuration parameters for PoS contract (multi-sig keys and quorum)

### DIFF
--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -4,6 +4,9 @@
 // initialBonds - the initial bonds map
 // epochLength - the length of the validation epoch in blocks
 // quarantineLength - the length of the quarantine time in blocks
+// numberOfActiveValidators - max number of active validator in a shard
+// posMultiSigPublicKeys - public keys
+// posMultiSigQuorum - how many confirmations are necessary to use multi-sig vault
 /*
 
 Life cycle in POS

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -104,17 +104,7 @@ in {
           revAddressOps!("fromPublicKey", posPk, *posDeployerRevAddressCh) |
           // Creates Coop multisig vault for slashed funds.
           // Either (false, errorMsg) or (true, (multiSigVault, revAddress, revVault)) are returned on coopVaultCh.
-          @MultiSigRevVault!(
-            "create",
-            [
-              "04db91a53a2b72fcdcb201031772da86edad1e4979eb6742928d27731b1771e0bc40c9e9c9fa6554bdec041a87cee423d6f2e09e9dfb408b78e85a4aa611aad20c".hexToBytes(),
-              "042a736b30fffcc7d5a58bb9416f7e46180818c82b15542d0a7819d1a437aa7f4b6940c50db73a67bfc5f5ec5b5fa555d24ef8339b03edaa09c096de4ded6eae14".hexToBytes(),
-              "047f0f0f5bbe1d6d1a8dac4d88a3957851940f39a57cd89d55fe25b536ab67e6d76fd3f365c83e5bfe11fe7117e549b1ae3dd39bfc867d1c725a4177692c4e7754".hexToBytes()
-            ],
-            [],
-            2,
-            *coopVaultCh
-          )
+          @MultiSigRevVault!("create", [$$posMultiSigPublicKeys$$], [], $$posMultiSigQuorum$$, *coopVaultCh)
         }
       } |
       // ret: the return channel of the create

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -104,7 +104,13 @@ in {
           revAddressOps!("fromPublicKey", posPk, *posDeployerRevAddressCh) |
           // Creates Coop multisig vault for slashed funds.
           // Either (false, errorMsg) or (true, (multiSigVault, revAddress, revVault)) are returned on coopVaultCh.
-          @MultiSigRevVault!("create", [$$posMultiSigPublicKeys$$], [], $$posMultiSigQuorum$$, *coopVaultCh)
+          @MultiSigRevVault!(
+            "create",
+            $$posMultiSigPublicKeys$$,
+            [],
+            $$posMultiSigQuorum$$,
+            *coopVaultCh
+          )
         }
       } |
       // ret: the return channel of the create

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -37,7 +37,7 @@ final case class GenesisBlockData(
     genesisBlockNumber: Long,
     numberOfActiveValidators: Int,
     deployTimestamp: Option[Long],
-    publicKeys: List[String]
+    posMultiSigPublicKeys: List[String]
 )
 
 final case class GenesisCeremonyConf(

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -37,7 +37,8 @@ final case class GenesisBlockData(
     genesisBlockNumber: Long,
     numberOfActiveValidators: Int,
     deployTimestamp: Option[Long],
-    posMultiSigPublicKeys: List[String]
+    posMultiSigPublicKeys: List[String],
+    posMultiSigQuorum: Int
 )
 
 final case class GenesisCeremonyConf(

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -36,7 +36,8 @@ final case class GenesisBlockData(
     quarantineLength: Int,
     genesisBlockNumber: Long,
     numberOfActiveValidators: Int,
-    deployTimestamp: Option[Long]
+    deployTimestamp: Option[Long],
+    publicKeys: List[String]
 )
 
 final case class GenesisCeremonyConf(

--- a/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
@@ -67,7 +67,8 @@ object ApproveBlockProtocol {
       duration: FiniteDuration,
       interval: FiniteDuration,
       blockNumber: Long,
-      posMultiSigPublicKeys: List[String]
+      posMultiSigPublicKeys: List[String],
+      posMultiSigQuorum: Int
   ): F[ApproveBlockProtocol[F]] =
     for {
       now       <- Time[F].currentMillis
@@ -99,7 +100,8 @@ object ApproveBlockProtocol {
                              quarantineLength = quarantineLength,
                              numberOfActiveValidators = numberOfActiveValidators,
                              validators = validators,
-                             posMultiSigPublicKeys = posMultiSigPublicKeys
+                             posMultiSigPublicKeys = posMultiSigPublicKeys,
+                             posMultiSigQuorum = posMultiSigQuorum
                            ),
                            vaults = vaults,
                            supply = Long.MaxValue,

--- a/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
@@ -67,7 +67,7 @@ object ApproveBlockProtocol {
       duration: FiniteDuration,
       interval: FiniteDuration,
       blockNumber: Long,
-      publicKeys: List[String]
+      posMultiSigPublicKeys: List[String]
   ): F[ApproveBlockProtocol[F]] =
     for {
       now       <- Time[F].currentMillis
@@ -99,7 +99,7 @@ object ApproveBlockProtocol {
                              quarantineLength = quarantineLength,
                              numberOfActiveValidators = numberOfActiveValidators,
                              validators = validators,
-                             publicKeys = publicKeys
+                             posMultiSigPublicKeys = posMultiSigPublicKeys
                            ),
                            vaults = vaults,
                            supply = Long.MaxValue,

--- a/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/ApproveBlockProtocol.scala
@@ -66,7 +66,8 @@ object ApproveBlockProtocol {
       requiredSigs: Int,
       duration: FiniteDuration,
       interval: FiniteDuration,
-      blockNumber: Long
+      blockNumber: Long,
+      publicKeys: List[String]
   ): F[ApproveBlockProtocol[F]] =
     for {
       now       <- Time[F].currentMillis
@@ -97,7 +98,8 @@ object ApproveBlockProtocol {
                              epochLength = epochLength,
                              quarantineLength = quarantineLength,
                              numberOfActiveValidators = numberOfActiveValidators,
-                             validators = validators
+                             validators = validators,
+                             publicKeys = publicKeys
                            ),
                            vaults = vaults,
                            supply = Long.MaxValue,

--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
@@ -35,7 +35,8 @@ final case class BlockApproverProtocol private (
     epochLength: Int,
     quarantineLength: Int,
     numberOfActiveValidators: Int,
-    requiredSigs: Int
+    requiredSigs: Int,
+    publicKeys: List[String]
 ) {
   implicit private val logSource: LogSource = LogSource(this.getClass)
   private val _bonds                        = bonds.map(e => ByteString.copyFrom(e._1.bytes) -> e._2)
@@ -57,7 +58,8 @@ final case class BlockApproverProtocol private (
           maximumBond,
           epochLength,
           quarantineLength,
-          numberOfActiveValidators
+          numberOfActiveValidators,
+          publicKeys
         )
         .flatMap {
           case Right(_) =>
@@ -90,7 +92,8 @@ object BlockApproverProtocol {
       epochLength: Int,
       quarantineLength: Int,
       numberOfActiveValidators: Int,
-      requiredSigs: Int
+      requiredSigs: Int,
+      publicKeys: List[String]
   )(implicit monadError: MonadError[F, Throwable]): F[BlockApproverProtocol] =
     if (bonds.size > requiredSigs)
       new BlockApproverProtocol(
@@ -103,7 +106,8 @@ object BlockApproverProtocol {
         epochLength,
         quarantineLength,
         numberOfActiveValidators,
-        requiredSigs
+        requiredSigs,
+        publicKeys
       ).pure[F]
     else
       monadError.raiseError(
@@ -135,7 +139,8 @@ object BlockApproverProtocol {
       maximumBond: Long,
       epochLength: Int,
       quarantineLength: Int,
-      numberOfActiveValidators: Int
+      numberOfActiveValidators: Int,
+      publicKeys: List[String]
   )(implicit runtimeManager: RuntimeManager[F]): F[Either[String, Unit]] = {
 
     def validate: Either[String, (Seq[ProcessedDeploy], RChainState)] =
@@ -163,7 +168,8 @@ object BlockApproverProtocol {
           validators,
           epochLength,
           quarantineLength,
-          numberOfActiveValidators
+          numberOfActiveValidators,
+          publicKeys
         )
         genesisBlessedContracts = Genesis
           .defaultBlessedTerms(

--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
@@ -36,7 +36,7 @@ final case class BlockApproverProtocol private (
     quarantineLength: Int,
     numberOfActiveValidators: Int,
     requiredSigs: Int,
-    publicKeys: List[String]
+    posMultiSigPublicKeys: List[String]
 ) {
   implicit private val logSource: LogSource = LogSource(this.getClass)
   private val _bonds                        = bonds.map(e => ByteString.copyFrom(e._1.bytes) -> e._2)
@@ -59,7 +59,7 @@ final case class BlockApproverProtocol private (
           epochLength,
           quarantineLength,
           numberOfActiveValidators,
-          publicKeys
+          posMultiSigPublicKeys
         )
         .flatMap {
           case Right(_) =>
@@ -93,7 +93,7 @@ object BlockApproverProtocol {
       quarantineLength: Int,
       numberOfActiveValidators: Int,
       requiredSigs: Int,
-      publicKeys: List[String]
+      posMultiSigPublicKeys: List[String]
   )(implicit monadError: MonadError[F, Throwable]): F[BlockApproverProtocol] =
     if (bonds.size > requiredSigs)
       new BlockApproverProtocol(
@@ -107,7 +107,7 @@ object BlockApproverProtocol {
         quarantineLength,
         numberOfActiveValidators,
         requiredSigs,
-        publicKeys
+        posMultiSigPublicKeys
       ).pure[F]
     else
       monadError.raiseError(
@@ -140,7 +140,7 @@ object BlockApproverProtocol {
       epochLength: Int,
       quarantineLength: Int,
       numberOfActiveValidators: Int,
-      publicKeys: List[String]
+      posMultiSigPublicKeys: List[String]
   )(implicit runtimeManager: RuntimeManager[F]): F[Either[String, Unit]] = {
 
     def validate: Either[String, (Seq[ProcessedDeploy], RChainState)] =
@@ -169,7 +169,7 @@ object BlockApproverProtocol {
           epochLength,
           quarantineLength,
           numberOfActiveValidators,
-          publicKeys
+          posMultiSigPublicKeys
         )
         genesisBlessedContracts = Genesis
           .defaultBlessedTerms(

--- a/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/BlockApproverProtocol.scala
@@ -36,7 +36,8 @@ final case class BlockApproverProtocol private (
     quarantineLength: Int,
     numberOfActiveValidators: Int,
     requiredSigs: Int,
-    posMultiSigPublicKeys: List[String]
+    posMultiSigPublicKeys: List[String],
+    posMultiSigQuorum: Int
 ) {
   implicit private val logSource: LogSource = LogSource(this.getClass)
   private val _bonds                        = bonds.map(e => ByteString.copyFrom(e._1.bytes) -> e._2)
@@ -59,7 +60,8 @@ final case class BlockApproverProtocol private (
           epochLength,
           quarantineLength,
           numberOfActiveValidators,
-          posMultiSigPublicKeys
+          posMultiSigPublicKeys,
+          posMultiSigQuorum
         )
         .flatMap {
           case Right(_) =>
@@ -93,7 +95,8 @@ object BlockApproverProtocol {
       quarantineLength: Int,
       numberOfActiveValidators: Int,
       requiredSigs: Int,
-      posMultiSigPublicKeys: List[String]
+      posMultiSigPublicKeys: List[String],
+      posMultiSigQuorum: Int
   )(implicit monadError: MonadError[F, Throwable]): F[BlockApproverProtocol] =
     if (bonds.size > requiredSigs)
       new BlockApproverProtocol(
@@ -107,7 +110,8 @@ object BlockApproverProtocol {
         quarantineLength,
         numberOfActiveValidators,
         requiredSigs,
-        posMultiSigPublicKeys
+        posMultiSigPublicKeys,
+        posMultiSigQuorum
       ).pure[F]
     else
       monadError.raiseError(
@@ -140,7 +144,8 @@ object BlockApproverProtocol {
       epochLength: Int,
       quarantineLength: Int,
       numberOfActiveValidators: Int,
-      posMultiSigPublicKeys: List[String]
+      posMultiSigPublicKeys: List[String],
+      posMultiSigQuorum: Int
   )(implicit runtimeManager: RuntimeManager[F]): F[Either[String, Unit]] = {
 
     def validate: Either[String, (Seq[ProcessedDeploy], RChainState)] =
@@ -169,7 +174,8 @@ object BlockApproverProtocol {
           epochLength,
           quarantineLength,
           numberOfActiveValidators,
-          posMultiSigPublicKeys
+          posMultiSigPublicKeys,
+          posMultiSigQuorum
         )
         genesisBlessedContracts = Genesis
           .defaultBlessedTerms(

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -183,7 +183,8 @@ object CasperLaunch {
                   conf.genesisBlockData.epochLength,
                   conf.genesisBlockData.quarantineLength,
                   conf.genesisBlockData.numberOfActiveValidators,
-                  conf.genesisCeremony.requiredSignatures
+                  conf.genesisCeremony.requiredSignatures,
+                  conf.genesisBlockData.publicKeys
                 )(Sync[F])
           _ <- EngineCell[F].set(
                 new GenesisValidator(
@@ -215,7 +216,8 @@ object CasperLaunch {
                     conf.genesisCeremony.requiredSignatures,
                     conf.genesisCeremony.approveDuration,
                     conf.genesisCeremony.approveInterval,
-                    conf.genesisBlockData.genesisBlockNumber
+                    conf.genesisBlockData.genesisBlockNumber,
+                    conf.genesisBlockData.publicKeys
                   )
           // TODO track fiber
           _ <- Concurrent[F].start(

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -184,7 +184,8 @@ object CasperLaunch {
                   conf.genesisBlockData.quarantineLength,
                   conf.genesisBlockData.numberOfActiveValidators,
                   conf.genesisCeremony.requiredSignatures,
-                  conf.genesisBlockData.posMultiSigPublicKeys
+                  conf.genesisBlockData.posMultiSigPublicKeys,
+                  conf.genesisBlockData.posMultiSigQuorum
                 )(Sync[F])
           _ <- EngineCell[F].set(
                 new GenesisValidator(
@@ -217,7 +218,8 @@ object CasperLaunch {
                     conf.genesisCeremony.approveDuration,
                     conf.genesisCeremony.approveInterval,
                     conf.genesisBlockData.genesisBlockNumber,
-                    conf.genesisBlockData.posMultiSigPublicKeys
+                    conf.genesisBlockData.posMultiSigPublicKeys,
+                    conf.genesisBlockData.posMultiSigQuorum
                   )
           // TODO track fiber
           _ <- Concurrent[F].start(

--- a/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/CasperLaunch.scala
@@ -184,7 +184,7 @@ object CasperLaunch {
                   conf.genesisBlockData.quarantineLength,
                   conf.genesisBlockData.numberOfActiveValidators,
                   conf.genesisCeremony.requiredSignatures,
-                  conf.genesisBlockData.publicKeys
+                  conf.genesisBlockData.posMultiSigPublicKeys
                 )(Sync[F])
           _ <- EngineCell[F].set(
                 new GenesisValidator(
@@ -217,7 +217,7 @@ object CasperLaunch {
                     conf.genesisCeremony.approveDuration,
                     conf.genesisCeremony.approveInterval,
                     conf.genesisBlockData.genesisBlockNumber,
-                    conf.genesisBlockData.publicKeys
+                    conf.genesisBlockData.posMultiSigPublicKeys
                   )
           // TODO track fiber
           _ <- Concurrent[F].start(

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -14,7 +14,7 @@ final case class ProofOfStake(
     epochLength: Int,
     quarantineLength: Int,
     numberOfActiveValidators: Int,
-    publicKeys: List[String]
+    posMultiSigPublicKeys: List[String]
 ) extends CompiledRholangTemplate(
       "PoS.rhox",
       NormalizerEnv.Empty,
@@ -24,7 +24,7 @@ final case class ProofOfStake(
       "epochLength"              -> epochLength,
       "quarantineLength"         -> quarantineLength,
       "numberOfActiveValidators" -> numberOfActiveValidators,
-      "publicKeys"               -> publicKeys
+      "posMultiSigPublicKeys"    -> posMultiSigPublicKeys
     ) {
 
   require(minimumBond <= maximumBond)

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -14,7 +14,8 @@ final case class ProofOfStake(
     epochLength: Int,
     quarantineLength: Int,
     numberOfActiveValidators: Int,
-    posMultiSigPublicKeys: List[String]
+    posMultiSigPublicKeys: List[String],
+    posMultiSigQuorum: Int
 ) extends CompiledRholangTemplate(
       "PoS.rhox",
       NormalizerEnv.Empty,
@@ -24,7 +25,8 @@ final case class ProofOfStake(
       "epochLength"              -> epochLength,
       "quarantineLength"         -> quarantineLength,
       "numberOfActiveValidators" -> numberOfActiveValidators,
-      "posMultiSigPublicKeys"    -> posMultiSigPublicKeys
+      "posMultiSigPublicKeys"    -> posMultiSigPublicKeys,
+      "posMultiSigQuorum"        -> posMultiSigQuorum
     ) {
 
   require(minimumBond <= maximumBond)

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -13,7 +13,8 @@ final case class ProofOfStake(
     validators: Seq[Validator],
     epochLength: Int,
     quarantineLength: Int,
-    numberOfActiveValidators: Int
+    numberOfActiveValidators: Int,
+    publicKeys: List[String]
 ) extends CompiledRholangTemplate(
       "PoS.rhox",
       NormalizerEnv.Empty,
@@ -22,7 +23,8 @@ final case class ProofOfStake(
       "initialBonds"             -> ProofOfStake.initialBonds(validators),
       "epochLength"              -> epochLength,
       "quarantineLength"         -> quarantineLength,
-      "numberOfActiveValidators" -> numberOfActiveValidators
+      "numberOfActiveValidators" -> numberOfActiveValidators,
+      "publicKeys"               -> publicKeys
     ) {
 
   require(minimumBond <= maximumBond)

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -25,7 +25,7 @@ final case class ProofOfStake(
       "epochLength"              -> epochLength,
       "quarantineLength"         -> quarantineLength,
       "numberOfActiveValidators" -> numberOfActiveValidators,
-      "posMultiSigPublicKeys"    -> posMultiSigPublicKeys,
+      "posMultiSigPublicKeys"    -> ProofOfStake.publicKeys(posMultiSigPublicKeys),
       "posMultiSigQuorum"        -> posMultiSigQuorum
     ) {
 
@@ -49,5 +49,14 @@ object ProofOfStake {
       }
       .mkString(", ")
     s"{$mapEntries}"
+  }
+
+  def publicKeys(posMultiSigPublicKeys: List[String]): String = {
+    val indentBrackets = 12
+    val indentKeys     = indentBrackets + 2
+    val pubKeyItems = posMultiSigPublicKeys
+      .map(pk => s"""${" " * indentKeys}"$pk".hexToBytes()""")
+      .mkString(",\n")
+    s"""[\n$pubKeyItems\n${" " * indentBrackets}]"""
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
@@ -91,7 +91,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
                 numberOfActiveValidators = approver.numberOfActiveValidators,
-                posMultiSigPublicKeys = approver.posMultiSigPublicKeys
+                posMultiSigPublicKeys = approver.posMultiSigPublicKeys,
+                posMultiSigQuorum = approver.posMultiSigQuorum
               )
         } yield r shouldBe Right(())
     }
@@ -115,7 +116,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
                 numberOfActiveValidators = approver.numberOfActiveValidators,
-                posMultiSigPublicKeys = approver.posMultiSigPublicKeys
+                posMultiSigPublicKeys = approver.posMultiSigPublicKeys,
+                posMultiSigQuorum = approver.posMultiSigQuorum
               )
         } yield r shouldBe (Left("Block bonds don't match expected."))
     }
@@ -141,7 +143,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
                 numberOfActiveValidators = approver.numberOfActiveValidators,
-                posMultiSigPublicKeys = approver.posMultiSigPublicKeys
+                posMultiSigPublicKeys = approver.posMultiSigPublicKeys,
+                posMultiSigQuorum = approver.posMultiSigQuorum
               )
         } yield r shouldBe (Left(
           "Mismatch between number of candidate deploys and expected number of deploys."
@@ -170,7 +173,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 epochLength = approver.epochLength + 1,
                 quarantineLength = approver.quarantineLength + 1,
                 numberOfActiveValidators = approver.numberOfActiveValidators + 1,
-                posMultiSigPublicKeys = approver.posMultiSigPublicKeys
+                posMultiSigPublicKeys = approver.posMultiSigPublicKeys,
+                posMultiSigQuorum = approver.posMultiSigQuorum
               )
         } yield r.isLeft shouldBe true
     }
@@ -206,7 +210,8 @@ object BlockApproverProtocolTest {
           genesisParams.proofOfStake.quarantineLength,
           genesisParams.proofOfStake.numberOfActiveValidators,
           requiredSigs,
-          genesisParams.proofOfStake.posMultiSigPublicKeys
+          genesisParams.proofOfStake.posMultiSigPublicKeys,
+          genesisParams.proofOfStake.posMultiSigQuorum
         )
         .map(_ -> node)
     }

--- a/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
@@ -90,7 +90,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 maximumBond = approver.maximumBond,
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
-                numberOfActiveValidators = approver.numberOfActiveValidators
+                numberOfActiveValidators = approver.numberOfActiveValidators,
+                publicKeys = approver.publicKeys
               )
         } yield r shouldBe Right(())
     }
@@ -113,7 +114,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 maximumBond = approver.maximumBond,
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
-                numberOfActiveValidators = approver.numberOfActiveValidators
+                numberOfActiveValidators = approver.numberOfActiveValidators,
+                publicKeys = approver.publicKeys
               )
         } yield r shouldBe (Left("Block bonds don't match expected."))
     }
@@ -138,7 +140,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 maximumBond = approver.maximumBond,
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
-                numberOfActiveValidators = approver.numberOfActiveValidators
+                numberOfActiveValidators = approver.numberOfActiveValidators,
+                publicKeys = approver.publicKeys
               )
         } yield r shouldBe (Left(
           "Mismatch between number of candidate deploys and expected number of deploys."
@@ -166,7 +169,8 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 maximumBond = approver.maximumBond - 1,
                 epochLength = approver.epochLength + 1,
                 quarantineLength = approver.quarantineLength + 1,
-                numberOfActiveValidators = approver.numberOfActiveValidators + 1
+                numberOfActiveValidators = approver.numberOfActiveValidators + 1,
+                publicKeys = approver.publicKeys
               )
         } yield r.isLeft shouldBe true
     }
@@ -201,7 +205,8 @@ object BlockApproverProtocolTest {
           genesisParams.proofOfStake.epochLength,
           genesisParams.proofOfStake.quarantineLength,
           genesisParams.proofOfStake.numberOfActiveValidators,
-          requiredSigs
+          requiredSigs,
+          genesisParams.proofOfStake.publicKeys
         )
         .map(_ -> node)
     }

--- a/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/BlockApproverProtocolTest.scala
@@ -91,7 +91,7 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
                 numberOfActiveValidators = approver.numberOfActiveValidators,
-                publicKeys = approver.publicKeys
+                posMultiSigPublicKeys = approver.posMultiSigPublicKeys
               )
         } yield r shouldBe Right(())
     }
@@ -115,7 +115,7 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
                 numberOfActiveValidators = approver.numberOfActiveValidators,
-                publicKeys = approver.publicKeys
+                posMultiSigPublicKeys = approver.posMultiSigPublicKeys
               )
         } yield r shouldBe (Left("Block bonds don't match expected."))
     }
@@ -141,7 +141,7 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 epochLength = approver.epochLength,
                 quarantineLength = approver.quarantineLength,
                 numberOfActiveValidators = approver.numberOfActiveValidators,
-                publicKeys = approver.publicKeys
+                posMultiSigPublicKeys = approver.posMultiSigPublicKeys
               )
         } yield r shouldBe (Left(
           "Mismatch between number of candidate deploys and expected number of deploys."
@@ -170,7 +170,7 @@ class BlockApproverProtocolTest extends FlatSpec with Matchers {
                 epochLength = approver.epochLength + 1,
                 quarantineLength = approver.quarantineLength + 1,
                 numberOfActiveValidators = approver.numberOfActiveValidators + 1,
-                publicKeys = approver.publicKeys
+                posMultiSigPublicKeys = approver.posMultiSigPublicKeys
               )
         } yield r.isLeft shouldBe true
     }
@@ -206,7 +206,7 @@ object BlockApproverProtocolTest {
           genesisParams.proofOfStake.quarantineLength,
           genesisParams.proofOfStake.numberOfActiveValidators,
           requiredSigs,
-          genesisParams.proofOfStake.publicKeys
+          genesisParams.proofOfStake.posMultiSigPublicKeys
         )
         .map(_ -> node)
     }

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -97,7 +97,7 @@ object Setup {
         genesisParams.proofOfStake.quarantineLength,
         genesisParams.proofOfStake.numberOfActiveValidators,
         requiredSigs,
-        genesisParams.proofOfStake.publicKeys
+        genesisParams.proofOfStake.posMultiSigPublicKeys
       )
       .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -97,7 +97,8 @@ object Setup {
         genesisParams.proofOfStake.quarantineLength,
         genesisParams.proofOfStake.numberOfActiveValidators,
         requiredSigs,
-        genesisParams.proofOfStake.posMultiSigPublicKeys
+        genesisParams.proofOfStake.posMultiSigPublicKeys,
+        genesisParams.proofOfStake.posMultiSigQuorum
       )
       .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -96,7 +96,8 @@ object Setup {
         genesisParams.proofOfStake.epochLength,
         genesisParams.proofOfStake.quarantineLength,
         genesisParams.proofOfStake.numberOfActiveValidators,
-        requiredSigs
+        requiredSigs,
+        genesisParams.proofOfStake.publicKeys
       )
       .unsafeRunSync(monix.execution.Scheduler.Implicits.global)
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -11,7 +11,7 @@ import coop.rchain.casper.genesis.contracts.{ProofOfStake, Validator}
 import coop.rchain.casper.helper.BlockDagStorageFixture
 import coop.rchain.casper.protocol.{BlockMessage, Bond}
 import coop.rchain.casper.util.rholang.{InterpreterUtil, Resources, RuntimeManager}
-import coop.rchain.casper.util.{BondsParser, ProtoUtil, VaultParser}
+import coop.rchain.casper.util.{BondsParser, GenesisBuilder, ProtoUtil, VaultParser}
 import coop.rchain.casper.{CasperShardConf, CasperSnapshot, OnChainCasperState}
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
@@ -277,7 +277,8 @@ object GenesisTest {
                            epochLength = epochLength,
                            quarantineLength = quarantineLength,
                            numberOfActiveValidators = numberOfActiveValidators,
-                           validators = validators
+                           validators = validators,
+                           publicKeys = GenesisBuilder.defaultPublicKeys
                          ),
                          vaults = vaults,
                          supply = Long.MaxValue,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -279,7 +279,7 @@ object GenesisTest {
                            numberOfActiveValidators = numberOfActiveValidators,
                            validators = validators,
                            posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
-                           posMultiSigQuorum = 3
+                           posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1
                          ),
                          vaults = vaults,
                          supply = Long.MaxValue,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -278,7 +278,7 @@ object GenesisTest {
                            quarantineLength = quarantineLength,
                            numberOfActiveValidators = numberOfActiveValidators,
                            validators = validators,
-                           publicKeys = GenesisBuilder.defaultPublicKeys
+                           posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys
                          ),
                          vaults = vaults,
                          supply = Long.MaxValue,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -278,7 +278,8 @@ object GenesisTest {
                            quarantineLength = quarantineLength,
                            numberOfActiveValidators = numberOfActiveValidators,
                            validators = validators,
-                           posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys
+                           posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
+                           posMultiSigQuorum = 3
                          ),
                          vaults = vaults,
                          supply = Long.MaxValue,

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -54,7 +54,7 @@ object GenesisBuilder {
     )
   }
 
-  val defaultPublicKeys = List(
+  val defaultPosMultiSigPublicKeys = List(
     "04db91a53a2b72fcdcb201031772da86edad1e4979eb6742928d27731b1771e0bc40c9e9c9fa6554bdec041a87cee423d6f2e09e9dfb408b78e85a4aa611aad20c",
     "042a736b30fffcc7d5a58bb9416f7e46180818c82b15542d0a7819d1a437aa7f4b6940c50db73a67bfc5f5ec5b5fa555d24ef8339b03edaa09c096de4ded6eae14",
     "047f0f0f5bbe1d6d1a8dac4d88a3957851940f39a57cd89d55fe25b536ab67e6d76fd3f365c83e5bfe11fe7117e549b1ae3dd39bfc867d1c725a4177692c4e7754"
@@ -83,7 +83,7 @@ object GenesisBuilder {
           quarantineLength = 50000,
           numberOfActiveValidators = 100,
           validators = bonds.map(Validator.tupled).toSeq,
-          publicKeys = defaultPublicKeys
+          posMultiSigPublicKeys = defaultPosMultiSigPublicKeys
         ),
         vaults = genesisVaults.toList.map(pair => predefinedVault(pair._2)) ++
           bonds.toList.map {

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -53,6 +53,13 @@ object GenesisBuilder {
       bondsFunction(defaultValidatorPks ++ randomValidatorPks)
     )
   }
+
+  val defaultPublicKeys = List(
+    "04db91a53a2b72fcdcb201031772da86edad1e4979eb6742928d27731b1771e0bc40c9e9c9fa6554bdec041a87cee423d6f2e09e9dfb408b78e85a4aa611aad20c",
+    "042a736b30fffcc7d5a58bb9416f7e46180818c82b15542d0a7819d1a437aa7f4b6940c50db73a67bfc5f5ec5b5fa555d24ef8339b03edaa09c096de4ded6eae14",
+    "047f0f0f5bbe1d6d1a8dac4d88a3957851940f39a57cd89d55fe25b536ab67e6d76fd3f365c83e5bfe11fe7117e549b1ae3dd39bfc867d1c725a4177692c4e7754"
+  )
+
   def buildGenesisParameters(
       validatorKeyPairs: Iterable[(PrivateKey, PublicKey)],
       bonds: Map[PublicKey, Long]
@@ -75,7 +82,8 @@ object GenesisBuilder {
           epochLength = 1000,
           quarantineLength = 50000,
           numberOfActiveValidators = 100,
-          validators = bonds.map(Validator.tupled).toSeq
+          validators = bonds.map(Validator.tupled).toSeq,
+          publicKeys = defaultPublicKeys
         ),
         vaults = genesisVaults.toList.map(pair => predefinedVault(pair._2)) ++
           bonds.toList.map {

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -84,7 +84,7 @@ object GenesisBuilder {
           numberOfActiveValidators = 100,
           validators = bonds.map(Validator.tupled).toSeq,
           posMultiSigPublicKeys = defaultPosMultiSigPublicKeys,
-          posMultiSigQuorum = 3
+          posMultiSigQuorum = defaultPosMultiSigPublicKeys.length - 1
         ),
         vaults = genesisVaults.toList.map(pair => predefinedVault(pair._2)) ++
           bonds.toList.map {

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -83,7 +83,8 @@ object GenesisBuilder {
           quarantineLength = 50000,
           numberOfActiveValidators = 100,
           validators = bonds.map(Validator.tupled).toSeq,
-          posMultiSigPublicKeys = defaultPosMultiSigPublicKeys
+          posMultiSigPublicKeys = defaultPosMultiSigPublicKeys,
+          posMultiSigQuorum = 3
         ),
         vaults = genesisVaults.toList.map(pair => predefinedVault(pair._2)) ++
           bonds.toList.map {

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -294,6 +294,10 @@ casper {
       042a736b30fffcc7d5a58bb9416f7e46180818c82b15542d0a7819d1a437aa7f4b6940c50db73a67bfc5f5ec5b5fa555d24ef8339b03edaa09c096de4ded6eae14,
       047f0f0f5bbe1d6d1a8dac4d88a3957851940f39a57cd89d55fe25b536ab67e6d76fd3f365c83e5bfe11fe7117e549b1ae3dd39bfc867d1c725a4177692c4e7754
     ]
+
+    # How many confirmations are necessary to use multi-sig vault.
+    # The value should be less or equal the number of PoS multi-sig public keys.
+    pos-multi-sig-quorum = 3
   }
 
   # Genesis ceremony variables

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -287,6 +287,13 @@ casper {
 
     # genesis-block-number is used for hard fork on existing network.
     genesis-block-number = 0
+
+    # Public keys accepted by the PoS contract in the genesis block.
+    public-keys = [
+      04db91a53a2b72fcdcb201031772da86edad1e4979eb6742928d27731b1771e0bc40c9e9c9fa6554bdec041a87cee423d6f2e09e9dfb408b78e85a4aa611aad20c,
+      042a736b30fffcc7d5a58bb9416f7e46180818c82b15542d0a7819d1a437aa7f4b6940c50db73a67bfc5f5ec5b5fa555d24ef8339b03edaa09c096de4ded6eae14,
+      047f0f0f5bbe1d6d1a8dac4d88a3957851940f39a57cd89d55fe25b536ab67e6d76fd3f365c83e5bfe11fe7117e549b1ae3dd39bfc867d1c725a4177692c4e7754
+    ]
   }
 
   # Genesis ceremony variables

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -289,7 +289,7 @@ casper {
     genesis-block-number = 0
 
     # Public keys accepted by the PoS contract in the genesis block.
-    public-keys = [
+    pos-multi-sig-public-keys = [
       04db91a53a2b72fcdcb201031772da86edad1e4979eb6742928d27731b1771e0bc40c9e9c9fa6554bdec041a87cee423d6f2e09e9dfb408b78e85a4aa611aad20c,
       042a736b30fffcc7d5a58bb9416f7e46180818c82b15542d0a7819d1a437aa7f4b6940c50db73a67bfc5f5ec5b5fa555d24ef8339b03edaa09c096de4ded6eae14,
       047f0f0f5bbe1d6d1a8dac4d88a3957851940f39a57cd89d55fe25b536ab67e6d76fd3f365c83e5bfe11fe7117e549b1ae3dd39bfc867d1c725a4177692c4e7754

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -297,7 +297,7 @@ casper {
 
     # How many confirmations are necessary to use multi-sig vault.
     # The value should be less or equal the number of PoS multi-sig public keys.
-    pos-multi-sig-quorum = 3
+    pos-multi-sig-quorum = 2
   }
 
   # Genesis ceremony variables

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -97,11 +97,12 @@ object Configuration {
     val posMultiSigQuorum           = nodeConf.casper.genesisBlockData.posMultiSigQuorum
     val posMultiSigPublicKeysLength = nodeConf.casper.genesisBlockData.posMultiSigPublicKeys.length
     if (posMultiSigQuorum > posMultiSigPublicKeysLength) {
-      throw new RuntimeException(
+      System.err.println(
         s"defaults.conf: " +
           s"The value 'pos-multi-sig-quorum' should be less or equal the length of 'pos-multi-sig-public-keys' " +
           s"(the actual values are '$posMultiSigQuorum' and '$posMultiSigPublicKeysLength' respectively)"
       )
+      System.exit(1)
     }
 
     val kamonConfigFile = dataDir.resolve("kamon.conf").toFile

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -93,6 +93,17 @@ object Configuration {
     }
     val nodeConf = nodeConfE.right.get
 
+    // Throw an error if pos-multi-sig-quorum greater then pos-multi-sig-public-keys length
+    val posMultiSigQuorum           = nodeConf.casper.genesisBlockData.posMultiSigQuorum
+    val posMultiSigPublicKeysLength = nodeConf.casper.genesisBlockData.posMultiSigPublicKeys.length
+    if (posMultiSigQuorum > posMultiSigPublicKeysLength) {
+      throw new RuntimeException(
+        s"defaults.conf: " +
+          s"The value 'pos-multi-sig-quorum' should be less or equal the length of 'pos-multi-sig-public-keys' " +
+          s"(the actual values are '$posMultiSigQuorum' and '$posMultiSigPublicKeysLength' respectively)"
+      )
+    }
+
     val kamonConfigFile = dataDir.resolve("kamon.conf").toFile
     val kamonDefaultConfig =
       if (kamonConfigFile.exists())

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -16,6 +16,7 @@ import coop.rchain.node.configuration.{
   Storage
 }
 import com.typesafe.config.ConfigFactory
+import coop.rchain.casper.util.GenesisBuilder
 import coop.rchain.casper.{CasperConf, GenesisBlockData, GenesisCeremonyConf, RoundRobinDispatcher}
 import coop.rchain.comm.transport.TlsConf
 import coop.rchain.comm.{CommError, PeerNode}
@@ -239,7 +240,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
           quarantineLength = 111111,
           numberOfActiveValidators = 111111,
           deployTimestamp = Some(111111),
-          genesisBlockNumber = 222
+          genesisBlockNumber = 222,
+          publicKeys = GenesisBuilder.defaultPublicKeys
         ),
         genesisCeremony = GenesisCeremonyConf(
           requiredSignatures = 111111,

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -242,7 +242,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
           deployTimestamp = Some(111111),
           genesisBlockNumber = 222,
           posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
-          posMultiSigQuorum = 3
+          posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1
         ),
         genesisCeremony = GenesisCeremonyConf(
           requiredSignatures = 111111,

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -241,7 +241,7 @@ class ConfigMapperSpec extends FunSuite with Matchers {
           numberOfActiveValidators = 111111,
           deployTimestamp = Some(111111),
           genesisBlockNumber = 222,
-          publicKeys = GenesisBuilder.defaultPublicKeys
+          posMultiSigPublicKeys = GenesisBuilder.defaultPublicKeys
         ),
         genesisCeremony = GenesisCeremonyConf(
           requiredSignatures = 111111,

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -241,7 +241,8 @@ class ConfigMapperSpec extends FunSuite with Matchers {
           numberOfActiveValidators = 111111,
           deployTimestamp = Some(111111),
           genesisBlockNumber = 222,
-          posMultiSigPublicKeys = GenesisBuilder.defaultPublicKeys
+          posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
+          posMultiSigQuorum = 3
         ),
         genesisCeremony = GenesisCeremonyConf(
           requiredSignatures = 111111,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -145,7 +145,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
           numberOfActiveValidators = 100,
           deployTimestamp = None,
           genesisBlockNumber = 0,
-          posMultiSigPublicKeys = GenesisBuilder.defaultPublicKeys
+          posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
+          posMultiSigQuorum = 3
         ),
         genesisCeremony = GenesisCeremonyConf(
           requiredSignatures = 0,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -145,7 +145,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
           numberOfActiveValidators = 100,
           deployTimestamp = None,
           genesisBlockNumber = 0,
-          publicKeys = GenesisBuilder.defaultPublicKeys
+          posMultiSigPublicKeys = GenesisBuilder.defaultPublicKeys
         ),
         genesisCeremony = GenesisCeremonyConf(
           requiredSignatures = 0,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -146,7 +146,7 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
           deployTimestamp = None,
           genesisBlockNumber = 0,
           posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
-          posMultiSigQuorum = 3
+          posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1
         ),
         genesisCeremony = GenesisCeremonyConf(
           requiredSignatures = 0,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -1,6 +1,7 @@
 package coop.rchain.node.configuration.hocon
 
 import com.typesafe.config.ConfigFactory
+import coop.rchain.casper.util.GenesisBuilder
 import coop.rchain.casper.{CasperConf, GenesisBlockData, GenesisCeremonyConf, RoundRobinDispatcher}
 import coop.rchain.comm.transport.TlsConf
 import coop.rchain.comm.{CommError, PeerNode}
@@ -143,7 +144,8 @@ class HoconConfigurationSpec extends FunSuite with Matchers {
           quarantineLength = 50000,
           numberOfActiveValidators = 100,
           deployTimestamp = None,
-          genesisBlockNumber = 0
+          genesisBlockNumber = 0,
+          publicKeys = GenesisBuilder.defaultPublicKeys
         ),
         genesisCeremony = GenesisCeremonyConf(
           requiredSignatures = 0,


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

The PoS multi-sig public keys and PoS multi-sig quorum which was hard-coded in [PoS.rhox](https://github.com/rchain/rchain/blob/3371c8a400f4b82a7af833f25b9a0b6fc71709db/casper/src/main/resources/PoS.rhox) now can be configured in [defaults.conf](https://github.com/rchain/rchain/blob/4b36505e22ab46ba401775840d6f23920dc85dfa/node/src/main/resources/defaults.conf). Added runtime checking the `pos-multi-sig-quorum` value less or equal length of `pos-multi-sig-public-keys`.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
