### PR TITLE
Initial Block processing state

### DIFF
--- a/sdk/src/main/scala/coop/rchain/sdk/block/state/BlocksState.scala
+++ b/sdk/src/main/scala/coop/rchain/sdk/block/state/BlocksState.scala
@@ -1,0 +1,20 @@
+package coop.rchain.sdk.block.state
+import coop.rchain.sdk.block.state.Buffered.{AckValidatedEffect, BufferedEffect}
+import coop.rchain.sdk.block.state.Requested.{AckBufferedEffect, RequestedEffect}
+import coop.rchain.sdk.block.state.Validated.Offence
+
+/** State of all blocks known. */
+final case class BlocksState[BId, Peer](
+    requested: Requested[BId, Peer],
+    buffer: Buffered[BId],
+    validated: Validated[BId]
+) {
+  type ST = BlocksState[BId, Peer]
+
+  // New block id is received
+  def bidReceived: (ST, RequestedEffect[Peer]) = ???
+  // Full block is received
+  def blockReceived: (ST, AckBufferedEffect, BufferedEffect[BId]) = ???
+  // Block has been validated
+  def blockValidated(bid: BId, offenceOpt: Option[Offence]): (ST, AckValidatedEffect[BId]) = ???
+}

--- a/sdk/src/main/scala/coop/rchain/sdk/block/state/Buffered.scala
+++ b/sdk/src/main/scala/coop/rchain/sdk/block/state/Buffered.scala
@@ -1,0 +1,57 @@
+package coop.rchain.sdk.block.state
+
+import coop.rchain.sdk.block.state.Buffered.{AckValidatedEffect, BufferedEffect, BufferedState}
+import cats.syntax.all._
+
+import scala.collection.immutable.Set
+
+/** State of DAG buffer - blocks that are received but not validated.. */
+final case class Buffered[BId](st: BufferedState[BId]) {
+  type ST = Buffered[BId]
+
+  def add(
+      bid: BId,
+      deps: Set[BId]
+  )(requested: Set[BId], validated: Set[BId]): (ST, BufferedEffect[BId]) = {
+    val newSt = {
+      val newChildMap = deps.foldLeft(st.childMap.updated(bid, Set())) {
+        case (acc, d) => acc.updated(d, acc.get(d).map(_ + bid).getOrElse(Set()))
+      }
+      st.copy(childMap = newChildMap)
+    }
+    val toRequest = deps.filterNot(bid => validated.contains(bid) || requested.contains(bid))
+    val effect    = BufferedEffect(toRequest)
+    (Buffered(newSt), effect)
+  }
+
+  def ackValidated(bid: BId): (ST, AckValidatedEffect[BId]) = {
+    val (newSt, unlocked) = {
+      val newChildMap = st.childMap - bid
+      assert(st.childMap.contains(bid), "Child map does not have id on ackValidated.")
+      val (unlocked, newDepsMap) = st.depsMap.iterator
+        .map { case (b, deps) => (b, deps - bid) }
+        .partition { case (_, deps) => deps.isEmpty }
+        .bimap(_.map(_._1).toSet, _.toMap)
+      val newDepsFree = st.depsFree ++ unlocked
+      (BufferedState(newChildMap, newDepsMap, newDepsFree), unlocked)
+    }
+    val effect = AckValidatedEffect(unlocked)
+    (Buffered(newSt), effect)
+  }
+
+  def contains(bid: BId): Boolean  = st.childMap.contains(bid)
+  def readyForValidation: Set[BId] = st.depsFree
+}
+
+object Buffered {
+  // State definition
+  final case class BufferedState[BId](
+      childMap: Map[BId, Set[BId]],
+      depsMap: Map[BId, Set[BId]],
+      depsFree: Set[BId]
+  )
+
+  // Effects
+  final case class BufferedEffect[BId](depsToRequest: Set[BId])
+  final case class AckValidatedEffect[BId](unlocked: Set[BId])
+}

--- a/sdk/src/main/scala/coop/rchain/sdk/block/state/Buffered.scala
+++ b/sdk/src/main/scala/coop/rchain/sdk/block/state/Buffered.scala
@@ -20,7 +20,7 @@ final case class Buffered[BId](st: BufferedState[BId]) {
       st.copy(childMap = newChildMap)
     }
     val toRequest = deps.filterNot(bid => validated.contains(bid) || requested.contains(bid))
-    val effect    = BufferedEffect(toRequest)
+    val effect    = BufferedEffect(toRequest, deps.forall(validated.contains))
     (Buffered(newSt), effect)
   }
 
@@ -52,6 +52,6 @@ object Buffered {
   )
 
   // Effects
-  final case class BufferedEffect[BId](depsToRequest: Set[BId])
+  final case class BufferedEffect[BId](depsToRequest: Set[BId], readyForValidation: Boolean)
   final case class AckValidatedEffect[BId](unlocked: Set[BId])
 }

--- a/sdk/src/main/scala/coop/rchain/sdk/block/state/Requested.scala
+++ b/sdk/src/main/scala/coop/rchain/sdk/block/state/Requested.scala
@@ -1,0 +1,83 @@
+package coop.rchain.sdk.block.state
+import cats.syntax.all._
+import coop.rchain.sdk.block.state.Requested._
+
+import scala.concurrent.duration.FiniteDuration
+
+/** State of block requester - blocks that node is aware of, but they are not received. */
+final case class Requested[BId, Peer](st: RequestedState[BId, Peer]) {
+  type ST = Requested[BId, Peer]
+
+  /**
+    * Record observation of a block.
+    * @param bid        block id
+    * @param sourceOpt  peer that sent block id (if provided)
+    * @param now        timestamp
+    * @return new state along with effects to be invoked
+    */
+  def add(bid: BId, sourceOpt: Option[Peer] = None, now: Long): (ST, RequestedEffect[Peer]) = {
+    val curReqOpt = st.get(bid)
+    val newReq = curReqOpt
+      .map { curSt =>
+        val curWaiting = curSt.waiting
+        val newWaiting = sourceOpt.map(curWaiting + _).getOrElse(curWaiting)
+        curSt.copy(waiting = newWaiting)
+      }
+      .getOrElse {
+        val waiting = sourceOpt.map(Set(_)).getOrElse(Set.empty[Peer])
+        RequestState(now, Set.empty[Peer], waiting)
+      }
+    val askPeerOpt = sourceOpt.flatMap { s =>
+      curReqOpt.exists(_.waiting.nonEmpty).guard[Option].as(s)
+    }
+    // if no record for the block ID at all - search for peers that can provide the full block
+    val searchForPeers = curReqOpt.isEmpty
+
+    val newSt  = st.updated(bid, newReq)
+    val effect = RequestedEffect(askPeerOpt, searchForPeers)
+    (Requested(newSt), effect)
+  }
+
+  def ackBuffered(bid: BId): (ST, AckBufferedEffect) = {
+    val newSt  = st - bid
+    val effect = AckBufferedEffect()
+    (Requested(newSt), effect)
+  }
+
+  /** Request all blocks that are timed out. */
+  def requestAll(ageThreshold: FiniteDuration, now: Long): (ST, RequestAllEffect[BId, Peer]) = {
+    val expired = st.filter { case (_, reqSt) => (now - reqSt.timestamp) > ageThreshold.toNanos }
+    val adjusted = expired.mapValues { reqSt =>
+      val nextPeerOpt = reqSt.waiting.headOption
+      val newQueried  = nextPeerOpt.map(reqSt.queried + _).getOrElse(reqSt.queried)
+      val newWaiting  = nextPeerOpt.map(_ => reqSt.waiting.tail).getOrElse(reqSt.waiting)
+      (reqSt.copy(timestamp = now, queried = newQueried, newWaiting), nextPeerOpt)
+    }
+    val toRequest = adjusted.map { case (block, (_, nextPeerOpt)) => (block, nextPeerOpt) }.toList
+
+    val newSt  = st ++ adjusted.mapValues(_._1)
+    val effect = RequestAllEffect(toRequest)
+    (Requested(newSt), effect)
+  }
+
+  def contains(bid: BId): Boolean = st.contains(bid)
+}
+
+object Requested {
+  // State definition
+  final case class RequestState[Peer](
+      timestamp: Long,                // Last time block was requested
+      queried: Set[Peer] = Set.empty, // Peers that were queried for this block
+      waiting: Set[Peer] = Set.empty  // Peers that reportedly have block and are yet to be queried
+  )
+  type RequestedState[BId, Peer] = Map[BId, RequestState[Peer]]
+
+  // Effects
+  // adding block id to requested might trigger request of the full block from some peer,
+  // or search for peers that have target block
+  final case class RequestedEffect[Peer](askPeerOpt: Option[Peer], searchForPeers: Boolean)
+  // no effects are required when acknowledging that block requested is buffered
+  final case class AckBufferedEffect()
+  // request blocks from some peers
+  final case class RequestAllEffect[BId, Peer](toRequest: List[(BId, Option[Peer])])
+}

--- a/sdk/src/main/scala/coop/rchain/sdk/block/state/Validated.scala
+++ b/sdk/src/main/scala/coop/rchain/sdk/block/state/Validated.scala
@@ -1,0 +1,32 @@
+package coop.rchain.sdk.block.state
+import cats.syntax.all._
+import coop.rchain.sdk.block.state.Validated._
+
+/** State of validated DAG. */
+final case class Validated[BId](st: ValidatedState[BId]) {
+  type ST = Validated[BId]
+
+  def add(b: BId, offenceOpt: Option[Offence]): (ST, ValidatedEffect[BId]) = {
+    val newSt  = st                                              // TODO
+    val effect = ValidatedEffect(none[Offence], List.empty[BId]) // TODO
+    (Validated(newSt), effect)
+  }
+
+  // Prune to LFS
+  def prune() = ??? // TODO
+
+  def contains(bid: BId): Boolean = st.dagSet.contains(bid)
+}
+
+object Validated {
+  // State definition
+  final case class ValidatedState[BId](dagSet: Set[BId]) // TODO this is content of BlockDagRepresentation
+
+  // Effects
+  final case class ValidatedEffect[BId](offence: Option[Offence], childrenUnlocked: List[BId])
+
+  trait Offence
+  // Now in Casper code there is no distinction between offences, just invalid block.
+  // In future would be good to store particular offence, but now it might be easier to use just this
+  final case object UnknownOffence extends Offence
+}


### PR DESCRIPTION
## Overview
Initial state for block processing. State is divided into 3 pieces, controlling blocks that are requested, recieved, and validated.

`Requested` is a pure translation of the effectful logic in [BlockRetriever](https://github.com/rchain/rchain/blob/5fac15cd259da0bfe96640c0c1829c8816d1eac3/casper/src/main/scala/coop/rchain/casper/engine/BlockRetriever.scala).
### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


###se make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
