### PR TITLE
Fix nonce confirmation to use public key

### DIFF
--- a/casper/src/main/resources/MultiSigRevVault.rho
+++ b/casper/src/main/resources/MultiSigRevVault.rho
@@ -94,10 +94,10 @@ in {
                       @revVault!("balance", *ret)
                     } |
 
-                    contract verify(@auth, idxAuthPubKeysCh, unsealedCh) = {
+                    contract verify(@auth, pubKeysCh, unsealedCh) = {
                       new unsealerTest, loopFindAny in {
                         // Check whether auth is valid to any public key
-                        loopFindAny!(publicKeys, *idxAuthPubKeysCh) |
+                        loopFindAny!(publicKeys, *pubKeysCh) |
                         // Returns either
                         //   (true, pubKey)  if auth is valid (public key is found)
                         //   (false, Nil)    if auth is not valid
@@ -136,9 +136,9 @@ in {
                     //         (true, (false, "done")) when only one sig required
                     //         (false, errorMsg) on failure
                     contract multiSig(@"transfer", @targetRevAddress, @amount, @auth, ret) = {
-                      new idxAuthPubKeysCh, unsealedCh in {
-                        verify!(auth, *idxAuthPubKeysCh, *unsealedCh) |
-                        for (@(hasPubKey, pubKey) <- idxAuthPubKeysCh & @unsealed, @info <- unsealedCh) {
+                      new pubKeysCh, unsealedCh in {
+                        verify!(auth, *pubKeysCh, *unsealedCh) |
+                        for (@(hasPubKey, pubKey) <- pubKeysCh & @unsealed, @info <- unsealedCh) {
                           if (hasPubKey or (unsealed and info.nth(1) == (bundle+{*multiSig}, targetRevAddress, amount, *ret))) {
                             for (@nonce <- @(*multiSig, *nonceStore) & @nonceMap <- @(*multiSig, *nonceMapStore)) {
                               @(*multiSig, *nonceStore)!(nonce + 1) |
@@ -183,9 +183,9 @@ in {
                     //         (true, (false, "done")) when all required sigs have been provided
                     //         (false, errorMsg) on failure
                     contract multiSig(@"confirm", @targetRevAddress, @amount, @auth, @nonce, ret) = {
-                      new idxAuthPubKeysCh, unsealedCh in {
-                        verify!(auth, *idxAuthPubKeysCh, *unsealedCh) |
-                        for (@(hasPubKey, pubKey) <- idxAuthPubKeysCh & @unsealed, @info <- unsealedCh) {
+                      new pubKeysCh, unsealedCh in {
+                        verify!(auth, *pubKeysCh, *unsealedCh) |
+                        for (@(hasPubKey, pubKey) <- pubKeysCh & @unsealed, @info <- unsealedCh) {
                           if (hasPubKey or (unsealed and info.nth(1) == (bundle+{*multiSig}, targetRevAddress, amount, nonce, *ret))) {
                             for (@nonceMap <- @(*multiSig, *nonceMapStore)) {
                               match nonceMap.get(nonce) {

--- a/casper/src/main/resources/MultiSigRevVault.rho
+++ b/casper/src/main/resources/MultiSigRevVault.rho
@@ -163,7 +163,7 @@ in {
                                 } else {
                                   // If a human is confirming, record which deployerAuthKey was used
                                   @(*multiSig, *nonceMapStore)!(
-                                    nonceMap.set(nonce, (targetRevAddress, amount, Set(auth)))
+                                    nonceMap.set(nonce, (targetRevAddress, amount, Set(pubKey)))
                                   )
                                 } |
                                 ret!((true, (true, nonce)))
@@ -199,7 +199,7 @@ in {
                                     @(*multiSig, *nonceMapStore)!(nonceMap) |
                                     ret!((false, "given data does not match stored data"))
                                   } else {
-                                    if (((not unsealed) and nonceConfirmers.contains(auth)) or
+                                    if (((not unsealed) and nonceConfirmers.contains(pubKey)) or
                                         (unsealed and nonceConfirmers.contains(unsealers.nth(info.nth(0))))) {
                                       @(*multiSig, *nonceMapStore)!(nonceMap) |
                                       ret!((false, "already confirmed"))
@@ -230,7 +230,7 @@ in {
                                           // If a human is confirming, record which deployerAuthKey was used
                                           @(*multiSig, *nonceMapStore)!(
                                             nonceMap.set(nonce,
-                                              (targetRevAddress, amount, nonceConfirmers.add(auth))
+                                              (targetRevAddress, amount, nonceConfirmers.add(pubKey))
                                             )
                                           )
                                         } |


### PR DESCRIPTION
## Overview

This PR contains additional commits to the fix of multi-sig vault to use public key in nonce confirmation instead of auth token.

- #3639

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
