### PR TITLE
Refactor BlockMetaData serializer to use scodec

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
@@ -37,12 +37,10 @@ class BlockMetadataCodecsTest extends FlatSpec {
       finalized = false
     )
 
-    val serialized = testBlockMetadataScodec.toByteString
-    println(s"serialized: $serialized")
+    val serialized         = testBlockMetadataScodec.toByteString
     val reconstructedBlock = MetadataScodec.decode(serialized)
-    println(s"deserialized: $reconstructedBlock")
 
-    reconstructedBlock shouldBe testBlockMetadataScodec
+    reconstructedBlock.toBlockMetadataBV() shouldBe testBlockMetadataScodec.toBlockMetadataBV()
   }
 }
 

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
@@ -3,7 +3,15 @@ package coop.rchain.casper.util
 import cats.effect.Sync
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.Justification
-import coop.rchain.models.{BlockMetadata, BlockMetadataAB, JustificationArr}
+import coop.rchain.models.{
+  BlockMetadata,
+  BlockMetadataAB,
+  BlockMetadataBS,
+  BlockMetadataBV,
+  JustificationArr,
+  JustificationBS,
+  JustificationBV
+}
 import coop.rchain.shared.Base16
 import monix.eval.Task
 import org.scalatest.FlatSpec
@@ -81,6 +89,52 @@ object GeneratorBlockMetadata {
       block.directlyFinalized,
       block.finalized
     )
+
+  def toBlockMetadataBV(block: BlockMetadata): BlockMetadataBV =
+    BlockMetadataBV(
+      ByteVector(block.blockHash.toByteArray),
+      block.parents.map(parent => ByteVector(parent.toByteArray)),
+      ByteVector(block.sender.toByteArray),
+      block.justifications.map(
+        just =>
+          JustificationBV(
+            ByteVector(just.validator.toByteArray),
+            ByteVector(just.latestBlockHash.toByteArray)
+          )
+      ),
+      block.weightMap.map { case (k, v) => (ByteVector(k.toByteArray) -> v) },
+      block.blockNum,
+      block.seqNum,
+      block.invalid,
+      block.directlyFinalized,
+      block.finalized
+    )
+
+  def randomBlockMetadataBV(parentsCount: Int, justCount: Int, weightCount: Int): BlockMetadataBV =
+    toBlockMetadataBV(randomBlockMetadata(parentsCount, justCount, weightCount))
+
+  def toBlockMetadataBS(block: BlockMetadata): BlockMetadataBS =
+    BlockMetadataBS(
+      ByteString.copyFrom(block.blockHash.toByteArray),
+      block.parents.map(parent => ByteString.copyFrom(parent.toByteArray)),
+      ByteString.copyFrom(block.sender.toByteArray),
+      block.justifications.map(
+        just =>
+          JustificationBS(
+            ByteString.copyFrom(just.validator.toByteArray),
+            ByteString.copyFrom(just.latestBlockHash.toByteArray)
+          )
+      ),
+      block.weightMap.map { case (k, v) => (ByteString.copyFrom(k.toByteArray) -> v) },
+      block.blockNum,
+      block.seqNum,
+      block.invalid,
+      block.directlyFinalized,
+      block.finalized
+    )
+
+  def randomBlockMetadataBS(parentsCount: Int, justCount: Int, weightCount: Int): BlockMetadataBS =
+    toBlockMetadataBS(randomBlockMetadata(parentsCount, justCount, weightCount))
 }
 
 class BlockMetadataCodecsTest extends FlatSpec {

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
@@ -1,0 +1,225 @@
+package coop.rchain.casper.util
+
+import cats.effect.Sync
+import com.google.protobuf.ByteString
+import coop.rchain.blockstorage.dag.codecs
+import coop.rchain.casper.protocol.Justification
+import coop.rchain.models.{BlockMetadata, BlockMetadataScodec, JustificationArr, MetadataScodec}
+import coop.rchain.shared.{Base16, Stopwatch}
+import monix.eval.Task
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers.convertToAnyShouldWrapper
+import scodec.bits.ByteVector
+import scodec.codecs.{bytes, uint8, variableSizeBytes}
+
+import scala.concurrent.duration.Duration
+
+class BlockMetadataCodecsTest extends FlatSpec {
+  private def createByteArray(s: String) = Base16.unsafeDecode(s)
+  "encode BlockMetadata object with new codec and decode serialized data" should "give initial object" in {
+    val testBlockMetadataScodec = BlockMetadataScodec(
+      blockHash = createByteArray("112233AA"),
+      parents =
+        List(createByteArray("AABBCC"), createByteArray("DCAA01"), createByteArray("AABBCC")),
+      sender = createByteArray("56FA55C1FC"),
+      justifications = List(
+        JustificationArr(createByteArray("347899"), createByteArray("561131")),
+        JustificationArr(createByteArray("34789943"), createByteArray("5631"))
+      ),
+      weightMap = Map(
+        createByteArray("437800") -> 233212L,
+        createByteArray("9911")   -> 23232L
+      ),
+      blockNum = 34,
+      seqNum = 2,
+      invalid = false,
+      directlyFinalized = false,
+      finalized = false
+    )
+
+    val serialized = testBlockMetadataScodec.toByteString
+    println(s"serialized: $serialized")
+    val reconstructedBlock = MetadataScodec.decode(serialized)
+    println(s"deserialized: $reconstructedBlock")
+
+    reconstructedBlock shouldBe testBlockMetadataScodec
+  }
+}
+
+class TimingMeasure extends FlatSpec {
+  it should "BlockMetadata with protobuf codec" in {
+    timingExperiment(
+      codecName = "BlockMetadata with protobuf codec",
+      new BlockMetadataProtobufCodec,
+      generateRandomBlockMetadata
+    )
+  }
+
+  it should "new scodec - codec" in {
+    timingExperiment(
+      codecName = "New scodec - codec",
+      new BlockMetadataScodecSerializer,
+      generateRandomBlockMetadataScodec
+    )
+  }
+
+  sealed trait UniversalCodec[T] {
+    def encode(block: T): ByteVector
+    def decode(serialized: ByteVector): T
+  }
+
+  class BlockMetadataProtobufCodec extends UniversalCodec[BlockMetadata] {
+    override def encode(block: BlockMetadata): ByteVector =
+      codecs.codecBlockMetadata.encode(block).require.toByteVector
+    def decode(serialized: ByteVector): BlockMetadata =
+      codecs.codecBlockMetadata.decode(serialized.toBitVector).require.value
+  }
+
+  class BlockMetadataScodecSerializer extends UniversalCodec[BlockMetadataScodec] {
+    override def encode(block: BlockMetadataScodec): ByteVector =
+      MetadataScodec.encode(block)
+    def decode(serialized: ByteVector): BlockMetadataScodec =
+      MetadataScodec.decode(serialized)
+  }
+
+  def timingExperiment[T, D <: UniversalCodec[T]](
+      codecName: String,
+      anyCodec: D,
+      generateBlock: (Int, Int, Int) => T,
+      averageStatistic: Boolean = false
+  ): Unit = {
+    def experiment(num: Int): Unit = {
+      val averageNum    = 500
+      val averageWarmUp = 1
+
+      val result =
+        (0 until (averageNum + averageWarmUp)).toList
+          .foldLeft((0L, 0L)) {
+            case ((timeEncode, timeDecode), i) =>
+              val blocks = (0 until num).map { _ =>
+                generateBlock(100, 100, 100)
+              }
+
+              def statistic(timeEncode: Long, timeDecode: Long): Unit = {
+                def iI(v: Int): String = "%7d) ".format(v)
+
+                def mS(v: Long) = "%7.3f ".format(v.toDouble / 1000)
+
+                val str = iI(i) + "  " + mS(timeEncode) + "    " + mS(timeDecode)
+                println(str)
+              }
+
+              val (blockEncode, timeEncodeTemp) = {
+                val t0  = System.nanoTime
+                val res = blocks.map(anyCodec.encode)
+                val t1  = System.nanoTime
+                val m   = Duration.fromNanos(t1 - t0).toMillis
+                (res, m)
+              }
+
+              val (_, timeDecodeTemp) = {
+                val t0  = System.nanoTime
+                val res = blockEncode.map(v => anyCodec.decode(v))
+                val t1  = System.nanoTime
+                val m   = Duration.fromNanos(t1 - t0).toMillis
+                (res, m)
+              }
+
+              //  assert(blockDecode == nodes, "Encoded and decoded node should be same")
+
+              if (averageStatistic) statistic(timeEncodeTemp, timeDecodeTemp)
+
+              if (i < averageWarmUp) (timeEncode, timeDecode)
+              else
+                (
+                  timeEncode + timeEncodeTemp,
+                  timeDecode + timeDecodeTemp
+                )
+          }
+
+      def numStr(v: Int) = "%7d".format(v)
+
+      def mS(v: Long) = "%7.3f".format(v.toDouble / (1000.toDouble * averageNum.toDouble))
+
+      val str = numStr(num) + " | " + mS(result._1) + " | " + mS(result._2)
+      println(str)
+    }
+
+    def fS(v: String): String = "%7s".format(v)
+
+    println(s"$codecName")
+    val strTitle = fS("num") + " | " + fS("timeEnc(sec)") + " | " + fS("timeDec(sec)")
+    println(strTitle)
+
+    experiment(num = 40)
+  }
+
+  private def arrayToByteString(arrInt: Array[Byte]) = ByteString.copyFrom(arrInt)
+  private def generateRandomArray(size: Int): Array[Byte] = {
+    val r   = scala.util.Random
+    val arr = new Array[Byte](size)
+    for (i <- arr.indices) arr(i) = r.nextInt(255).toByte
+    arr
+  }
+  private def generateRandomBlockMetadata(
+      parentsCount: Int,
+      justCount: Int,
+      weightCount: Int
+  ): BlockMetadata = {
+    val blockHash = arrayToByteString(generateRandomArray(size = 32))
+    val parents =
+      (0 until parentsCount).toList.map(_ => arrayToByteString(generateRandomArray(size = 32)))
+    val sender = arrayToByteString(generateRandomArray(size = 10))
+    val justifications = (0 until justCount).toList.map(
+      _ =>
+        Justification(
+          arrayToByteString(generateRandomArray(size = 32)),
+          arrayToByteString(generateRandomArray(size = 22))
+        )
+    )
+
+    val weightMap = (0 until weightCount).toList
+      .map(_ => arrayToByteString(generateRandomArray(size = 11)) -> 11223344L)
+      .toMap
+
+    BlockMetadata(
+      blockHash,
+      parents,
+      sender,
+      justifications,
+      weightMap,
+      blockNum = 6,
+      seqNum = 4,
+      invalid = false,
+      directlyFinalized = false,
+      finalized = false
+    )
+  }
+
+  private def generateRandomBlockMetadataScodec(
+      parentsCount: Int,
+      justCount: Int,
+      weightCount: Int
+  ): BlockMetadataScodec =
+    toBlockMetadataScodec(generateRandomBlockMetadata(parentsCount, justCount, weightCount))
+
+  private def toBlockMetadataScodec(block: BlockMetadata): BlockMetadataScodec =
+    BlockMetadataScodec(
+      block.blockHash.toByteArray,
+      block.parents.map(parent => parent.toByteArray),
+      block.sender.toByteArray,
+      block.justifications.map(
+        just =>
+          JustificationArr(
+            just.validator.toByteArray,
+            just.latestBlockHash.toByteArray
+          )
+      ),
+      block.weightMap.map { case (str, long) => (str.toByteArray, long) },
+      block.blockNum,
+      block.seqNum,
+      block.invalid,
+      block.directlyFinalized,
+      block.finalized
+    )
+}

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
@@ -106,7 +106,7 @@ class BlockMetadataCodecsTest extends FlatSpec {
     areEqual shouldBe true
   }
 
-  "encode BlockMetadataScodec object with some empty fields" should "give initial object without errors" in {
+  "encode BlockMetadataScodec object with some empty fields and decode binary data" should "give initial object without errors" in {
     val referenceBlocks = List(
       randomBlockMetadataScodec(parentsCount = 0, justCount = 10, weightCount = 10),
       randomBlockMetadataScodec(parentsCount = 10, justCount = 0, weightCount = 10),

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
@@ -2,182 +2,43 @@ package coop.rchain.casper.util
 
 import cats.effect.Sync
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.dag.codecs
 import coop.rchain.casper.protocol.Justification
-import coop.rchain.models.{BlockMetadata, BlockMetadataScodec, JustificationArr, MetadataScodec}
-import coop.rchain.shared.{Base16, Stopwatch}
+import coop.rchain.models.{BlockMetadata, BlockMetadataAB, JustificationArr}
+import coop.rchain.shared.Base16
 import monix.eval.Task
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers.convertToAnyShouldWrapper
 import scodec.bits.ByteVector
-import scodec.codecs.{bytes, uint8, variableSizeBytes}
 
 import scala.concurrent.duration.Duration
 
-class BlockMetadataCodecsTest extends FlatSpec {
-  private def createByteArray(s: String) = Base16.unsafeDecode(s)
-  "encode BlockMetadata object with new codec and decode serialized data" should "give initial object" in {
-    val testBlockMetadataScodec = BlockMetadataScodec(
-      blockHash = createByteArray("112233AA"),
-      parents =
-        List(createByteArray("AABBCC"), createByteArray("DCAA01"), createByteArray("AABBCC")),
-      sender = createByteArray("56FA55C1FC"),
-      justifications = List(
-        JustificationArr(createByteArray("347899"), createByteArray("561131")),
-        JustificationArr(createByteArray("34789943"), createByteArray("5631"))
-      ),
-      weightMap = Map(
-        createByteArray("437800") -> 233212L,
-        createByteArray("9911")   -> 23232L
-      ),
-      blockNum = 34,
-      seqNum = 2,
-      invalid = false,
-      directlyFinalized = false,
-      finalized = false
-    )
-
-    val serialized         = testBlockMetadataScodec.toByteString
-    val reconstructedBlock = MetadataScodec.decode(serialized)
-
-    reconstructedBlock.toBlockMetadataBV() shouldBe testBlockMetadataScodec.toBlockMetadataBV()
-  }
-}
-
-class TimingMeasure extends FlatSpec {
-  it should "BlockMetadata with protobuf codec" in {
-    timingExperiment(
-      codecName = "BlockMetadata with protobuf codec",
-      new BlockMetadataProtobufCodec,
-      generateRandomBlockMetadata
-    )
-  }
-
-  it should "new scodec - codec" in {
-    timingExperiment(
-      codecName = "New scodec - codec",
-      new BlockMetadataScodecSerializer,
-      generateRandomBlockMetadataScodec
-    )
-  }
-
-  sealed trait UniversalCodec[T] {
-    def encode(block: T): ByteVector
-    def decode(serialized: ByteVector): T
-  }
-
-  class BlockMetadataProtobufCodec extends UniversalCodec[BlockMetadata] {
-    override def encode(block: BlockMetadata): ByteVector =
-      codecs.codecBlockMetadata.encode(block).require.toByteVector
-    def decode(serialized: ByteVector): BlockMetadata =
-      codecs.codecBlockMetadata.decode(serialized.toBitVector).require.value
-  }
-
-  class BlockMetadataScodecSerializer extends UniversalCodec[BlockMetadataScodec] {
-    override def encode(block: BlockMetadataScodec): ByteVector =
-      MetadataScodec.encode(block)
-    def decode(serialized: ByteVector): BlockMetadataScodec =
-      MetadataScodec.decode(serialized)
-  }
-
-  def timingExperiment[T, D <: UniversalCodec[T]](
-      codecName: String,
-      anyCodec: D,
-      generateBlock: (Int, Int, Int) => T,
-      averageStatistic: Boolean = false
-  ): Unit = {
-    def experiment(num: Int): Unit = {
-      val averageNum    = 500
-      val averageWarmUp = 1
-
-      val result =
-        (0 until (averageNum + averageWarmUp)).toList
-          .foldLeft((0L, 0L)) {
-            case ((timeEncode, timeDecode), i) =>
-              val blocks = (0 until num).map { _ =>
-                generateBlock(100, 100, 100)
-              }
-
-              def statistic(timeEncode: Long, timeDecode: Long): Unit = {
-                def iI(v: Int): String = "%7d) ".format(v)
-
-                def mS(v: Long) = "%7.3f ".format(v.toDouble / 1000)
-
-                val str = iI(i) + "  " + mS(timeEncode) + "    " + mS(timeDecode)
-                println(str)
-              }
-
-              val (blockEncode, timeEncodeTemp) = {
-                val t0  = System.nanoTime
-                val res = blocks.map(anyCodec.encode)
-                val t1  = System.nanoTime
-                val m   = Duration.fromNanos(t1 - t0).toMillis
-                (res, m)
-              }
-
-              val (_, timeDecodeTemp) = {
-                val t0  = System.nanoTime
-                val res = blockEncode.map(v => anyCodec.decode(v))
-                val t1  = System.nanoTime
-                val m   = Duration.fromNanos(t1 - t0).toMillis
-                (res, m)
-              }
-
-              //  assert(blockDecode == nodes, "Encoded and decoded node should be same")
-
-              if (averageStatistic) statistic(timeEncodeTemp, timeDecodeTemp)
-
-              if (i < averageWarmUp) (timeEncode, timeDecode)
-              else
-                (
-                  timeEncode + timeEncodeTemp,
-                  timeDecode + timeDecodeTemp
-                )
-          }
-
-      def numStr(v: Int) = "%7d".format(v)
-
-      def mS(v: Long) = "%7.3f".format(v.toDouble / (1000.toDouble * averageNum.toDouble))
-
-      val str = numStr(num) + " | " + mS(result._1) + " | " + mS(result._2)
-      println(str)
-    }
-
-    def fS(v: String): String = "%7s".format(v)
-
-    println(s"$codecName")
-    val strTitle = fS("num") + " | " + fS("timeEnc(sec)") + " | " + fS("timeDec(sec)")
-    println(strTitle)
-
-    experiment(num = 40)
-  }
-
+object GeneratorBlockMetadata {
   private def arrayToByteString(arrInt: Array[Byte]) = ByteString.copyFrom(arrInt)
-  private def generateRandomArray(size: Int): Array[Byte] = {
+  def randomArray(size: Int): Array[Byte] = {
     val r   = scala.util.Random
     val arr = new Array[Byte](size)
     for (i <- arr.indices) arr(i) = r.nextInt(255).toByte
     arr
   }
-  private def generateRandomBlockMetadata(
+  def randomBlockMetadata(
       parentsCount: Int,
       justCount: Int,
       weightCount: Int
   ): BlockMetadata = {
-    val blockHash = arrayToByteString(generateRandomArray(size = 32))
+    val blockHash = arrayToByteString(randomArray(size = 32))
     val parents =
-      (0 until parentsCount).toList.map(_ => arrayToByteString(generateRandomArray(size = 32)))
-    val sender = arrayToByteString(generateRandomArray(size = 10))
+      (0 until parentsCount).toList.map(_ => arrayToByteString(randomArray(size = 32)))
+    val sender = arrayToByteString(randomArray(size = 10))
     val justifications = (0 until justCount).toList.map(
       _ =>
         Justification(
-          arrayToByteString(generateRandomArray(size = 32)),
-          arrayToByteString(generateRandomArray(size = 22))
+          arrayToByteString(randomArray(size = 32)),
+          arrayToByteString(randomArray(size = 22))
         )
     )
 
     val weightMap = (0 until weightCount).toList
-      .map(_ => arrayToByteString(generateRandomArray(size = 11)) -> 11223344L)
+      .map(_ => arrayToByteString(randomArray(size = 11)) -> 11112L)
       .toMap
 
     BlockMetadata(
@@ -186,23 +47,23 @@ class TimingMeasure extends FlatSpec {
       sender,
       justifications,
       weightMap,
-      blockNum = 6,
-      seqNum = 4,
+      blockNum = 123456L,
+      seqNum = 11,
       invalid = false,
       directlyFinalized = false,
       finalized = false
     )
   }
 
-  private def generateRandomBlockMetadataScodec(
+  def randomBlockMetadataScodec(
       parentsCount: Int,
       justCount: Int,
       weightCount: Int
-  ): BlockMetadataScodec =
-    toBlockMetadataScodec(generateRandomBlockMetadata(parentsCount, justCount, weightCount))
+  ): BlockMetadataAB =
+    toBlockMetadataScodec(randomBlockMetadata(parentsCount, justCount, weightCount))
 
-  private def toBlockMetadataScodec(block: BlockMetadata): BlockMetadataScodec =
-    BlockMetadataScodec(
+  def toBlockMetadataScodec(block: BlockMetadata): BlockMetadataAB =
+    BlockMetadataAB(
       block.blockHash.toByteArray,
       block.parents.map(parent => parent.toByteArray),
       block.sender.toByteArray,
@@ -213,11 +74,49 @@ class TimingMeasure extends FlatSpec {
             just.latestBlockHash.toByteArray
           )
       ),
-      block.weightMap.map { case (str, long) => (str.toByteArray, long) },
+      block.weightMap.map { case (k, v) => (k.toByteArray -> v) },
       block.blockNum,
       block.seqNum,
       block.invalid,
       block.directlyFinalized,
       block.finalized
     )
+}
+
+class BlockMetadataCodecsTest extends FlatSpec {
+  import GeneratorBlockMetadata._
+  "encode BlockMetadataScodec object with new codec and decode serialized data" should "give initial object" in {
+    val testBlockMetadataScodec = randomBlockMetadataScodec(
+      parentsCount = 10,
+      justCount = 10,
+      weightCount = 100
+    )
+
+    val testBlockMetadataScodec2 = randomBlockMetadataScodec(
+      parentsCount = 10,
+      justCount = 20,
+      weightCount = 5
+    )
+
+    val referenceBlocks = Vector(testBlockMetadataScodec, testBlockMetadataScodec2)
+    val serialized      = referenceBlocks.map(BlockMetadataAB.toByteVector)
+    val reconstructed   = serialized.map(BlockMetadataAB.fromByteVector)
+
+    val areEqual = reconstructed.zip(referenceBlocks).forall { case (a, b) => a.isEqualTo(b) }
+    areEqual shouldBe true
+  }
+
+  "encode BlockMetadataScodec object with some empty fields" should "give initial object without errors" in {
+    val referenceBlocks = List(
+      randomBlockMetadataScodec(parentsCount = 0, justCount = 10, weightCount = 10),
+      randomBlockMetadataScodec(parentsCount = 10, justCount = 0, weightCount = 10),
+      randomBlockMetadataScodec(parentsCount = 10, justCount = 10, weightCount = 0)
+    )
+
+    val serialized    = referenceBlocks.map(BlockMetadataAB.toByteVector)
+    val reconstructed = serialized.map(BlockMetadataAB.fromByteVector)
+
+    val areEqual = (reconstructed zip referenceBlocks).forall { case (a, b) => a.isEqualTo(b) }
+    areEqual shouldBe true
+  }
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataCodecsTest.scala
@@ -8,7 +8,7 @@ import coop.rchain.models.{
   BlockMetadataAB,
   BlockMetadataBS,
   BlockMetadataBV,
-  JustificationArr,
+  JustificationBA,
   JustificationBS,
   JustificationBV
 }
@@ -63,21 +63,21 @@ object GeneratorBlockMetadata {
     )
   }
 
-  def randomBlockMetadataScodec(
+  def randomBlockMetadataAB(
       parentsCount: Int,
       justCount: Int,
       weightCount: Int
   ): BlockMetadataAB =
-    toBlockMetadataScodec(randomBlockMetadata(parentsCount, justCount, weightCount))
+    toBlockMetadataAB(randomBlockMetadata(parentsCount, justCount, weightCount))
 
-  def toBlockMetadataScodec(block: BlockMetadata): BlockMetadataAB =
+  def toBlockMetadataAB(block: BlockMetadata): BlockMetadataAB =
     BlockMetadataAB(
       block.blockHash.toByteArray,
       block.parents.map(parent => parent.toByteArray),
       block.sender.toByteArray,
       block.justifications.map(
         just =>
-          JustificationArr(
+          JustificationBA(
             just.validator.toByteArray,
             just.latestBlockHash.toByteArray
           )
@@ -140,13 +140,13 @@ object GeneratorBlockMetadata {
 class BlockMetadataCodecsTest extends FlatSpec {
   import GeneratorBlockMetadata._
   "encode BlockMetadataScodec object with new codec and decode serialized data" should "give initial object" in {
-    val testBlockMetadataScodec = randomBlockMetadataScodec(
+    val testBlockMetadataScodec = randomBlockMetadataAB(
       parentsCount = 10,
       justCount = 10,
       weightCount = 100
     )
 
-    val testBlockMetadataScodec2 = randomBlockMetadataScodec(
+    val testBlockMetadataScodec2 = randomBlockMetadataAB(
       parentsCount = 10,
       justCount = 20,
       weightCount = 5
@@ -162,9 +162,9 @@ class BlockMetadataCodecsTest extends FlatSpec {
 
   "encode BlockMetadataScodec object with some empty fields and decode binary data" should "give initial object without errors" in {
     val referenceBlocks = List(
-      randomBlockMetadataScodec(parentsCount = 0, justCount = 10, weightCount = 10),
-      randomBlockMetadataScodec(parentsCount = 10, justCount = 0, weightCount = 10),
-      randomBlockMetadataScodec(parentsCount = 10, justCount = 10, weightCount = 0)
+      randomBlockMetadataAB(parentsCount = 0, justCount = 10, weightCount = 10),
+      randomBlockMetadataAB(parentsCount = 10, justCount = 0, weightCount = 10),
+      randomBlockMetadataAB(parentsCount = 10, justCount = 10, weightCount = 0)
     )
 
     val serialized    = referenceBlocks.map(BlockMetadataAB.toByteVector)

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataTimingMeasure.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataTimingMeasure.scala
@@ -1,0 +1,124 @@
+import coop.rchain.blockstorage.dag.codecs
+import coop.rchain.casper.util.GeneratorBlockMetadata
+import coop.rchain.models.{BlockMetadata, BlockMetadataAB}
+import org.scalatest.FlatSpec
+import scodec.bits.ByteVector
+
+import scala.concurrent.duration.Duration
+
+class BlockMetadataTimingMeasure extends FlatSpec {
+  sealed trait UniversalCodec[T] {
+    def encode(block: T): ByteVector
+    def decode(serialized: ByteVector): T
+  }
+
+  import GeneratorBlockMetadata._
+
+  class BlockMetadataProtobufCodec extends UniversalCodec[BlockMetadata] {
+    override def encode(block: BlockMetadata): ByteVector =
+      codecs.codecBlockMetadata.encode(block).require.toByteVector
+    def decode(serialized: ByteVector): BlockMetadata =
+      codecs.codecBlockMetadata.decode(serialized.toBitVector).require.value
+  }
+
+  class BlockMetadataScodecSerializer extends UniversalCodec[BlockMetadataAB] {
+    override def encode(block: BlockMetadataAB): ByteVector =
+      block.toByteVector
+    def decode(serialized: ByteVector): BlockMetadataAB =
+      BlockMetadataAB.fromByteVector(serialized)
+  }
+
+  it should "Time - measurement of protobuf codec" in {
+    def compareBlocks(a: BlockMetadata, b: BlockMetadata): Boolean = a == b
+    timingExperiment(
+      codecName = "BlockMetadata with protobuf codec",
+      new BlockMetadataProtobufCodec,
+      randomBlockMetadata,
+      compareBlocks
+    )
+  }
+
+  it should "Time - measurement of scodec - codec" in {
+    def compareBlocks(a: BlockMetadataAB, b: BlockMetadataAB): Boolean = a.isEqualTo(b)
+    timingExperiment(
+      codecName = "New scodec - codec",
+      new BlockMetadataScodecSerializer,
+      randomBlockMetadataScodec,
+      compareBlocks
+    )
+  }
+
+  def timingExperiment[T, D <: UniversalCodec[T]](
+      codecName: String,
+      codec: D,
+      generateBlock: (Int, Int, Int) => T,
+      compareBlocks: (T, T) => Boolean,
+      averageStatistic: Boolean = false
+  ): Unit = {
+    def experiment(num: Int): Unit = {
+      val averageNum    = 50
+      val averageWarmUp = 1
+
+      val result =
+        (0 until (averageNum + averageWarmUp)).toList
+          .foldLeft((0L, 0L)) {
+            case ((timeEncode, timeDecode), i) =>
+              val blocks = (0 until num).map { _ =>
+                generateBlock(100, 100, 100)
+              }
+
+              def statistic(timeEncode: Long, timeDecode: Long): Unit = {
+                def iI(v: Int): String = "%7d) ".format(v)
+
+                def mS(v: Long) = "%7.3f ".format(v.toDouble / 1000)
+
+                val str = iI(i) + "  " + mS(timeEncode) + "    " + mS(timeDecode)
+                println(str)
+              }
+
+              val (blocksEncode, timeEncodeTemp) = {
+                val t0  = System.nanoTime
+                val res = blocks.map(codec.encode)
+                val t1  = System.nanoTime
+                val m   = Duration.fromNanos(t1 - t0).toMillis
+                (res, m)
+              }
+
+              val (blocksDecode, timeDecodeTemp) = {
+                val t0  = System.nanoTime
+                val res = blocksEncode.map(codec.decode)
+                val t1  = System.nanoTime
+                val m   = Duration.fromNanos(t1 - t0).toMillis
+                (res, m)
+              }
+
+              val areEqual = (blocksDecode zip blocks).forall { case (a, b) => compareBlocks(a, b) }
+              assert(areEqual, s"${i}: Encoded and decoded blocks should be same")
+
+              if (averageStatistic) statistic(timeEncodeTemp, timeDecodeTemp)
+
+              if (i < averageWarmUp) (timeEncode, timeDecode)
+              else
+                (
+                  timeEncode + timeEncodeTemp,
+                  timeDecode + timeDecodeTemp
+                )
+          }
+
+      def numStr(v: Int) = "%7d".format(v)
+
+      def mS(v: Long) = "%7.3f".format(v.toDouble / (1000.toDouble * averageNum.toDouble))
+
+      val str = numStr(num) + " | " + mS(result._1) + " | " + mS(result._2)
+      println(str)
+    }
+
+    def fS(v: String): String = "%7s".format(v)
+
+    println(s"$codecName")
+    val strTitle = fS("num") + " | " + fS("timeEnc(sec)") + " | " + fS("timeDec(sec)")
+    println(strTitle)
+
+    experiment(num = 500)
+  }
+}

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataTimingMeasure.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataTimingMeasure.scala
@@ -1,6 +1,12 @@
 import coop.rchain.blockstorage.dag.codecs
 import coop.rchain.casper.util.GeneratorBlockMetadata
-import coop.rchain.models.{BlockMetadata, BlockMetadataAB, BlockMetadataBV, BlockMetadataScodecBV}
+import coop.rchain.models.{
+  BlockMetadata,
+  BlockMetadataAB,
+  BlockMetadataBS,
+  BlockMetadataBV,
+  BlockMetadataScodecBV
+}
 import org.scalatest.FlatSpec
 import scodec.bits.ByteVector
 
@@ -35,6 +41,13 @@ class BlockMetadataTimingMeasure extends FlatSpec {
       BlockMetadataBV.fromByteVector(serialized)
   }
 
+  class BlockMetadataScodecBSSerializer extends UniversalCodec[BlockMetadataBS] {
+    override def encode(block: BlockMetadataBS): ByteVector =
+      block.toByteVector
+    def decode(serialized: ByteVector): BlockMetadataBS =
+      BlockMetadataBS.fromByteVector(serialized)
+  }
+
   it should "Time - measurement of protobuf codec" in {
     def compareBlocks(a: BlockMetadata, b: BlockMetadata): Boolean = a == b
     timingExperiment(
@@ -61,6 +74,16 @@ class BlockMetadataTimingMeasure extends FlatSpec {
       codecName = "New BlockMetadata scodec (ByteVector)",
       new BlockMetadataScodecBVSerializer,
       randomBlockMetadataBV,
+      compareBlocks
+    )
+  }
+
+  it should "Time - measurement of scodec - codec (using ByteString)" in {
+    def compareBlocks(a: BlockMetadataBS, b: BlockMetadataBS): Boolean = a == b
+    timingExperiment(
+      codecName = "New BlockMetadata scodec (ByteString)",
+      new BlockMetadataScodecBSSerializer,
+      randomBlockMetadataBS,
       compareBlocks
     )
   }
@@ -138,6 +161,6 @@ class BlockMetadataTimingMeasure extends FlatSpec {
       " | " + fS("timeDec(sec)")
     println(strTitle)
 
-    experiment(num = 500, 100)
+    experiment(num = 500, elementsCount = 100)
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataTimingMeasure.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockMetadataTimingMeasure.scala
@@ -63,7 +63,7 @@ class BlockMetadataTimingMeasure extends FlatSpec {
     timingExperiment(
       codecName = "New BlockMetadata scodec(Array[Byte])",
       new BlockMetadataScodecSerializer,
-      randomBlockMetadataScodec,
+      randomBlockMetadataAB,
       compareBlocks
     )
   }

--- a/models/src/main/scala/coop/rchain/models/BlockMetadataAB.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadataAB.scala
@@ -14,9 +14,8 @@ object BlockMetadataScodec {
   import scodec.Codec
   import scodec.codecs._
 
-  private val codecByteArray = {
+  private val codecByteArray =
     variableSizeBytesLong(uint32, bytes).xmap[Array[Byte]](_.toArray, ByteVector(_))
-  }
 
   private val codecParents = listOfN(int32, codecByteArray)
 

--- a/models/src/main/scala/coop/rchain/models/BlockMetadataAB.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadataAB.scala
@@ -15,7 +15,7 @@ object BlockMetadataScodec {
   import scodec.codecs._
 
   private val codecByteArray = {
-    variableSizeBytes(uint8, bytes).xmap[Array[Byte]](_.toArray, ByteVector(_))
+    variableSizeBytesLong(uint32, bytes).xmap[Array[Byte]](_.toArray, ByteVector(_))
   }
 
   private val codecParents = listOfN(int32, codecByteArray)

--- a/models/src/main/scala/coop/rchain/models/BlockMetadataBS.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadataBS.scala
@@ -1,0 +1,65 @@
+package coop.rchain.models
+
+import com.google.protobuf.ByteString
+import scodec.TransformSyntax
+import scodec.bits.ByteVector
+
+final case class JustificationBS(validator: ByteString, latestBlockHash: ByteString)
+
+object BlockMetadataScodecBS {
+  import scodec.Codec
+  import scodec.codecs._
+
+  private val codecByteArray =
+    variableSizeBytesLong(uint32, bytes)
+      .xmap[ByteString](bv => ByteString.copyFrom(bv.toArray), bs => ByteVector(bs.toByteArray))
+
+  private val codecParents = listOfN(int32, codecByteArray)
+
+  private val codecJustification  = (codecByteArray :: codecByteArray).as[JustificationBS]
+  private val codecJustifications = listOfN(int32, codecJustification)
+
+  private val tupleCodec: Codec[(ByteString, Long)] = codecByteArray.pairedWith(int64)
+  private val codecWeightMap =
+    listOfN(int32, tupleCodec).xmap[Map[ByteString, Long]](_.toMap, _.toList)
+
+  private val codecMetadata =
+    (("hash" | codecByteArray) :: ("parents" | codecParents) ::
+      ("sender" | codecByteArray) :: ("justifications" | codecJustifications) ::
+      ("weightMap" | codecWeightMap) :: ("blockNum" | int64) :: ("seqNum" | int32) :: ("invalid" | bool) ::
+      ("df" | bool) :: ("finalized" | bool)).as[BlockMetadataBS]
+
+  def encode(block: BlockMetadataBS): ByteVector =
+    codecMetadata.encode(block).require.toByteVector
+
+  def encodeToArray(block: BlockMetadataBS): Array[Byte] = encode(block).toArray
+
+  def decodeFromArray(bytes: Array[Byte]): BlockMetadataBS = decode(ByteVector(bytes))
+  def decode(serializedBlock: ByteVector): BlockMetadataBS =
+    codecMetadata.decode(serializedBlock.toBitVector).require.value
+}
+
+final case class BlockMetadataBS(
+    blockHash: ByteString,
+    parents: List[ByteString],
+    sender: ByteString,
+    justifications: List[JustificationBS],
+    weightMap: Map[ByteString, Long],
+    blockNum: Long,
+    seqNum: Int,
+    invalid: Boolean,
+    directlyFinalized: Boolean,
+    finalized: Boolean
+) {
+  def toByteVector: ByteVector = BlockMetadataScodecBS.encode(block = this)
+  def toBytes: Array[Byte]     = this.toByteVector.toArray
+}
+
+object BlockMetadataBS {
+  def toByteVector(block: BlockMetadataBS): ByteVector =
+    block.toByteVector
+  def fromBytes(bytes: Array[Byte]): BlockMetadataBS =
+    BlockMetadataScodecBS.decodeFromArray(bytes)
+  def fromByteVector(byteVector: ByteVector): BlockMetadataBS =
+    BlockMetadataScodecBS.decode(byteVector)
+}

--- a/models/src/main/scala/coop/rchain/models/BlockMetadataBS.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadataBS.scala
@@ -10,22 +10,22 @@ object BlockMetadataScodecBS {
   import scodec.Codec
   import scodec.codecs._
 
-  private val codecByteArray =
+  private val codecByteString =
     variableSizeBytesLong(uint32, bytes)
       .xmap[ByteString](bv => ByteString.copyFrom(bv.toArray), bs => ByteVector(bs.toByteArray))
 
-  private val codecParents = listOfN(int32, codecByteArray)
+  private val codecParents = listOfN(int32, codecByteString)
 
-  private val codecJustification  = (codecByteArray :: codecByteArray).as[JustificationBS]
+  private val codecJustification  = (codecByteString :: codecByteString).as[JustificationBS]
   private val codecJustifications = listOfN(int32, codecJustification)
 
-  private val tupleCodec: Codec[(ByteString, Long)] = codecByteArray.pairedWith(int64)
+  private val tupleCodec: Codec[(ByteString, Long)] = codecByteString.pairedWith(int64)
   private val codecWeightMap =
     listOfN(int32, tupleCodec).xmap[Map[ByteString, Long]](_.toMap, _.toList)
 
   private val codecMetadata =
-    (("hash" | codecByteArray) :: ("parents" | codecParents) ::
-      ("sender" | codecByteArray) :: ("justifications" | codecJustifications) ::
+    (("hash" | codecByteString) :: ("parents" | codecParents) ::
+      ("sender" | codecByteString) :: ("justifications" | codecJustifications) ::
       ("weightMap" | codecWeightMap) :: ("blockNum" | int64) :: ("seqNum" | int32) :: ("invalid" | bool) ::
       ("df" | bool) :: ("finalized" | bool)).as[BlockMetadataBS]
 

--- a/models/src/main/scala/coop/rchain/models/BlockMetadataScodec.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadataScodec.scala
@@ -73,18 +73,5 @@ final case class BlockMetadataScodec(
     directlyFinalized: Boolean,
     finalized: Boolean
 ) {
-
   def toByteString = MetadataScodec.encode(block = this)
-
-  def validateWithOtherBlock(block: BlockMetadataScodec): Boolean =
-    blockHash.corresponds(block.blockHash)(_ == _) &&
-      parents == block.parents &&
-      sender.corresponds(block.sender)(_ == _) &&
-      justifications == block.justifications &&
-      weightMap == block.weightMap &&
-      blockNum == block.blockNum &&
-      seqNum == block.seqNum &&
-      invalid == block.invalid &&
-      directlyFinalized == block.directlyFinalized &&
-      finalized == block.finalized
 }

--- a/models/src/main/scala/coop/rchain/models/BlockMetadataScodec.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadataScodec.scala
@@ -1,0 +1,90 @@
+package coop.rchain.models
+
+import scodec.TransformSyntax
+import scodec.bits.ByteVector
+
+final case class JustificationArr(validator: Array[Byte], latestBlockHash: Array[Byte])
+
+object MetadataScodec {
+  import scodec.Codec
+  import scodec.bits.ByteVector
+  import scodec.codecs._
+
+  private val codecByteArray = {
+    variableSizeBytes(uint8, bytes).xmap[Array[Byte]](_.toArray, ByteVector(_))
+  }
+
+  //  Codecs of Lists and Map should be created through the flatZip method
+  //  (these codecs must know exact count of elements in List/Map container)
+  private val codecParentsBase = uint16 flatZip { count =>
+    listOfN(provide(count), codecByteArray)
+  }
+  private val codecParents = codecParentsBase.xmap[List[Array[Byte]]]({ case (_, lst) => lst }, {
+    sourceList =>
+      (sourceList.size, sourceList)
+  })
+
+  private val codecJustification = (codecByteArray :: codecByteArray).as[JustificationArr]
+  private val codecJustificationsBase = uint16 flatZip { count =>
+    listOfN(provide(count), codecJustification)
+  }
+
+  private val codecJustifications = codecJustificationsBase.xmap[List[JustificationArr]]({
+    case (_, lst) => lst
+  }, { sourceList =>
+    (sourceList.size, sourceList)
+  })
+
+  private val tupleCodec: Codec[(Array[Byte], Long)] = codecByteArray.pairedWith(int64)
+
+  private val codecWeightMapBase = uint16 flatZip { count =>
+    val tuplesList = listOfN(provide(count), tupleCodec)
+    tuplesList.xmap[Map[Array[Byte], Long]](_.toMap, _.toList)
+  }
+
+  private val codecWeightMap = codecWeightMapBase.xmap[Map[Array[Byte], Long]](
+    { case (_, sourceMap) => sourceMap }, { sourceMap =>
+      (sourceMap.size, sourceMap)
+    }
+  )
+
+  private val codecMetadata =
+    (("hash" | codecByteArray) :: ("parents" | codecParents) ::
+      ("sender" | codecByteArray) :: ("justifications" | codecJustifications) ::
+      ("weightMap" | codecWeightMap) :: ("blockNum" | int64) :: ("seqNum" | int32) :: ("invalid" | bool) ::
+      ("df" | bool) :: ("finalized" | bool)).as[BlockMetadataScodec]
+
+  def encode(block: BlockMetadataScodec): ByteVector =
+    codecMetadata.encode(block).require.toByteVector
+
+  def decode(serializedBlock: ByteVector): BlockMetadataScodec =
+    codecMetadata.decode(serializedBlock.toBitVector).require.value
+}
+
+final case class BlockMetadataScodec(
+    blockHash: Array[Byte],
+    parents: List[Array[Byte]],
+    sender: Array[Byte],
+    justifications: List[JustificationArr],
+    weightMap: Map[Array[Byte], Long],
+    blockNum: Long,
+    seqNum: Int,
+    invalid: Boolean,
+    directlyFinalized: Boolean,
+    finalized: Boolean
+) {
+
+  def toByteString = MetadataScodec.encode(block = this)
+
+  def validateWithOtherBlock(block: BlockMetadataScodec): Boolean =
+    blockHash.corresponds(block.blockHash)(_ == _) &&
+      parents == block.parents &&
+      sender.corresponds(block.sender)(_ == _) &&
+      justifications == block.justifications &&
+      weightMap == block.weightMap &&
+      blockNum == block.blockNum &&
+      seqNum == block.seqNum &&
+      invalid == block.invalid &&
+      directlyFinalized == block.directlyFinalized &&
+      finalized == block.finalized
+}

--- a/models/src/main/scala/coop/rchain/models/BlockMetadataScodec.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockMetadataScodec.scala
@@ -7,7 +7,6 @@ final case class JustificationArr(validator: Array[Byte], latestBlockHash: Array
 
 object MetadataScodec {
   import scodec.Codec
-  import scodec.bits.ByteVector
   import scodec.codecs._
 
   private val codecByteArray = {
@@ -15,7 +14,7 @@ object MetadataScodec {
   }
 
   //  Codecs of Lists and Map should be created through the flatZip method
-  //  (these codecs must know exact count of elements in List/Map container)
+  //  (these codecs must know exact count of elements in List/Map containers)
   private val codecParentsBase = uint16 flatZip { count =>
     listOfN(provide(count), codecByteArray)
   }


### PR DESCRIPTION
## Overview
Realization of serializer for BlockMetadata class based on scodec - library according to the [issue](https://github.com/rchain/rchain/issues/3656)


### Notes
1. Created 3 new BlockMetadata implementations (All ByteString fields from the original class represented as Array[Byte], ByteString and ByteVector objects respectively)
2. Defined 3  codecs for class BlockMetadata (based on scodec - library) 
3. Compared performance of existing protobuf codec and new codecs. Results of timing measurements placed in the [table](https://docs.google.com/spreadsheets/d/1Qjn9RAiz0MBB2dhWOgybjuLlqlH_J8i1FNlCeU7RBbc/edit#gid=0) and in the graphics below

|                                       	| num 	| Parents  count 	| Justifications count 	| weightMap count 	| timeEnc(sec) 	| timeDec(sec) 	|
|---------------------------------------	|-----	|----------------	|----------------------	|-----------------	|--------------	|--------------	|
|     BlockMetadata (protobuf codec)    	| 500 	|       100      	|          100         	|       100       	|     0.017    	|     0.017    	|
| New BlockMetadata scodec(Array[Byte]) 	| 500 	|       100      	|          100         	|       100       	|     0.241    	|     0.134    	|
| New BlockMetadata scodec (ByteVector) 	| 500 	|       100      	|          100         	|       100       	|     0.237    	|     0.139    	|
| New BlockMetadata scodec (ByteString) 	| 500 	|       100      	|          100         	|       100       	|     0.238    	|     0.132    	|

Graphics of compare codecs performance:
![Screenshot from 2022-04-22 12-56-13](https://user-images.githubusercontent.com/90717554/164684157-840c56d5-2038-4088-8bee-ba79d95e347e.png)
![Screenshot from 2022-04-22 12-56-30](https://user-images.githubusercontent.com/90717554/164684162-2f7b7b70-8832-4ec5-88bc-1d41da31d4af.png)

The dependence of the encoding/decoding time on the number of fields in BlockMetadata


![Screenshot from 2022-04-22 13-13-57](https://user-images.githubusercontent.com/90717554/164688053-4f80b5c1-e2de-46f6-aee3-bdd5d937e2bc.png)
![Screenshot from 2022-04-22 13-14-14](https://user-images.githubusercontent.com/90717554/164688059-e07bf02b-b618-43e6-85ae-f9da9ab93bb2.png)

Note: N – fields in BlockMetadata: 
* 1 – blockHash
* 2 – blockHash, parents
* 3 – blockHash, parents, sender
* 4 – blockHash, parents, sender, justifications
* 5 – blockHash, parents, sender, justifications, weightMap
* 6 – blockHash, parents, sender, justifications, weightMap, blockNum, seqNum, invalid, directlyFinalized, finalized


### Please make sure that this PR:

- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
