### PR TITLE
Change LFS chunk size to 750 nodes

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/LfsTupleSpaceRequester.scala
@@ -35,9 +35,10 @@ object LfsTupleSpaceRequester {
     */
   type StatePartPath = Seq[(Blake2b256Hash, Option[Byte])]
 
-  // TODO: extract this as a parameter
-  // 20,000 records uses about 2G of direct buffer memory on importing side
-  val pageSize = 20000
+  /**
+    * Number of nodes in LFS sync data transfer
+    */
+  val pageSize = 750
 
   /**
     * State to control processing of requests


### PR DESCRIPTION
## Overview

Heap and direct buffer memory usage on LFS syncing is much higher with the new history. The main reason is different binary size per history node.
This PR reduces the size from 20k to 750 nodes. Sync on test net shows heap usage ~1GB, direct buffer ~85MB with ~450 requests/chunks for RSpace size ~7.5GB in ~10 min.

| Nodes \ Stats | Heap (max) | Direct Buffer (max) | Chunks |   Time |
|--------------:|-----------:|--------------------:|-------:|-------:|
| 500           |       1 GB |               48 MB | 667    | 10 min |
| 750           |       1 GB |               85 MB | 447    | 10 min |
| 1000          |    1.25 GB |              100 MB | 337    | 10 min |
| 1500          | 2.5 GB     | 210 MB              | 227    | 11 min |
| 4000          |       2 GB |              270 MB | 92     | 17 min |

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
