### PR TITLE
Fix multi-sig vault with public key authentication

### DIFF
--- a/casper/src/main/resources/MultiSigRevVault.rho
+++ b/casper/src/main/resources/MultiSigRevVault.rho
@@ -18,7 +18,6 @@
 new MultiSigRevVault,
     rs(`rho:registry:insertSigned:secp256k1`), uriOut,
     rl(`rho:registry:lookup`),
-    _fromPublicKey,
     _multiSigRevVault,
     RevVaultCh,
     AuthKeyCh,
@@ -56,21 +55,11 @@ in {
     } |
 
     contract MultiSigRevVault(@"deployerAuthKey", deployerId, ret) = {
-      new DeployerIdOps(`rho:rchain:deployerId:ops`),
-          revAddrCh,
-          deployerPubKeyBytesCh in {
+      new DeployerIdOps(`rho:rchain:deployerId:ops`), deployerPubKeyBytesCh in {
         DeployerIdOps!("pubKeyBytes", *deployerId, *deployerPubKeyBytesCh) |
-        for (@deployerPubKeyBytes <- deployerPubKeyBytesCh) {
-          _fromPublicKey!(deployerPubKeyBytes, *ret)
-        }
-      }
-    } |
-
-    contract _fromPublicKey(@publicKey, ret) = {
-      new RevAddress(`rho:rev:address`), revAddrCh in {
-        RevAddress!("fromPublicKey", publicKey, *revAddrCh)|
-        for (@revAddress <- revAddrCh) {
-          @AuthKey!("make", (*_multiSigRevVault, revAddress), *ret)
+        // Create auth token with deployer public key
+        for(@deployerPubKeyBytes <- deployerPubKeyBytesCh) {
+          @AuthKey!("make", (*_multiSigRevVault, deployerPubKeyBytes), *ret)
         }
       }
     } |
@@ -82,11 +71,10 @@ in {
           quorumSize <= 0) {
         ret!((false, "invalid quorum size"))
       } else {
-        new unf, authKeyCh, authPubKeysCh, RevAddress(`rho:rev:address`), revAddrCh in {
+        new unf, authKeyCh, RevAddress(`rho:rev:address`), revAddrCh in {
           RevAddress!("fromUnforgeable", *unf, *revAddrCh) |
           @RevVault!("unforgeableAuthKey", *unf, *authKeyCh) |
-          @ListOps!("map", publicKeys, *_fromPublicKey, *authPubKeysCh) |
-          for (@revVaultAuthKey <- authKeyCh & @authPubKeys <- authPubKeysCh & @revAddr <- revAddrCh) {
+          for (@revVaultAuthKey <- authKeyCh & @revAddr <- revAddrCh) {
             new multiSig, nonceStore, nonceMapStore, revVaultCh, verify in {
               @RevVault!("findOrCreate", revAddr, *revVaultCh) |
               for (@maybeRevVault <- revVaultCh) {
@@ -107,9 +95,27 @@ in {
                     } |
 
                     contract verify(@auth, idxAuthPubKeysCh, unsealedCh) = {
-                      new unsealerTest in {
-                        // Check whether auth is in the list of authPubKeys
-                        @ListOps!("indexOf", authPubKeys, auth, *idxAuthPubKeysCh) |
+                      new unsealerTest, loopFindAny in {
+                        // Check whether auth is valid to any public key
+                        loopFindAny!(publicKeys, *idxAuthPubKeysCh) |
+                        // Returns either
+                        //   (true, pubKey)  if auth is valid (public key is found)
+                        //   (false, Nil)    if auth is not valid
+                        contract loopFindAny(@list, loopAnyRet) = {
+                          match list {
+                            [] => loopAnyRet!((false, Nil))
+                            [pubKey ... rest] => {
+                              new authCheckRet in {
+                                @AuthKey!("check", auth, (*_multiSigRevVault, pubKey), *authCheckRet) |
+                                for (@isValid <- authCheckRet) {
+                                  if (isValid) loopAnyRet!((true, pubKey))
+                                  else loopFindAny!(rest, *loopAnyRet)
+                                }
+                              }
+                            }
+                          }
+                        } |
+
                         // Check whether auth is a sealed tuple
                         @ListOps!("partialFold", unsealers, (-1, Nil), *unsealerTest, *unsealedCh) |
                         contract unsealerTest(head, @(prevPos, _), result) = {
@@ -132,8 +138,8 @@ in {
                     contract multiSig(@"transfer", @targetRevAddress, @amount, @auth, ret) = {
                       new idxAuthPubKeysCh, unsealedCh in {
                         verify!(auth, *idxAuthPubKeysCh, *unsealedCh) |
-                        for (@idxAuthPubKeys <- idxAuthPubKeysCh & @unsealed, @info <- unsealedCh) {
-                          if (idxAuthPubKeys >= 0 or (unsealed and info.nth(1) == (bundle+{*multiSig}, targetRevAddress, amount, *ret))) {
+                        for (@(hasPubKey, pubKey) <- idxAuthPubKeysCh & @unsealed, @info <- unsealedCh) {
+                          if (hasPubKey or (unsealed and info.nth(1) == (bundle+{*multiSig}, targetRevAddress, amount, *ret))) {
                             for (@nonce <- @(*multiSig, *nonceStore) & @nonceMap <- @(*multiSig, *nonceMapStore)) {
                               @(*multiSig, *nonceStore)!(nonce + 1) |
                               if (quorumSize == 1) {
@@ -179,8 +185,8 @@ in {
                     contract multiSig(@"confirm", @targetRevAddress, @amount, @auth, @nonce, ret) = {
                       new idxAuthPubKeysCh, unsealedCh in {
                         verify!(auth, *idxAuthPubKeysCh, *unsealedCh) |
-                        for (@idxAuthPubKeys <- idxAuthPubKeysCh & @unsealed, @info <- unsealedCh) {
-                          if (idxAuthPubKeys >= 0 or (unsealed and info.nth(1) == (bundle+{*multiSig}, targetRevAddress, amount, nonce, *ret))) {
+                        for (@(hasPubKey, pubKey) <- idxAuthPubKeysCh & @unsealed, @info <- unsealedCh) {
+                          if (hasPubKey or (unsealed and info.nth(1) == (bundle+{*multiSig}, targetRevAddress, amount, nonce, *ret))) {
                             for (@nonceMap <- @(*multiSig, *nonceMapStore)) {
                               match nonceMap.get(nonce) {
                                 Nil => {


### PR DESCRIPTION
## Overview

Currently _auth token_ is checked directly for equality which is not how AuthKey contract should be used making multi-sig unavailable for all defined public keys.
Tests of multi-sig with the use of public keys are not written.

This PR contains a fix to use `AuthKey("check")` method to verify and find public key used for authentication.

**TODO: Add tests for multi-sig with the use of public keys.**

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
