### PR TITLE
Prepare pure state for BlockDagRepresentation

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagRepresentationSyntax.scala
@@ -1,8 +1,10 @@
 package coop.rchain.blockstorage.dag
 
+import cats.Applicative
 import cats.data.OptionT
-import cats.effect.{Concurrent, Sync}
+import cats.effect.Sync
 import cats.syntax.all._
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol.Justification
 import coop.rchain.models.BlockHash.BlockHash
@@ -12,60 +14,93 @@ import coop.rchain.models.syntax._
 import coop.rchain.shared.syntax._
 import fs2.Stream
 
-trait BlockDagRepresentationSyntax {
-  implicit final def blockStorageSyntaxBlockDagRepresentation[F[_]](
-      dag: BlockDagRepresentation[F]
-  ): BlockDagRepresentationOps[F] = new BlockDagRepresentationOps[F](dag)
+import scala.collection.immutable.SortedMap
+
+trait DagRepresentationSyntax {
+  implicit final def blockStorageSyntaxDagRepresentation[F[_]](
+      dag: DagRepresentation
+  ): DagRepresentationOps[F] = new DagRepresentationOps[F](dag)
 }
 
 final case class BlockDagInconsistencyError(message: String) extends Exception(message)
 final case class NoLatestMessage(message: String)            extends Exception(message)
 
-final class BlockDagRepresentationOps[F[_]](
-    // BlockDagRepresentation extensions / syntax
-    private val dag: BlockDagRepresentation[F]
+final class DagRepresentationOps[F[_]](
+    // DagRepresentation extensions / syntax
+    private val dag: DagRepresentation
 ) extends AnyVal {
 
-  /**
-    * Get block metadata, "unsafe" because method expects block already in the DAG.
-    *
-    * Unfortunately there is no way to get stack trace when error is thrown in async execution.
-    * Monix does not have support and cats.effect support is in creation.
-    * https://github.com/typelevel/cats-effect/pull/854
-    * So extra source parameters are a desperate measure to indicate who is the caller.
-    */
-  def lookupUnsafe(hash: BlockHash)(
-      implicit sync: Sync[F]
-  ): F[BlockMetadata] = {
-    def errMsg = s"DAG storage is missing hash ${PrettyPrinter.buildString(hash)}"
-    dag.lookup(hash) >>= (_.liftTo(BlockDagInconsistencyError(errMsg)))
-  }
+  def contains(blockHash: BlockHash)(implicit a: Applicative[F]): F[Boolean] =
+    DagRepresentation.contains(dag, blockHash)
 
-  def lookupUnsafe(
-      hashes: Seq[BlockHash]
-  )(implicit concurrent: Concurrent[F]): F[List[BlockMetadata]] = {
-    val streams = hashes.map(h => fs2.Stream.eval(lookupUnsafe(h)))
-    fs2.Stream.emits(streams).parJoinUnbounded.compile.toList
-  }
+  def children(blockHash: BlockHash)(implicit a: Applicative[F]): F[Option[Set[BlockHash]]] =
+    DagRepresentation.children(dag, blockHash)
 
-  def latestMessageHashUnsafe(v: Validator)(implicit sync: Sync[F]): F[BlockHash] = {
+  def lastFinalizedBlock(implicit s: Sync[F]): F[BlockHash] =
+    DagRepresentation.lastFinalizedBlock(dag)
+
+  def isFinalized(blockHash: BlockHash)(implicit a: Applicative[F]): F[Boolean] =
+    DagRepresentation.isFinalized(dag, blockHash)
+
+  def getHeightMap(implicit a: Applicative[F]): F[SortedMap[Long, Set[BlockHash]]] =
+    DagRepresentation.getHeightMap(dag)
+
+  def latestBlockNumber(implicit a: Applicative[F]): F[Long] =
+    DagRepresentation.latestBlockNumber(dag)
+
+  def topoSort(
+      startBlockNumber: Long,
+      maybeEndBlockNumber: Option[Long]
+  )(implicit s: Sync[F]): F[Vector[Vector[BlockHash]]] =
+    DagRepresentation.topoSort(dag, startBlockNumber, maybeEndBlockNumber)
+
+  def find(truncatedHash: String)(implicit s: Sync[F]): F[Option[BlockHash]] =
+    DagRepresentation.find(dag, truncatedHash)
+
+  def invalidBlocks(implicit s: Sync[F], bds: BlockDagStorage[F]): F[Set[BlockMetadata]] =
+    DagRepresentation.invalidBlocks(dag)
+
+  def latestMessageHash(
+      validator: Validator
+  )(implicit s: Sync[F], bds: BlockDagStorage[F]): F[Option[BlockHash]] =
+    DagRepresentation.latestMessageHash(dag, validator)
+
+  def latestMessageHashes(
+      implicit s: Sync[F],
+      bds: BlockDagStorage[F]
+  ): F[Map[Validator, BlockHash]] =
+    DagRepresentation.latestMessageHashes(dag)
+
+  def latestMessageHashUnsafe(
+      v: Validator
+  )(implicit sync: Sync[F], bds: BlockDagStorage[F]): F[BlockHash] = {
     def errMsg = s"No latest message for validator ${PrettyPrinter.buildString(v)}"
-    dag.latestMessageHash(v) >>= (_.liftTo(NoLatestMessage(errMsg)))
+    latestMessageHash(v) >>= (_.liftTo(NoLatestMessage(errMsg)))
   }
 
-  def latestMessage(validator: Validator)(implicit sync: Sync[F]): F[Option[BlockMetadata]] =
-    dag.latestMessageHash(validator) >>= (_.traverse(lookupUnsafe))
+  def latestMessage(
+      validator: Validator
+  )(implicit sync: Sync[F], bds: BlockDagStorage[F]): F[Option[BlockMetadata]] =
+    latestMessageHash(validator) >>= (_.traverse(bds.lookupUnsafe))
 
-  def latestMessages(implicit sync: Sync[F]): F[Map[Validator, BlockMetadata]] = {
+  def latestMessages(
+      implicit sync: Sync[F],
+      bds: BlockDagStorage[F]
+  ): F[Map[Validator, BlockMetadata]] = {
     import cats.instances.vector._
-    dag.latestMessageHashes >>= (
+    latestMessageHashes >>= (
       _.toVector
-        .traverse { case (validator, hash) => lookupUnsafe(hash).map(validator -> _) }
+        .traverse {
+          case (validator, hash) => bds.lookupUnsafe(hash).map(validator -> _)
+        }
         .map(_.toMap)
       )
   }
 
-  def invalidLatestMessages(implicit sync: Sync[F]): F[Map[Validator, BlockHash]] =
+  def invalidLatestMessages(
+      implicit sync: Sync[F],
+      bds: BlockDagStorage[F]
+  ): F[Map[Validator, BlockHash]] =
     latestMessages.flatMap(
       lm =>
         invalidLatestMessages(lm.map {
@@ -74,50 +109,63 @@ final class BlockDagRepresentationOps[F[_]](
     )
 
   def invalidLatestMessages(latestMessagesHashes: Map[Validator, BlockHash])(
-      implicit sync: Sync[F]
+      implicit sync: Sync[F],
+      bds: BlockDagStorage[F]
   ): F[Map[Validator, BlockHash]] =
-    dag.invalidBlocks.map { invalidBlocks =>
+    invalidBlocks.map { invalidBlocks =>
       latestMessagesHashes.filter {
         case (_, blockHash) => invalidBlocks.map(_.blockHash).contains(blockHash)
       }
     }
 
-  def invalidBlocksMap(implicit sync: Sync[F]): F[Map[BlockHash, Validator]] =
+  def invalidBlocksMap(
+      implicit sync: Sync[F],
+      bds: BlockDagStorage[F]
+  ): F[Map[BlockHash, Validator]] =
     for {
-      ib <- dag.invalidBlocks
+      ib <- invalidBlocks
       r  = ib.map(block => (block.blockHash, block.sender)).toMap
     } yield r
 
-  def selfJustificationChain(h: BlockHash)(implicit sync: Sync[F]): Stream[F, Justification] =
+  def selfJustificationChain(
+      h: BlockHash
+  )(implicit sync: Sync[F], bds: BlockDagStorage[F]): Stream[F, Justification] =
     Stream.unfoldEval(h)(
       message =>
-        lookupUnsafe(message)
+        bds
+          .lookupUnsafe(message)
           .map { v =>
             v.justifications.find(_.validator == v.sender)
           }
           .map(_.map(next => (next, next.latestBlockHash)))
     )
 
-  def selfJustification(h: BlockHash)(implicit sync: Sync[F]): F[Option[Justification]] =
+  def selfJustification(
+      h: BlockHash
+  )(implicit sync: Sync[F], bds: BlockDagStorage[F]): F[Option[Justification]] =
     selfJustificationChain(h).head.compile.last
 
   def mainParentChain(h: BlockHash, stopAtHeight: Long = 0)(
-      implicit sync: Sync[F]
+      implicit sync: Sync[F],
+      bds: BlockDagStorage[F]
   ): Stream[F, BlockHash] =
     Stream.unfoldEval(h) { message =>
-      lookupUnsafe(message).map(
-        meta =>
-          if (meta.blockNum <= stopAtHeight)
-            none[(BlockHash, BlockHash)]
-          else
-            meta.parents.headOption.map(v => (v, v))
-      )
+      bds
+        .lookupUnsafe(message)
+        .map(
+          meta =>
+            if (meta.blockNum <= stopAtHeight)
+              none[(BlockHash, BlockHash)]
+            else
+              meta.parents.headOption.map(v => (v, v))
+        )
     }
 
   def isInMainChain(ancestor: BlockHash, descendant: BlockHash)(
-      implicit sync: Sync[F]
+      implicit sync: Sync[F],
+      bds: BlockDagStorage[F]
   ): F[Boolean] = {
-    val result = OptionT(dag.lookup(ancestor).map(_.map(_.blockNum))).semiflatMap { aHeight =>
+    val result = OptionT(bds.lookup(ancestor).map(_.map(_.blockNum))).semiflatMap { aHeight =>
       mainParentChain(descendant, aHeight)
         .filter(_ == ancestor)
         .head
@@ -128,31 +176,32 @@ final class BlockDagRepresentationOps[F[_]](
     (descendant == ancestor).pure ||^ result.getOrElse(false)
   }
 
-  def parentsUnsafe(item: BlockHash)(implicit sync: Sync[F]): F[List[BlockHash]] = {
+  def parentsUnsafe(
+      item: BlockHash
+  )(implicit sync: Sync[F], bds: BlockDagStorage[F]): F[List[BlockHash]] = {
     def errMsg = s"Parents lookup failed: DAG is missing ${item.show}"
-    dag.lookup(item).map(_.map(v => v.parents)) >>= (_.liftTo(BlockDagInconsistencyError(errMsg)))
+    bds.lookup(item).map(_.map(v => v.parents)) >>= (_.liftTo(BlockDagInconsistencyError(errMsg)))
   }
 
-  def nonFinalizedBlocks(implicit sync: Sync[F]): F[Set[BlockHash]] =
-    for {
-      tips <- latestMessages.map(_.values.map(_.blockHash).toList)
-      r <- Stream
-            .unfoldLoopEval(tips) { lvl =>
-              for {
-                out  <- lvl.filterA(dag.isFinalized(_).not)
-                next <- out.traverse(dag.lookup(_).map(_.map(_.parents))).map(_.flatten.flatten)
-              } yield (out, next.nonEmpty.guard[Option].as(next))
-            }
-            .flatMap(Stream.emits)
-            .compile
-            .to(Set)
-    } yield r
+  def nonFinalizedBlocks(implicit sync: Sync[F], bds: BlockDagStorage[F]): F[Set[BlockHash]] =
+    Stream
+      .unfoldLoopEval(dag.latestMessagesHashes.valuesIterator.toList) { lvl =>
+        for {
+          out  <- lvl.filterA(dag.isFinalized(_).not)
+          next <- out.traverse(bds.lookup(_).map(_.map(_.parents))).map(_.flatten.flatten)
+        } yield (out, next.nonEmpty.guard[Option].as(next))
+      }
+      .flatMap(Stream.emits)
+      .compile
+      .to(Set)
 
-  def descendants(blockHash: BlockHash)(implicit sync: Sync[F]): F[Set[BlockHash]] =
+  def descendants(
+      blockHash: BlockHash
+  )(implicit sync: Sync[F]): F[Set[BlockHash]] =
     Stream
       .unfoldLoopEval(List(blockHash)) { lvl =>
         for {
-          out  <- lvl.traverse(dag.children).map(_.flatten.flatten)
+          out  <- lvl.traverse(dag.children(_)(sync)).map(_.flatten.flatten)
           next = out
         } yield (out, next.nonEmpty.guard[Option].as(next))
       }
@@ -161,12 +210,13 @@ final class BlockDagRepresentationOps[F[_]](
       .to(Set)
 
   def ancestors(blockHash: BlockHash, filterF: BlockHash => F[Boolean])(
-      implicit sync: Sync[F]
+      implicit sync: Sync[F],
+      bds: BlockDagStorage[F]
   ): F[Set[BlockHash]] =
     Stream
       .unfoldEval(List(blockHash)) { lvl =>
         val parents = lvl
-          .traverse(lookupUnsafe)
+          .traverse(bds.lookupUnsafe)
           .flatMap(_.flatMap(_.parents).distinct.filterA(filterF))
         parents.map(p => p.nonEmpty.guard[Option].as(p, p))
       }
@@ -175,7 +225,13 @@ final class BlockDagRepresentationOps[F[_]](
       .to(Set)
 
   def withAncestors(blockHash: BlockHash, filterF: BlockHash => F[Boolean])(
-      implicit sync: Sync[F]
+      implicit sync: Sync[F],
+      bds: BlockDagStorage[F]
   ): F[Set[BlockHash]] =
     ancestors(blockHash, filterF).map(_ + blockHash)
+
+  // TODO replace all calls with direct calls for BlockDagStorage
+  def lookup(blockHash: BlockHash)(implicit bds: BlockDagStorage[F]) = bds.lookup(blockHash)
+  def lookupUnsafe(blockHash: BlockHash)(implicit s: Sync[F], bds: BlockDagStorage[F]) =
+    bds.lookupUnsafe(blockHash)
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorage.scala
@@ -5,46 +5,24 @@ import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.BlockMetadata
-import coop.rchain.models.Validator.Validator
-
-import scala.collection.immutable.SortedMap
 
 trait BlockDagStorage[F[_]] {
-  def getRepresentation: F[BlockDagRepresentation[F]]
+  def getRepresentation: F[DagRepresentation]
   def insert(
       block: BlockMessage,
       invalid: Boolean,
       approved: Boolean = false
-  ): F[BlockDagRepresentation[F]]
+  ): F[DagRepresentation]
   def recordDirectlyFinalized(
       direct: BlockHash,
       finalizationEffect: Set[BlockHash] => F[Unit]
   ): F[Unit]
+  def lookup(blockHash: BlockHash): F[Option[BlockMetadata]]
+  def lookupByDeployId(blockHash: DeployId): F[Option[BlockHash]]
 }
 
 object BlockDagStorage {
   type DeployId = ByteString
 
   def apply[F[_]](implicit instance: BlockDagStorage[F]): BlockDagStorage[F] = instance
-}
-
-trait BlockDagRepresentation[F[_]] {
-  def children(blockHash: BlockHash): F[Option[Set[BlockHash]]]
-  def lookup(blockHash: BlockHash): F[Option[BlockMetadata]]
-  def contains(blockHash: BlockHash): F[Boolean]
-  def latestMessageHash(validator: Validator): F[Option[BlockHash]]
-  def latestMessageHashes: F[Map[Validator, BlockHash]]
-  def invalidBlocks: F[Set[BlockMetadata]]
-  // For BlockAPI
-  def latestBlockNumber: F[Long]
-  def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]]
-  def getHeightMap: F[SortedMap[Long, Set[BlockHash]]]
-  def topoSort(
-      startBlockNumber: Long,
-      maybeEndBlockNumber: Option[Long]
-  ): F[Vector[Vector[BlockHash]]]
-  // DAG representation has to have finalized block, or it does not make sense
-  def lastFinalizedBlock: BlockHash
-  def isFinalized(blockHash: BlockHash): F[Boolean]
-  def find(truncatedHash: String): F[Option[BlockHash]]
 }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorageSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockDagStorageSyntax.scala
@@ -1,0 +1,32 @@
+package coop.rchain.blockstorage.dag
+
+import cats.effect.{Concurrent, Sync}
+import cats.syntax.all._
+import coop.rchain.casper.PrettyPrinter
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockMetadata
+
+trait BlockDagStorageSyntax {
+  implicit final def blockStorageSyntax[F[_]](
+      bds: BlockDagStorage[F]
+  ): BlockDagStorageOps[F] = new BlockDagStorageOps[F](bds)
+}
+
+final class BlockDagStorageOps[F[_]](
+    // DagRepresentation extensions / syntax
+    private val bds: BlockDagStorage[F]
+) extends AnyVal {
+  def lookupUnsafe(hash: BlockHash)(
+      implicit sync: Sync[F]
+  ): F[BlockMetadata] = {
+    def errMsg = s"DAG storage is missing hash ${PrettyPrinter.buildString(hash)}"
+    bds.lookup(hash) >>= (_.liftTo(BlockDagInconsistencyError(errMsg)))
+  }
+
+  def lookupUnsafe(
+      hashes: Seq[BlockHash]
+  )(implicit concurrent: Concurrent[F]): F[List[BlockMetadata]] = {
+    val streams = hashes.map(h => fs2.Stream.eval(lookupUnsafe(h)))
+    fs2.Stream.emits(streams).parJoinUnbounded.compile.toList
+  }
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/BlockMetadataStore.scala
@@ -136,13 +136,10 @@ object BlockMetadataStore {
     def heightMap: F[SortedMap[Long, Set[BlockHash]]] =
       dagState.get.map(_.heightMap)
 
-    def lastFinalizedBlock(implicit sync: Sync[F]): F[BlockHash] = {
-      val errMsg =
-        "DagState does not contain lastFinalizedBlock. Are you calling this on empty BlockDagStorage? Otherwise there is a bug."
-      dagState.get.flatMap(_.lastFinalizedBlock.liftTo[F](new Exception(errMsg)).map {
-        case (hash, _) => hash
-      })
-    }
+    // This is Option because method is called on BlockDagStorage initialization which is before
+    // the first finalized block (genesis) is inserted.
+    def lastFinalizedBlock(implicit sync: Sync[F]): F[Option[BlockHash]] =
+      dagState.get.map(_.lastFinalizedBlock.map(_._1))
 
     def finalizedBlockSet: F[Set[BlockHash]] = dagState.get.map(_.finalizedBlockSet)
   }

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
@@ -1,8 +1,6 @@
 package coop.rchain.blockstorage.dag
-import cats.Applicative
 import cats.effect.Sync
 import cats.syntax.all._
-import coop.rchain.blockstorage.TopoSortFragmentParameterError
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
@@ -19,7 +17,44 @@ final case class DagRepresentation(
     invalidBlocksSet: Set[BlockHash],
     lastFinalizedBlockHash: Option[BlockHash],
     finalizedBlocksSet: Set[BlockHash]
-)
+) {
+  def contains(blockHash: BlockHash): Boolean =
+    blockHash.size == BlockHash.Length && dagSet.contains(blockHash)
+
+  def children(blockHash: BlockHash): Option[Set[BlockHash]] = childMap.get(blockHash)
+
+  def isFinalized(blockHash: BlockHash): Boolean = finalizedBlocksSet.contains(blockHash)
+
+  def latestBlockNumber: Long = heightMap.lastOption.map { case (h, _) => h + 1 }.getOrElse(0L)
+
+  def topoSort(
+      startBlockNumber: Long,
+      maybeEndBlockNumber: Option[Long]
+  ): Option[Vector[Vector[BlockHash]]] = {
+    val maxNumber   = latestBlockNumber
+    val startNumber = Math.max(0, startBlockNumber)
+    val endNumber   = maybeEndBlockNumber.map(Math.min(maxNumber, _)).getOrElse(maxNumber)
+    val validRange  = startNumber >= 0 && startNumber <= endNumber
+    validRange.guard[Option].as {
+      heightMap
+        .filterKeys(h => h >= startNumber && h <= endNumber)
+        .map { case (_, v) => v.toVector }
+        .toVector
+    }
+  }
+
+  def find(truncatedHash: String): Option[BlockHash] =
+    if (truncatedHash.length % 2 == 0) {
+      val truncatedByteString = truncatedHash.unsafeHexToByteString
+      dagSet.find(hash => hash.startsWith(truncatedByteString))
+    } else {
+      // if truncatedHash is odd length string we cannot convert it to ByteString with 8 bit resolution
+      // because each symbol has 4 bit resolution. Need to make a string of even length by removing the last symbol,
+      // then find all the matching hashes and choose one that matches the full truncatedHash string
+      val truncatedByteString = truncatedHash.dropRight(1).unsafeHexToByteString
+      dagSet.filter(_.startsWith(truncatedByteString)).find(_.toHexString.startsWith(truncatedHash))
+    }
+}
 
 object DagRepresentation {
   def empty: DagRepresentation =
@@ -33,69 +68,11 @@ object DagRepresentation {
       Set.empty[BlockHash]
     )
 
-  def contains[F[_]: Applicative](dr: DagRepresentation, blockHash: BlockHash): F[Boolean] =
-    (blockHash.size == BlockHash.Length && dr.dagSet.contains(blockHash)).pure
-
-  def children[F[_]: Applicative](
-      dr: DagRepresentation,
-      blockHash: BlockHash
-  ): F[Option[Set[BlockHash]]] =
-    dr.childMap.get(blockHash).pure
-
-  def lastFinalizedBlock[F[_]: Sync](dr: DagRepresentation): F[BlockHash] = {
+  def lastFinalizedBlockUnsafe[F[_]: Sync](dr: DagRepresentation): F[BlockHash] = {
     val errMsg =
       "DagState does not contain lastFinalizedBlock. Are you calling this on empty BlockDagStorage? Otherwise there is a bug."
     dr.lastFinalizedBlockHash.liftTo[F](new Exception(errMsg))
   }
-
-  def isFinalized[F[_]: Applicative](dr: DagRepresentation, blockHash: BlockHash): F[Boolean] =
-    dr.finalizedBlocksSet.contains(blockHash).pure
-
-  private def getMaxHeight(dr: DagRepresentation) =
-    if (dr.heightMap.nonEmpty) dr.heightMap.last._1 + 1L else 0L
-
-  def getHeightMap[F[_]: Applicative](dr: DagRepresentation): F[SortedMap[Long, Set[BlockHash]]] =
-    dr.heightMap.pure[F]
-
-  def latestBlockNumber[F[_]: Applicative](dr: DagRepresentation): F[Long] = getMaxHeight(dr).pure
-
-  def topoSort[F[_]: Sync](
-      dr: DagRepresentation,
-      startBlockNumber: Long,
-      maybeEndBlockNumber: Option[Long]
-  ): F[Vector[Vector[BlockHash]]] = {
-    val maxNumber   = getMaxHeight(dr)
-    val startNumber = Math.max(0, startBlockNumber)
-    val endNumber   = maybeEndBlockNumber.map(Math.min(maxNumber, _)).getOrElse(maxNumber)
-    if (startNumber >= 0 && startNumber <= endNumber) {
-      Sync[F].delay(
-        dr.heightMap
-          .filterKeys(h => h >= startNumber && h <= endNumber)
-          .map { case (_, v) => v.toVector }
-          .toVector
-      )
-    } else {
-      Sync[F].raiseError(
-        TopoSortFragmentParameterError(startNumber, endNumber)
-      )
-    }
-  }
-
-  def find[F[_]: Sync](dr: DagRepresentation, truncatedHash: String): F[Option[BlockHash]] =
-    Sync[F].delay {
-      if (truncatedHash.length % 2 == 0) {
-        val truncatedByteString = truncatedHash.unsafeHexToByteString
-        dr.dagSet.find(hash => hash.startsWith(truncatedByteString))
-      } else {
-        // if truncatedHash is odd length string we cannot convert it to ByteString with 8 bit resolution
-        // because each symbol has 4 bit resolution. Need to make a string of even length by removing the last symbol,
-        // then find all the matching hashes and choose one that matches the full truncatedHash string
-        val truncatedByteString = truncatedHash.dropRight(1).unsafeHexToByteString
-        dr.dagSet
-          .filter(_.startsWith(truncatedByteString))
-          .find(_.toHexString.startsWith(truncatedHash))
-      }
-    }
 
   def invalidBlocks[F[_]: Sync: BlockDagStorage](dr: DagRepresentation): F[Set[BlockMetadata]] =
     dr.invalidBlocksSet.toList.traverse(BlockDagStorage[F].lookupUnsafe).map(_.toSet)

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
@@ -1,0 +1,120 @@
+package coop.rchain.blockstorage.dag
+import cats.Applicative
+import cats.effect.Sync
+import cats.syntax.all._
+import coop.rchain.blockstorage.TopoSortFragmentParameterError
+import coop.rchain.blockstorage.syntax._
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.Validator.Validator
+import coop.rchain.models.syntax._
+import coop.rchain.models.{BlockHash, BlockMetadata}
+
+import scala.collection.immutable.SortedMap
+
+final case class DagRepresentation(
+    dagSet: Set[BlockHash],
+    latestMessagesHashes: Map[Validator, BlockHash],
+    childMap: Map[BlockHash, Set[BlockHash]],
+    heightMap: SortedMap[Long, Set[BlockHash]],
+    invalidBlocksSet: Set[BlockHash],
+    lastFinalizedBlockHash: Option[BlockHash],
+    finalizedBlocksSet: Set[BlockHash]
+)
+
+object DagRepresentation {
+  def empty: DagRepresentation =
+    DagRepresentation(
+      Set.empty[BlockHash],
+      Map.empty[Validator, BlockHash],
+      Map.empty[BlockHash, Set[BlockHash]],
+      SortedMap.empty[Long, Set[BlockHash]],
+      Set.empty[BlockHash],
+      none[BlockHash],
+      Set.empty[BlockHash]
+    )
+
+  def contains[F[_]: Applicative](dr: DagRepresentation, blockHash: BlockHash): F[Boolean] =
+    (blockHash.size == BlockHash.Length && dr.dagSet.contains(blockHash)).pure
+
+  def children[F[_]: Applicative](
+      dr: DagRepresentation,
+      blockHash: BlockHash
+  ): F[Option[Set[BlockHash]]] =
+    dr.childMap.get(blockHash).pure
+
+  def lastFinalizedBlock[F[_]: Sync](dr: DagRepresentation): F[BlockHash] = {
+    val errMsg =
+      "DagState does not contain lastFinalizedBlock. Are you calling this on empty BlockDagStorage? Otherwise there is a bug."
+    dr.lastFinalizedBlockHash.liftTo[F](new Exception(errMsg))
+  }
+
+  def isFinalized[F[_]: Applicative](dr: DagRepresentation, blockHash: BlockHash): F[Boolean] =
+    dr.finalizedBlocksSet.contains(blockHash).pure
+
+  private def getMaxHeight(dr: DagRepresentation) =
+    if (dr.heightMap.nonEmpty) dr.heightMap.last._1 + 1L else 0L
+
+  def getHeightMap[F[_]: Applicative](dr: DagRepresentation): F[SortedMap[Long, Set[BlockHash]]] =
+    dr.heightMap.pure[F]
+
+  def latestBlockNumber[F[_]: Applicative](dr: DagRepresentation): F[Long] = getMaxHeight(dr).pure
+
+  def topoSort[F[_]: Sync](
+      dr: DagRepresentation,
+      startBlockNumber: Long,
+      maybeEndBlockNumber: Option[Long]
+  ): F[Vector[Vector[BlockHash]]] = {
+    val maxNumber   = getMaxHeight(dr)
+    val startNumber = Math.max(0, startBlockNumber)
+    val endNumber   = maybeEndBlockNumber.map(Math.min(maxNumber, _)).getOrElse(maxNumber)
+    if (startNumber >= 0 && startNumber <= endNumber) {
+      Sync[F].delay(
+        dr.heightMap
+          .filterKeys(h => h >= startNumber && h <= endNumber)
+          .map { case (_, v) => v.toVector }
+          .toVector
+      )
+    } else {
+      Sync[F].raiseError(
+        TopoSortFragmentParameterError(startNumber, endNumber)
+      )
+    }
+  }
+
+  def find[F[_]: Sync](dr: DagRepresentation, truncatedHash: String): F[Option[BlockHash]] =
+    Sync[F].delay {
+      if (truncatedHash.length % 2 == 0) {
+        val truncatedByteString = truncatedHash.unsafeHexToByteString
+        dr.dagSet.find(hash => hash.startsWith(truncatedByteString))
+      } else {
+        // if truncatedHash is odd length string we cannot convert it to ByteString with 8 bit resolution
+        // because each symbol has 4 bit resolution. Need to make a string of even length by removing the last symbol,
+        // then find all the matching hashes and choose one that matches the full truncatedHash string
+        val truncatedByteString = truncatedHash.dropRight(1).unsafeHexToByteString
+        dr.dagSet
+          .filter(_.startsWith(truncatedByteString))
+          .find(_.toHexString.startsWith(truncatedHash))
+      }
+    }
+
+  def invalidBlocks[F[_]: Sync: BlockDagStorage](dr: DagRepresentation): F[Set[BlockMetadata]] =
+    dr.invalidBlocksSet.toList.traverse(BlockDagStorage[F].lookupUnsafe).map(_.toSet)
+
+  def latestMessageHash[F[_]: Sync: BlockDagStorage](
+      dr: DagRepresentation,
+      validator: Validator
+  ): F[Option[BlockHash]] =
+    dr.latestMessagesHashes.find(_._1 == validator).map(_._2).pure
+
+  def latestMessageHashes[F[_]: Sync: BlockDagStorage](
+      dr: DagRepresentation
+  ): F[Map[Validator, BlockHash]] =
+    dr.latestMessagesHashes.pure
+
+  def latestMessages[F[_]: Sync: BlockDagStorage](
+      dr: DagRepresentation
+  ): F[Map[Validator, BlockMetadata]] =
+    dr.latestMessagesHashes.toList
+      .traverse { case (s, h) => BlockDagStorage[F].lookupUnsafe(h).map((s, _)) }
+      .map(_.toMap)
+}

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/DagRepresentation.scala
@@ -104,7 +104,7 @@ object DagRepresentation {
       dr: DagRepresentation,
       validator: Validator
   ): F[Option[BlockHash]] =
-    dr.latestMessagesHashes.find(_._1 == validator).map(_._2).pure
+    dr.latestMessagesHashes.get(validator).pure
 
   def latestMessageHashes[F[_]: Sync: BlockDagStorage](
       dr: DagRepresentation

--- a/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/package.scala
@@ -1,6 +1,6 @@
 package coop.rchain
 
-import coop.rchain.blockstorage.dag.BlockDagRepresentationSyntax
+import coop.rchain.blockstorage.dag.{BlockDagStorageSyntax, DagRepresentationSyntax}
 import coop.rchain.blockstorage.{ApprovedStoreSyntax, BlockStoreSyntax, ByteStringKVStoreSyntax}
 import coop.rchain.metrics.Metrics
 
@@ -16,5 +16,6 @@ package object blockstorage {
 trait AllSyntaxBlockStorage
     extends ApprovedStoreSyntax
     with BlockStoreSyntax
-    with BlockDagRepresentationSyntax
+    with DagRepresentationSyntax
+    with BlockDagStorageSyntax
     with ByteStringKVStoreSyntax

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -59,10 +59,9 @@ trait BlockDagStorageTest
 
   it should "be able to handle checking if contains a block with empty hash" in {
     withDagStorage { dagStorage =>
-      implicit val s = Sync[Task]
       for {
         dag        <- dagStorage.getRepresentation
-        ifContains <- dag.contains(ByteString.EMPTY)
+        ifContains = dag.contains(ByteString.EMPTY)
       } yield ifContains shouldBe false
     }
   }

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -31,6 +31,8 @@ trait BlockDagStorageTest
   "DAG Storage" should "be able to lookup a stored block" in {
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>
       withDagStorage { dagStorage =>
+        implicit val bds = dagStorage
+        implicit val s   = Sync[Task]
         for {
           _   <- blockElements.traverse(dagStorage.insert(_, false))
           dag <- dagStorage.getRepresentation
@@ -58,6 +60,7 @@ trait BlockDagStorageTest
 
   it should "be able to handle checking if contains a block with empty hash" in {
     withDagStorage { dagStorage =>
+      implicit val s = Sync[Task]
       for {
         dag        <- dagStorage.getRepresentation
         ifContains <- dag.contains(ByteString.EMPTY)

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -30,9 +30,8 @@ trait BlockDagStorageTest
 
   "DAG Storage" should "be able to lookup a stored block" in {
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>
-      withDagStorage { dagStorage =>
-        implicit val bds = dagStorage
-        implicit val s   = Sync[Task]
+      withDagStorage { implicit dagStorage =>
+        implicit val s = Sync[Task]
         for {
           _   <- blockElements.traverse(dagStorage.insert(_, false))
           dag <- dagStorage.getRepresentation

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedHeightConstraintChecker.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedHeightConstraintChecker.scala
@@ -23,7 +23,7 @@ final class LastFinalizedHeightConstraintChecker[F[_]: Sync: Log: BlockDagStorag
     val validator                 = ByteString.copyFrom(validatorIdentity.publicKey.bytes)
     val heightConstraintThreshold = s.onChainState.shardConf.heightConstraintThreshold
     for {
-      lastFinalizedBlockHash <- s.dag.lastFinalizedBlock
+      lastFinalizedBlockHash <- s.dag.lastFinalizedBlockUnsafe
       lastFinalizedBlock     <- s.dag.lookupUnsafe(lastFinalizedBlockHash)
       latestMessageOpt       <- s.dag.latestMessage(validator)
       result <- latestMessageOpt match {

--- a/casper/src/main/scala/coop/rchain/casper/LastFinalizedHeightConstraintChecker.scala
+++ b/casper/src/main/scala/coop/rchain/casper/LastFinalizedHeightConstraintChecker.scala
@@ -4,6 +4,7 @@ import cats.effect.Sync
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.blockStore.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper.blocks.proposer.{
   CheckProposeConstraintsResult,
   TooFarAheadOfLastFinalized
@@ -12,19 +13,19 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.syntax._
 import coop.rchain.shared.Log
 
-final class LastFinalizedHeightConstraintChecker[F[_]: Sync: Log] {
+final class LastFinalizedHeightConstraintChecker[F[_]: Sync: Log: BlockDagStorage] {
   def check(
-      s: CasperSnapshot[F],
+      s: CasperSnapshot,
       // TODO having genesis is a weird way to check, remove
       genesis: BlockMessage,
       validatorIdentity: ValidatorIdentity
   ): F[CheckProposeConstraintsResult] = {
     val validator                 = ByteString.copyFrom(validatorIdentity.publicKey.bytes)
     val heightConstraintThreshold = s.onChainState.shardConf.heightConstraintThreshold
-    val lastFinalizedBlockHash    = s.dag.lastFinalizedBlock
     for {
-      lastFinalizedBlock <- s.dag.lookupUnsafe(lastFinalizedBlockHash)
-      latestMessageOpt   <- s.dag.latestMessage(validator)
+      lastFinalizedBlockHash <- s.dag.lastFinalizedBlock
+      lastFinalizedBlock     <- s.dag.lookupUnsafe(lastFinalizedBlockHash)
+      latestMessageOpt       <- s.dag.latestMessage(validator)
       result <- latestMessageOpt match {
                  case Some(latestMessage) =>
                    val latestFinalizedHeight = lastFinalizedBlock.blockNum
@@ -46,6 +47,6 @@ final class LastFinalizedHeightConstraintChecker[F[_]: Sync: Log] {
 }
 
 object LastFinalizedHeightConstraintChecker {
-  def apply[F[_]: Sync: BlockStore: Log]: LastFinalizedHeightConstraintChecker[F] =
+  def apply[F[_]: Sync: BlockStore: BlockDagStorage: Log]: LastFinalizedHeightConstraintChecker[F] =
     new LastFinalizedHeightConstraintChecker[F]
 }

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -81,7 +81,7 @@ class MultiParentCasperImpl[F[_]
     } yield r
   }
 
-  def dagContains(hash: BlockHash): F[Boolean] = blockDag.flatMap(_.contains(hash))
+  def dagContains(hash: BlockHash): F[Boolean] = blockDag.map(_.contains(hash))
 
   def bufferContains(hash: BlockHash): F[Boolean] = CasperBufferStorage[F].contains(hash)
 
@@ -107,7 +107,7 @@ class MultiParentCasperImpl[F[_]
   def lastFinalizedBlock: F[BlockMessage] =
     for {
       dag          <- blockDag
-      blockMessage <- dag.lastFinalizedBlock.flatMap(BlockStore[F].getUnsafe)
+      blockMessage <- dag.lastFinalizedBlockUnsafe.flatMap(BlockStore[F].getUnsafe)
     } yield blockMessage
 
   def blockDag: F[DagRepresentation] =
@@ -209,7 +209,7 @@ class MultiParentCasperImpl[F[_]
                      }
         } yield result
       }
-      lfb <- dag.lastFinalizedBlock
+      lfb <- dag.lastFinalizedBlockUnsafe
     } yield CasperSnapshot(
       dag,
       lfb,

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasperImpl.scala
@@ -7,7 +7,7 @@ import coop.rchain.blockstorage.blockStore.BlockStore
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.casperbuffer.CasperBufferStorage
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
-import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
+import coop.rchain.blockstorage.dag.{BlockDagStorage, DagRepresentation}
 import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.casper.engine.BlockRetriever
 import coop.rchain.casper.merging.BlockIndex
@@ -107,10 +107,10 @@ class MultiParentCasperImpl[F[_]
   def lastFinalizedBlock: F[BlockMessage] =
     for {
       dag          <- blockDag
-      blockMessage <- BlockStore[F].getUnsafe(dag.lastFinalizedBlock)
+      blockMessage <- dag.lastFinalizedBlock.flatMap(BlockStore[F].getUnsafe)
     } yield blockMessage
 
-  def blockDag: F[BlockDagRepresentation[F]] =
+  def blockDag: F[DagRepresentation] =
     BlockDagStorage[F].getRepresentation
 
   def getRuntimeManager: F[RuntimeManager[F]] = Sync[F].delay(RuntimeManager[F])
@@ -135,7 +135,7 @@ class MultiParentCasperImpl[F[_]
     } yield ()
   }
 
-  override def getSnapshot: F[CasperSnapshot[F]] = {
+  override def getSnapshot: F[CasperSnapshot] = {
     import cats.instances.list._
 
     def getOnChainState(b: BlockMessage): F[OnChainCasperState] =
@@ -209,7 +209,7 @@ class MultiParentCasperImpl[F[_]
                      }
         } yield result
       }
-      lfb = dag.lastFinalizedBlock
+      lfb <- dag.lastFinalizedBlock
     } yield CasperSnapshot(
       dag,
       lfb,
@@ -227,7 +227,7 @@ class MultiParentCasperImpl[F[_]
 
   override def validate(
       b: BlockMessage,
-      s: CasperSnapshot[F]
+      s: CasperSnapshot
   ): F[Either[BlockError, ValidBlock]] = {
     val validationProcess: EitherT[F, BlockError, ValidBlock] =
       for {
@@ -309,7 +309,7 @@ class MultiParentCasperImpl[F[_]
     Log[F].info(s"Validating block ${PrettyPrinter.buildString(b, short = true)}.") *> validationProcessDiag
   }
 
-  override def handleValidBlock(block: BlockMessage): F[BlockDagRepresentation[F]] =
+  override def handleValidBlock(block: BlockMessage): F[DagRepresentation] =
     for {
       updatedDag <- BlockDagStorage[F].insert(block, invalid = false)
       _          <- CasperBufferStorage[F].remove(block.blockHash)
@@ -319,13 +319,13 @@ class MultiParentCasperImpl[F[_]
   override def handleInvalidBlock(
       block: BlockMessage,
       status: InvalidBlock,
-      dag: BlockDagRepresentation[F]
-  ): F[BlockDagRepresentation[F]] = {
+      dag: DagRepresentation
+  ): F[DagRepresentation] = {
     // TODO: Slash block for status except InvalidUnslashableBlock
     def handleInvalidBlockEffect(
         status: BlockError,
         block: BlockMessage
-    ): F[BlockDagRepresentation[F]] =
+    ): F[DagRepresentation] =
       for {
         _ <- Log[F].warn(
               s"Recording invalid block ${PrettyPrinter.buildString(block.blockHash)} for ${status.toString}."

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -5,6 +5,7 @@ import cats.syntax.all._
 import cats.instances.list._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.blockStore.BlockStore
+import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.blockstorage.deploy.DeployStorage
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol.{Header, _}
@@ -35,8 +36,8 @@ object BlockCreator {
    *  3. Extract all valid deploys that aren't already in all ancestors of S (the parents).
    *  4. Create a new block that contains the deploys from the previous step.
    */
-  def create[F[_]: Concurrent: Log: Time: BlockStore: DeployStorage: Metrics: RuntimeManager: Span](
-      s: CasperSnapshot[F],
+  def create[F[_]: Concurrent: Log: Time: BlockStore: BlockDagStorage: DeployStorage: Metrics: RuntimeManager: Span](
+      s: CasperSnapshot,
       validatorIdentity: ValidatorIdentity,
       dummyDeployOpt: Option[(PrivateKey, String)] = None
   )(implicit runtimeManager: RuntimeManager[F]): F[BlockCreatorResult] =

--- a/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
+++ b/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
@@ -170,9 +170,9 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
       for {
         dag    <- getRepresentation
         errMsg = s"Attempting to finalize nonexistent hash ${PrettyPrinter.buildString(directlyFinalizedHash)}."
-        _      <- dag.contains(directlyFinalizedHash).ifM(().pure, new Exception(errMsg).raiseError)
+        _      <- new Exception(errMsg).raiseError.unlessA(dag.contains(directlyFinalizedHash))
         // all non finalized ancestors should be finalized as well (indirectly)
-        indirectlyFinalized <- dag.ancestors(directlyFinalizedHash, dag.isFinalized(_).not)
+        indirectlyFinalized <- dag.ancestors(directlyFinalizedHash, dag.isFinalized(_).pure.not)
         // invoke effects
         _ <- finalizationEffect(indirectlyFinalized + directlyFinalizedHash)
         // persist finalization

--- a/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
+++ b/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
@@ -1,14 +1,14 @@
 package coop.rchain.casper.dag
 
-import cats.effect.concurrent.Semaphore
-import cats.effect.{Concurrent, Sync}
+import cats.effect.Concurrent
+import cats.effect.concurrent.{Ref, Semaphore}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.dag.BlockMetadataStore.BlockMetadataStore
 import coop.rchain.blockstorage.dag.codecs._
-import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage, BlockMetadataStore}
+import coop.rchain.blockstorage.dag.{BlockDagStorage, BlockMetadataStore, DagRepresentation}
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.blockstorage.util.BlockMessageUtil._
 import coop.rchain.casper.PrettyPrinter
@@ -17,15 +17,13 @@ import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.{Metrics, MetricsSemaphore}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator
-import coop.rchain.models.syntax._
 import coop.rchain.models.{BlockHash, BlockMetadata, Validator}
 import coop.rchain.shared.syntax._
 import coop.rchain.shared.{Log, LogSource}
 import coop.rchain.store.{KeyValueStoreManager, KeyValueTypedStore}
 
-import scala.collection.immutable.SortedMap
-
 final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
+    representationState: Ref[F, DagRepresentation],
     lock: Semaphore[F],
     latestMessagesIndex: KeyValueTypedStore[F, Validator, BlockHash],
     blockMetadataIndex: BlockMetadataStore[F],
@@ -34,116 +32,13 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
 ) extends BlockDagStorage[F] {
   implicit private val logSource: LogSource = LogSource(BlockDagKeyValueStorage.getClass)
 
-  private case class KeyValueDagRepresentation(
-      dagSet: Set[BlockHash],
-      latestMessagesMap: Map[Validator, BlockHash],
-      childMap: Map[BlockHash, Set[BlockHash]],
-      heightMap: SortedMap[Long, Set[BlockHash]],
-      invalidBlocksSet: Set[BlockMetadata],
-      lastFinalizedBlockHash: BlockHash,
-      finalizedBlocksSet: Set[BlockHash]
-  ) extends BlockDagRepresentation[F] {
-
-    def lookup(blockHash: BlockHash): F[Option[BlockMetadata]] =
-      if (dagSet.contains(blockHash)) blockMetadataIndex.get(blockHash)
-      else none[BlockMetadata].pure[F]
-
-    def contains(blockHash: BlockHash): F[Boolean] =
-      (blockHash.size == BlockHash.Length && dagSet.contains(blockHash)).pure[F]
-
-    def children(blockHash: BlockHash): F[Option[Set[BlockHash]]] =
-      childMap.get(blockHash).pure[F]
-
-    def latestMessageHash(validator: Validator): F[Option[BlockHash]] =
-      latestMessagesMap.get(validator).pure[F]
-
-    def latestMessageHashes: F[Map[Validator, BlockHash]] = latestMessagesMap.pure[F]
-
-    def invalidBlocks: F[Set[BlockMetadata]] = invalidBlocksSet.pure[F]
-
-    override def lastFinalizedBlock: BlockHash = lastFinalizedBlockHash
-
-    // latestBlockNumber, topoSort and lookupByDeployId are only used in BlockAPI.
-    // Do they need to be part of the DAG current state or they can be moved to DAG storage directly?
-
-    private def getMaxHeight = if (heightMap.nonEmpty) heightMap.last._1 + 1L else 0L
-
-    def latestBlockNumber: F[Long] =
-      getMaxHeight.pure[F]
-
-    def isFinalized(blockHash: BlockHash): F[Boolean] =
-      finalizedBlocksSet.contains(blockHash).pure[F]
-
-    override def find(truncatedHash: String): F[Option[BlockHash]] = Sync[F].delay {
-      if (truncatedHash.length % 2 == 0) {
-        val truncatedByteString = truncatedHash.unsafeHexToByteString
-        dagSet.find(hash => hash.startsWith(truncatedByteString))
-      } else {
-        // if truncatedHash is odd length string we cannot convert it to ByteString with 8 bit resolution
-        // because each symbol has 4 bit resolution. Need to make a string of even length by removing the last symbol,
-        // then find all the matching hashes and choose one that matches the full truncatedHash string
-        val truncatedByteString = truncatedHash.dropRight(1).unsafeHexToByteString
-        dagSet
-          .filter(_.startsWith(truncatedByteString))
-          .find(_.toHexString.startsWith(truncatedHash))
-      }
-    }
-
-    override def getHeightMap: F[SortedMap[Long, Set[BlockHash]]] = heightMap.pure[F]
-
-    def topoSort(
-        startBlockNumber: Long,
-        maybeEndBlockNumber: Option[Long]
-    ): F[Vector[Vector[BlockHash]]] = {
-      val maxNumber   = getMaxHeight
-      val startNumber = Math.max(0, startBlockNumber)
-      val endNumber   = maybeEndBlockNumber.map(Math.min(maxNumber, _)).getOrElse(maxNumber)
-      if (startNumber >= 0 && startNumber <= endNumber) {
-        Sync[F].delay(
-          heightMap
-            .filterKeys(h => h >= startNumber && h <= endNumber)
-            .map { case (_, v) => v.toVector }
-            .toVector
-        )
-      } else {
-        Sync[F].raiseError(
-          TopoSortFragmentParameterError(startNumber, endNumber)
-        )
-      }
-    }
-
-    def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] =
-      deployIndex.get1(deployId)
-  }
-
-  private def representation: F[BlockDagRepresentation[F]] =
-    for {
-      // Take current DAG state / view of the DAG
-      latestMessages     <- latestMessagesIndex.toMap
-      dagSet             <- blockMetadataIndex.dagSet
-      childMap           <- blockMetadataIndex.childMapData
-      heightMap          <- blockMetadataIndex.heightMap
-      invalidBlocks      <- invalidBlocksIndex.toMap.map(_.toSeq.map(_._2).toSet)
-      lastFinalizedBlock <- blockMetadataIndex.lastFinalizedBlock
-      finalizedBlocksSet <- blockMetadataIndex.finalizedBlockSet
-    } yield KeyValueDagRepresentation(
-      dagSet,
-      latestMessages,
-      childMap,
-      heightMap,
-      invalidBlocks,
-      lastFinalizedBlock,
-      finalizedBlocksSet
-    )
-
-  def getRepresentation: F[BlockDagRepresentation[F]] =
-    lock.withPermit(representation)
+  def getRepresentation: F[DagRepresentation] = representationState.get
 
   def insert(
       block: BlockMessage,
       invalid: Boolean,
       approved: Boolean
-  ): F[BlockDagRepresentation[F]] = {
+  ): F[DagRepresentation] = {
     import cats.instances.list._
     import cats.instances.option._
     import coop.rchain.catscontrib.Catscontrib.ToBooleanF
@@ -235,7 +130,31 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
     lock.withPermit(
       blockMetadataIndex
         .contains(block.blockHash)
-        .ifM(logAlreadyStored, doInsert) >> representation
+        .ifM(logAlreadyStored, doInsert) >> {
+        // TODO BlockDagStore inset method should be rewritten to only save to disk,
+        //  all logic should be done on the state.
+        //  This update of the state as a result of insert method should be removed.
+        val representation =
+          for {
+            // Take current DAG state / view of the DAG
+            latestMessages     <- latestMessagesIndex.toMap
+            dagSet             <- blockMetadataIndex.dagSet
+            childMap           <- blockMetadataIndex.childMapData
+            heightMap          <- blockMetadataIndex.heightMap
+            invalidBlocks      <- invalidBlocksIndex.toMap.map(_.toSeq.map(_._2).toSet)
+            lastFinalizedBlock <- blockMetadataIndex.lastFinalizedBlock
+            finalizedBlocksSet <- blockMetadataIndex.finalizedBlockSet
+          } yield DagRepresentation(
+            dagSet,
+            latestMessages,
+            childMap,
+            heightMap,
+            invalidBlocks.map(_.blockHash),
+            lastFinalizedBlock,
+            finalizedBlocksSet
+          )
+        representation.flatTap(representationState.set)
+      }
     )
   }
 
@@ -243,12 +162,13 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
   def recordDirectlyFinalized(
       directlyFinalizedHash: BlockHash,
       finalizationEffect: Set[BlockHash] => F[Unit]
-  ): F[Unit] =
+  ): F[Unit] = {
+    implicit val bds = this
     // Lock here is a safeguard for persisting changes in BlockMetadataIndex which can happen concurrently when
     // blocks are replayed in parallel
     lock.withPermit(
       for {
-        dag    <- representation
+        dag    <- getRepresentation
         errMsg = s"Attempting to finalize nonexistent hash ${PrettyPrinter.buildString(directlyFinalizedHash)}."
         _      <- dag.contains(directlyFinalizedHash).ifM(().pure, new Exception(errMsg).raiseError)
         // all non finalized ancestors should be finalized as well (indirectly)
@@ -259,6 +179,14 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
         _ <- blockMetadataIndex.recordFinalized(directlyFinalizedHash, indirectlyFinalized)
       } yield ()
     )
+  }
+
+  override def lookup(
+      blockHash: BlockHash
+  ): F[Option[BlockMetadata]] = blockMetadataIndex.get(blockHash)
+
+  override def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] =
+    deployIndex.get1(deployId)
 }
 
 object BlockDagKeyValueStorage {
@@ -315,7 +243,30 @@ object BlockDagKeyValueStorage {
     for {
       lock   <- MetricsSemaphore.single[F]
       stores <- createStores(kvm)
+      initST <- {
+        import stores._
+        for {
+          // Take current DAG state / view of the DAG
+          latestMessages     <- latestMessages.toMap
+          dagSet             <- metadata.dagSet
+          childMap           <- metadata.childMapData
+          heightMap          <- metadata.heightMap
+          invalidBlocks      <- invalidBlocks.toMap.map(_.toSeq.map(_._2).toSet)
+          lastFinalizedBlock <- metadata.lastFinalizedBlock
+          finalizedBlocksSet <- metadata.finalizedBlockSet
+        } yield DagRepresentation(
+          dagSet,
+          latestMessages,
+          childMap,
+          heightMap,
+          invalidBlocks.map(_.blockHash),
+          lastFinalizedBlock,
+          finalizedBlocksSet
+        )
+      }
+      stRef <- Ref.of[F, DagRepresentation](initST)
     } yield new BlockDagKeyValueStorage[F](
+      stRef,
       lock,
       stores.latestMessages,
       stores.metadata,

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -51,7 +51,7 @@ object Running {
     * To mitigate this issue we can update fork choice tips if current fork-choice tip has old timestamp,
     * which means node does not propose new blocks and no new blocks were received recently.
     */
-  def updateForkChoiceTipsIfStuck[F[_]: Sync: CommUtil: Log: Time: BlockStore: EngineCell](
+  def updateForkChoiceTipsIfStuck[F[_]: Sync: CommUtil: Log: Time: BlockStore: BlockDagStorage: EngineCell](
       delayThreshold: FiniteDuration
   ): F[Unit] =
     for {
@@ -183,7 +183,7 @@ object Running {
     * Peer asks for fork-choice tip
     */
   // TODO name for this message is misleading, as its a request for all tips, not just fork choice.
-  def handleForkChoiceTipRequest[F[_]: Sync: TransportLayer: RPConfAsk: BlockStore: Log](
+  def handleForkChoiceTipRequest[F[_]: Sync: TransportLayer: RPConfAsk: BlockStore: BlockDagStorage: Log](
       peer: PeerNode
   )(casper: MultiParentCasper[F]): F[Unit] = {
     val logRequest = Log[F].info(s"Received ForkChoiceTipRequest from ${peer.endpoint.host}")
@@ -315,7 +315,7 @@ class Running[F[_]
       handleForkChoiceTipRequest(peer)(casper)
     case abr: ApprovedBlockRequest =>
       for {
-        lfBlockHash <- BlockDagStorage[F].getRepresentation.map(_.lastFinalizedBlock)
+        lfBlockHash <- BlockDagStorage[F].getRepresentation.flatMap(_.lastFinalizedBlock)
 
         // Create approved block from last finalized block
         lastFinalizedBlock = for {

--- a/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Running.scala
@@ -315,7 +315,7 @@ class Running[F[_]
       handleForkChoiceTipRequest(peer)(casper)
     case abr: ApprovedBlockRequest =>
       for {
-        lfBlockHash <- BlockDagStorage[F].getRepresentation.flatMap(_.lastFinalizedBlock)
+        lfBlockHash <- BlockDagStorage[F].getRepresentation.flatMap(_.lastFinalizedBlockUnsafe)
 
         // Create approved block from last finalized block
         lastFinalizedBlock = for {

--- a/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
@@ -33,7 +33,7 @@ object DagMerger {
       // all not finalized blocks (conflict set)
       nonFinalisedBlocks <- dag.nonFinalizedBlocks
       // blocks that see last finalized state
-      actualBlocks <- dag.descendants(lfb)
+      actualBlocks = dag.descendants(lfb)
       // blocks that does not see last finalized state
       lateBlocks = nonFinalisedBlocks diff actualBlocks
 

--- a/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper.merging
 import cats.effect.Concurrent
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.{BlockDagStorage, DagRepresentation}
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.rholang.interpreter.RhoRuntime.RhoHistoryRepository
@@ -21,8 +21,8 @@ object DagMerger {
   def costOptimalRejectionAlg: DeployChainIndex => Long =
     (r: DeployChainIndex) => r.deploysWithCost.map(_.cost).sum
 
-  def merge[F[_]: Concurrent: Log](
-      dag: BlockDagRepresentation[F],
+  def merge[F[_]: Concurrent: BlockDagStorage: Log](
+      dag: DagRepresentation,
       lfb: BlockHash,
       lfbPostState: Blake2b256Hash,
       index: BlockHash => F[Vector[DeployChainIndex]],

--- a/casper/src/main/scala/coop/rchain/casper/state/instances/BlockStateManagerImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/state/instances/BlockStateManagerImpl.scala
@@ -3,6 +3,7 @@ package coop.rchain.casper.state.instances
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.blockstorage.blockStore.BlockStore
+import coop.rchain.blockstorage.syntax._
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper.state.BlockStateManager
 

--- a/casper/src/main/scala/coop/rchain/casper/state/instances/BlockStateManagerImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/state/instances/BlockStateManagerImpl.scala
@@ -22,7 +22,7 @@ object BlockStateManagerImpl {
     override def isEmpty: F[Boolean] =
       for {
         dag       <- blockDagStorage.getRepresentation
-        firstHash <- dag.topoSort(0, 1L.some)
+        firstHash = dag.topoSort(0, 1L.some)
       } yield firstHash.isEmpty
   }
 }

--- a/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
+++ b/casper/src/main/scala/coop/rchain/casper/util/ProtoUtil.scala
@@ -6,7 +6,7 @@ import cats.effect.Sync
 import cats.syntax.all._
 import com.google.protobuf.{ByteString, Int32Value, StringValue}
 import coop.rchain.blockstorage.blockStore.BlockStore
-import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.{BlockDagStorage, DagRepresentation}
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol.{DeployData, _}
@@ -37,8 +37,8 @@ object ProtoUtil {
     * requires a list to be returned. When we reach the goalFunc,
     * we return an empty list.
     */
-  def getCreatorJustificationAsListUntilGoalInMemory[F[_]: Monad](
-      blockDag: BlockDagRepresentation[F],
+  def getCreatorJustificationAsListUntilGoalInMemory[F[_]: Monad: BlockDagStorage](
+      blockDag: DagRepresentation,
       blockHash: BlockHash,
       goalFunc: BlockHash => Boolean = _ => false
   ): F[List[BlockHash]] =
@@ -68,8 +68,8 @@ object ProtoUtil {
   def weightMapTotal(weights: Map[ByteString, Long]): Long =
     weights.values.sum
 
-  def minTotalValidatorWeight[F[_]: Monad](
-      blockDag: BlockDagRepresentation[F],
+  def minTotalValidatorWeight[F[_]: Monad: BlockDagStorage](
+      blockDag: DagRepresentation,
       blockHash: BlockHash,
       maxCliqueMinSize: Int
   ): F[Long] =
@@ -83,8 +83,8 @@ object ProtoUtil {
     blockMessage.header.parentsHashList.headOption.flatTraverse(BlockStore[F].get1)
   }
 
-  def weightFromValidatorByDag[F[_]: Monad](
-      dag: BlockDagRepresentation[F],
+  def weightFromValidatorByDag[F[_]: Monad: BlockDagStorage](
+      dag: DagRepresentation,
       blockHash: BlockHash,
       validator: Validator
   ): F[Long] = {
@@ -125,18 +125,18 @@ object ProtoUtil {
     parentHashes(b).traverse(BlockStore[F].getUnsafe)
   }
 
-  def getParentsMetadata[F[_]: Sync](
+  def getParentsMetadata[F[_]: Sync: BlockDagStorage](
       b: BlockMetadata,
-      dag: BlockDagRepresentation[F]
+      dag: DagRepresentation
   ): F[List[BlockMetadata]] = {
     import cats.instances.list._
-    b.parents.traverse(dag.lookupUnsafe)
+    b.parents.traverse(dag.lookupUnsafe(_))
   }
 
-  def getParentMetadatasAboveBlockNumber[F[_]: Sync](
+  def getParentMetadatasAboveBlockNumber[F[_]: Sync: BlockDagStorage](
       b: BlockMetadata,
       blockNumber: Long,
-      dag: BlockDagRepresentation[F]
+      dag: DagRepresentation
   ): F[List[BlockMetadata]] =
     getParentsMetadata(b, dag)
       .map(parents => parents.filter(p => p.blockNum >= blockNumber))
@@ -187,9 +187,9 @@ object ProtoUtil {
         acc.updated(validator, block)
     }
 
-  def toLatestMessage[F[_]: Sync: BlockStore](
+  def toLatestMessage[F[_]: Sync: BlockStore: BlockDagStorage](
       justifications: Seq[Justification],
-      dag: BlockDagRepresentation[F]
+      dag: DagRepresentation
   ): F[immutable.Map[Validator, BlockMetadata]] = {
 
     import cats.instances.list._
@@ -289,8 +289,8 @@ object ProtoUtil {
   }
 
   // Return hashes of all blocks that are yet to be seen by the passed in block
-  def unseenBlockHashes[F[_]: Sync: BlockStore](
-      dag: BlockDagRepresentation[F],
+  def unseenBlockHashes[F[_]: Sync: BlockStore: BlockDagStorage](
+      dag: DagRepresentation,
       block: BlockMessage
   ): F[Set[BlockHash]] = {
     import cats.instances.stream._
@@ -325,8 +325,8 @@ object ProtoUtil {
     } yield unseenBlockHashes -- blocksLatestMessages.values.map(_.blockHash) - block.blockHash
   }
 
-  private def getCreatorBlocksBetween[F[_]: Sync](
-      dag: BlockDagRepresentation[F],
+  private def getCreatorBlocksBetween[F[_]: Sync: BlockDagStorage](
+      dag: DagRepresentation,
       topBlock: BlockMetadata,
       bottomBlock: Option[BlockMetadata]
   ): F[Set[BlockHash]] =
@@ -346,8 +346,8 @@ object ProtoUtil {
           .toSet
     }
 
-  private def getCreatorJustificationUnlessGoal[F[_]: Sync](
-      dag: BlockDagRepresentation[F],
+  private def getCreatorJustificationUnlessGoal[F[_]: Sync: BlockDagStorage](
+      dag: DagRepresentation,
       block: BlockMetadata,
       goal: BlockMetadata
   ): F[List[BlockMetadata]] =

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -28,6 +28,7 @@ class BlocksResponseAPITest
     with BlockGenerator
     with BlockDagStorageFixture {
   implicit val log: Log[Task] = new Log.NOPLog[Task]()
+  implicit val s              = Sync[Task]
 
   val v1     = generateValidator("Validator One")
   val v2     = generateValidator("Validator Two")

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.batch1
 
+import cats.effect.Sync
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode._
 import coop.rchain.casper.util.{ConstructDeploy, RSpaceUtil}
@@ -7,6 +8,8 @@ import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import coop.rchain.blockstorage.syntax._
+import monix.eval.Task
 
 class MultiParentCasperMergeSpec extends FlatSpec with Matchers with Inspectors {
 
@@ -21,6 +24,7 @@ class MultiParentCasperMergeSpec extends FlatSpec with Matchers with Inspectors 
   "HashSetCasper" should "handle multi-parent blocks correctly" in effectTest {
     TestNode.networkEff(genesis, networkSize = 3).use { nodes =>
       implicit val rm = nodes(1).runtimeManager
+      implicit val s  = Sync[Task]
       val shardId     = genesis.genesisBlock.shardId
       for {
         deployData0 <- ConstructDeploy.basicDeployData[Effect](

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
@@ -45,11 +45,11 @@ class MultiParentCasperMergeSpec extends FlatSpec with Matchers with Inspectors 
         _      <- TestNode.propagate(nodes)
 
         _ <- nodes(0).blockDagStorage.getRepresentation
-              .flatMap(_.isFinalized(genesis.genesisBlock.blockHash)) shouldBeF true
+              .map(_.isFinalized(genesis.genesisBlock.blockHash)) shouldBeF true
         _ <- nodes(0).blockDagStorage.getRepresentation
-              .flatMap(_.isFinalized(block0.blockHash)) shouldBeF false
+              .map(_.isFinalized(block0.blockHash)) shouldBeF false
         _ <- nodes(0).blockDagStorage.getRepresentation
-              .flatMap(_.isFinalized(block1.blockHash)) shouldBeF false
+              .map(_.isFinalized(block1.blockHash)) shouldBeF false
 
         //multiparent block joining block0 and block1 since they do not conflict
         multiparentBlock <- nodes(0).propagateBlock(deploys(2))(nodes: _*)

--- a/casper/src/test/scala/coop/rchain/casper/batch2/SingleParentCasperSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/SingleParentCasperSpec.scala
@@ -1,9 +1,7 @@
 package coop.rchain.casper.batch2
 
-import cats.instances.list._
-import cats.syntax.either._
-import cats.syntax.flatMap._
-import cats.syntax.traverse._
+import cats.effect.Sync
+import cats.syntax.all._
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode.Effect
 import coop.rchain.casper.protocol.DeployData
@@ -11,8 +9,10 @@ import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.GenesisBuilder.buildGenesis
 import coop.rchain.casper.{BlockStatus, ValidBlock, Validate}
 import coop.rchain.crypto.signatures.Signed
+import coop.rchain.metrics.NoopSpan
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib.effectTest
+import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{FlatSpec, Inspectors, Matchers}
 
@@ -65,6 +65,8 @@ class SingleParentCasperSpec extends FlatSpec with Matchers with Inspectors {
 
           validateResult <- {
             import n1._
+            implicit val s  = Sync[Task]
+            implicit val sp = NoopSpan[Task]
             n1.casperEff.getSnapshot >>=
               (snap => Validate.parents(dualParentB3, n1.genesis, snap))
           }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -1,10 +1,11 @@
 package coop.rchain.casper.batch2
 
 import cats.Monad
+import cats.effect.Sync
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.blockStore.BlockStore
-import coop.rchain.blockstorage.dag.{BlockDagRepresentation, IndexedBlockDagStorage}
+import coop.rchain.blockstorage.dag.{DagRepresentation, IndexedBlockDagStorage}
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
@@ -48,8 +49,9 @@ class ValidateTest
   private val SHARD_ID                = "root-shard"
   implicit val span: Span[Task]       = NoopSpan[Task]()
   implicit val metrics: Metrics[Task] = new Metrics.MetricsNOP[Task]()
+  implicit val s                      = Sync[Task]
 
-  def mkCasperSnapshot[F[_]](dag: BlockDagRepresentation[F]) =
+  def mkCasperSnapshot[F[_]](dag: DagRepresentation) =
     CasperSnapshot(
       dag,
       ByteString.EMPTY,

--- a/casper/src/test/scala/coop/rchain/casper/dag/BlockDagKeyValueStorageTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/dag/BlockDagKeyValueStorageTest.scala
@@ -189,8 +189,7 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
 
   it should "be able to restore invalid blocks on startup" in {
     forAll(blockElementsWithParentsGen(genesis), minSize(0), sizeRange(10)) { blockElements =>
-      withDagStorage { storage =>
-        implicit val bds = storage
+      withDagStorage { implicit storage =>
         for {
           _             <- blockElements.traverse_(storage.insert(_, true))
           dag           <- storage.getRepresentation
@@ -228,8 +227,7 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
   }
 
   "recording of new directly finalized block" should "record finalized all non finalized ancestors of LFB" in
-    withDagStorage { storage =>
-      implicit val bds = storage
+    withDagStorage { implicit storage =>
       for {
         _ <- storage.insert(genesis, false, true)
         b1 = getRandomBlock(

--- a/casper/src/test/scala/coop/rchain/casper/dag/BlockDagKeyValueStorageTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/dag/BlockDagKeyValueStorageTest.scala
@@ -62,14 +62,14 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
                  blockMetadata     <- dag.lookup(b.blockHash)
                  latestMessageHash <- dag.latestMessageHash(b.sender)
                  latestMessage     <- dag.latestMessage(b.sender)
-                 children          <- dag.children(b.blockHash)
-                 contains          <- dag.contains(b.blockHash)
+                 children          = dag.children(b.blockHash)
+                 contains          = dag.contains(b.blockHash)
                } yield (blockMetadata, latestMessageHash, latestMessage, children, contains)
              }
       latestMessageHashes <- dag.latestMessageHashes
       latestMessages      <- dag.latestMessages
-      topoSort            <- dag.topoSort(topoSortStartBlockNumber, none)
-      latestBlockNumber   <- dag.latestBlockNumber
+      topoSort            <- dag.topoSortUnsafe(topoSortStartBlockNumber, none)
+      latestBlockNumber   = dag.latestBlockNumber
     } yield (list, latestMessageHashes, latestMessages, topoSort, latestBlockNumber)
   }
 
@@ -244,14 +244,14 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
 
         // only genesis is finalized
         _ <- dag.lookupUnsafe(genesis.blockHash).map(_.finalized shouldBe true)
-        _ <- dag.isFinalized(genesis.blockHash).map(_ shouldBe true)
-        _ <- dag.isFinalized(b1.blockHash).map(_ shouldBe false)
+        _ = dag.isFinalized(genesis.blockHash) shouldBe true
+        _ = dag.isFinalized(b1.blockHash) shouldBe false
         _ <- dag.lookupUnsafe(b1.blockHash).map(_.finalized shouldBe false)
-        _ <- dag.isFinalized(b2.blockHash).map(_ shouldBe false)
+        _ = dag.isFinalized(b2.blockHash) shouldBe false
         _ <- dag.lookupUnsafe(b2.blockHash).map(_.finalized shouldBe false)
-        _ <- dag.isFinalized(b3.blockHash).map(_ shouldBe false)
+        _ = dag.isFinalized(b3.blockHash) shouldBe false
         _ <- dag.lookupUnsafe(b3.blockHash).map(_.finalized shouldBe false)
-        _ <- dag.isFinalized(b4.blockHash).map(_ shouldBe false)
+        _ = dag.isFinalized(b4.blockHash) shouldBe false
         _ <- dag.lookupUnsafe(b4.blockHash).map(_.finalized shouldBe false)
 
         // record directly finalized block
@@ -260,11 +260,11 @@ class BlockDagKeyValueStorageTest extends BlockDagStorageTest {
         dag        <- storage.getRepresentation
 
         // in mem DAG state should be correct
-        _ = dag.lastFinalizedBlock shouldBe b3.blockHash
-        _ <- dag.isFinalized(b1.blockHash).map(_ shouldBe true)
-        _ <- dag.isFinalized(b2.blockHash).map(_ shouldBe true)
-        _ <- dag.isFinalized(b3.blockHash).map(_ shouldBe true)
-        _ <- dag.isFinalized(b4.blockHash).map(_ shouldBe false)
+        _ = dag.lastFinalizedBlockUnsafe shouldBe b3.blockHash
+        _ = dag.isFinalized(b1.blockHash) shouldBe true
+        _ = dag.isFinalized(b2.blockHash) shouldBe true
+        _ = dag.isFinalized(b3.blockHash) shouldBe true
+        _ = dag.isFinalized(b4.blockHash) shouldBe false
 
         // persisted state should be correct
         _ <- dag

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningSpec.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.engine
 
+import cats.effect.Sync
 import com.google.protobuf.ByteString
 import coop.rchain.casper._
 import coop.rchain.casper.helper.{NoOpsCasperEffect, RSpaceStateManagerTestImpl}
@@ -13,12 +14,14 @@ import coop.rchain.models.blockImplicits.getRandomBlock
 import coop.rchain.shared.syntax._
 import monix.eval.Task
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
+import coop.rchain.blockstorage.syntax._
 
 import scala.concurrent.duration.FiniteDuration
 
 class RunningSpec extends WordSpec with BeforeAndAfterEach with Matchers {
 
-  val fixture = Setup()
+  val fixture    = Setup()
+  implicit val s = Sync[Task]
   import fixture._
 
   override def beforeEach(): Unit =

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -4,7 +4,7 @@ import cats._
 import cats.effect.concurrent.Ref
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.casperbuffer.CasperBufferKeyValueStorage
-import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.DagRepresentation
 import coop.rchain.blockstorage.deploy.KeyValueDeployStorage
 import coop.rchain.casper._
 import coop.rchain.casper.dag.BlockDagKeyValueStorage

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -5,7 +5,7 @@ import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.blockStore.BlockStore
-import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.DagRepresentation
 import coop.rchain.casper.genesis.Genesis.createGenesisBlock
 import coop.rchain.casper.genesis.contracts.{ProofOfStake, Validator}
 import coop.rchain.casper.helper.BlockDagStorageFixture
@@ -34,7 +34,7 @@ class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDag
   implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
   implicit val span: Span[Task]          = NoopSpan[Task]()
 
-  def mkCasperSnapshot[F[_]](dag: BlockDagRepresentation[F]) =
+  def mkCasperSnapshot(dag: DagRepresentation) =
     CasperSnapshot(
       dag,
       ByteString.EMPTY,

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -34,7 +34,7 @@ object BlockGenerator {
     Metrics.Source(CasperMetricsSource, "generate-block")
 
   implicit val logSource: LogSource = LogSource(this.getClass)
-  def mkCasperSnapshot[F[_]](dag: BlockDagRepresentation[F]) =
+  def mkCasperSnapshot[F[_]](dag: DagRepresentation) =
     CasperSnapshot(
       dag,
       ByteString.EMPTY,
@@ -72,10 +72,10 @@ object BlockGenerator {
                )
     } yield result
 
-  private def computeBlockCheckpoint[F[_]: Concurrent: Log: BlockStore: Metrics: Span](
+  private def computeBlockCheckpoint[F[_]: Concurrent: Log: BlockStore: BlockDagStorage: Metrics: Span](
       b: BlockMessage,
       genesis: BlockMessage,
-      s: CasperSnapshot[F],
+      s: CasperSnapshot,
       runtimeManager: RuntimeManager[F]
   ): F[(StateHash, Seq[ProcessedDeploy])] = Span[F].trace(GenerateBlockMetricsSource) {
     for {

--- a/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/NoOpsCasperEffect.scala
@@ -6,7 +6,7 @@ import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.blockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
-import coop.rchain.blockstorage.dag.{BlockDagRepresentation, BlockDagStorage}
+import coop.rchain.blockstorage.dag.{BlockDagStorage, DagRepresentation}
 import coop.rchain.casper.protocol.{BlockMessage, DeployData}
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.casper.{BlockStatus, DeployError, MultiParentCasper, _}
@@ -33,9 +33,9 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
   def bufferContains(blockHash: BlockHash): F[Boolean] = false.pure[F]
   def deploy(r: Signed[DeployData]): F[Either[DeployError, DeployId]] =
     Applicative[F].pure(Right(ByteString.EMPTY))
-  def estimator(dag: BlockDagRepresentation[F]): F[IndexedSeq[BlockHash]] =
+  def estimator(dag: DagRepresentation): F[IndexedSeq[BlockHash]] =
     estimatorFunc.pure[F]
-  def blockDag: F[BlockDagRepresentation[F]]                          = BlockDagStorage[F].getRepresentation
+  def blockDag: F[DagRepresentation]                                  = BlockDagStorage[F].getRepresentation
   def normalizedInitialFault(weights: Map[Validator, Long]): F[Float] = 0f.pure[F]
   def lastFinalizedBlock: F[BlockMessage]                             = getRandomBlock().pure[F]
   def getRuntimeManager: F[RuntimeManager[F]]                         = runtimeManager.pure[F]
@@ -51,17 +51,17 @@ class NoOpsCasperEffect[F[_]: Sync: BlockStore: BlockDagStorage] private (
       _ <- Sync[F].delay(store.update(b.get.blockHash, b.get))
     } yield BlockStatus.valid.asRight
 
-  override def getSnapshot: F[CasperSnapshot[F]] = ???
+  override def getSnapshot: F[CasperSnapshot] = ???
   override def validate(
       b: BlockMessage,
-      s: CasperSnapshot[F]
-  ): F[Either[BlockError, ValidBlock]]                                             = ???
-  override def handleValidBlock(block: BlockMessage): F[BlockDagRepresentation[F]] = ???
+      s: CasperSnapshot
+  ): F[Either[BlockError, ValidBlock]]                                     = ???
+  override def handleValidBlock(block: BlockMessage): F[DagRepresentation] = ???
   override def handleInvalidBlock(
       block: BlockMessage,
       status: InvalidBlock,
-      dag: BlockDagRepresentation[F]
-  ): F[BlockDagRepresentation[F]]                                 = ???
+      dag: DagRepresentation
+  ): F[DagRepresentation]                                         = ???
   override def getDependencyFreeFromBuffer: F[List[BlockMessage]] = ???
 }
 

--- a/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/CasperUtilTest.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.util
 
+import cats.effect.Sync
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
@@ -15,6 +16,7 @@ class CasperUtilTest
     with Matchers
     with BlockGenerator
     with BlockDagStorageFixture {
+  implicit val s = Sync[Task]
 
   "isInMainChain" should "classify appropriately" in withStorage {
     implicit blockStore => implicit blockDagStorage =>

--- a/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DagOperationsTest.scala
@@ -117,20 +117,23 @@ class DagOperationsTest
 
           dag <- blockDagStorage.getRepresentation
 
-          _ <- DagOperations.uncommonAncestors(Vector(b6, b7), dag)(Monad[Task]) shouldBeF Map(
+          _ <- DagOperations.uncommonAncestors(Vector(b6, b7), dag)(Monad[Task], blockDagStorage) shouldBeF Map(
                 toMetadata(b6) -> BitSet(0),
                 toMetadata(b4) -> BitSet(0),
                 toMetadata(b7) -> BitSet(1),
                 toMetadata(b2) -> BitSet(1)
               )
 
-          _ <- DagOperations.uncommonAncestors(Vector(b6, b3), dag)(Monad[Task]) shouldBeF Map(
+          _ <- DagOperations.uncommonAncestors(Vector(b6, b3), dag)(Monad[Task], blockDagStorage) shouldBeF Map(
                 toMetadata(b6) -> BitSet(0),
                 toMetadata(b4) -> BitSet(0),
                 toMetadata(b5) -> BitSet(0)
               )
 
-          _ <- DagOperations.uncommonAncestors(Vector(b2, b4, b5), dag)(Monad[Task]) shouldBeF Map(
+          _ <- DagOperations.uncommonAncestors(Vector(b2, b4, b5), dag)(
+                Monad[Task],
+                blockDagStorage
+              ) shouldBeF Map(
                 toMetadata(b2) -> BitSet(0),
                 toMetadata(b4) -> BitSet(1),
                 toMetadata(b5) -> BitSet(2),
@@ -138,7 +141,7 @@ class DagOperationsTest
                 toMetadata(b1) -> BitSet(1, 2)
               )
 
-          result <- DagOperations.uncommonAncestors(Vector(b1), dag)(Monad[Task]) shouldBeF Map
+          result <- DagOperations.uncommonAncestors(Vector(b1), dag)(Monad[Task], blockDagStorage) shouldBeF Map
                      .empty[BlockMetadata, BitSet]
         } yield result
   }

--- a/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
@@ -37,7 +37,7 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
   "unseenBlockHashes" should "return empty for a single block dag" in effectTest {
     TestNode.standaloneEff(genesis).use { node =>
       import node.blockStore
-      implicit val bds = node.blockDagStorage
+      import node.blockDagStorage
       for {
         signedBlock <- ConstructDeploy.basicDeployData[Effect](
                         0,

--- a/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
@@ -37,6 +37,7 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
   "unseenBlockHashes" should "return empty for a single block dag" in effectTest {
     TestNode.standaloneEff(genesis).use { node =>
       import node.blockStore
+      implicit val bds = node.blockDagStorage
       for {
         signedBlock <- ConstructDeploy.basicDeployData[Effect](
                         0,
@@ -51,9 +52,9 @@ class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyC
 
   it should "return all but the first block when passed the first block in a chain" in effectTest {
     TestNode.standaloneEff(genesis).use { node =>
-      import node._
-      implicit val timeEff = new LogicalTime[Effect]
-      val shardId          = this.genesis.genesisBlock.shardId
+      import node.blockDagStorage
+      import node.blockStore
+      val shardId = this.genesis.genesisBlock.shardId
 
       for {
         block0 <- ConstructDeploy

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/InterpreterUtilTest.scala
@@ -4,7 +4,7 @@ import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.blockStore.BlockStore
-import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.{BlockDagStorage, DagRepresentation}
 import coop.rchain.casper.{CasperShardConf, CasperSnapshot, OnChainCasperState}
 import coop.rchain.casper.helper._
 import coop.rchain.casper.protocol._
@@ -55,7 +55,7 @@ class InterpreterUtilTest
 
   val genesisContext = GenesisBuilder.buildGenesis()
   val genesis        = genesisContext.genesisBlock
-  def mkCasperSnapshot[F[_]](dag: BlockDagRepresentation[F]) =
+  def mkCasperSnapshot(dag: DagRepresentation) =
     CasperSnapshot(
       dag,
       ByteString.EMPTY,
@@ -73,10 +73,10 @@ class InterpreterUtilTest
         Seq.empty
       )
     )
-  def computeDeploysCheckpoint[F[_]: Concurrent: Log: BlockStore: Span: Time: Metrics](
+  def computeDeploysCheckpoint[F[_]: Concurrent: Log: BlockStore: BlockDagStorage: Span: Time: Metrics](
       parents: Seq[BlockMessage],
       deploys: Seq[Signed[DeployData]],
-      dag: BlockDagRepresentation[F],
+      dag: DagRepresentation,
       runtimeManager: RuntimeManager[F],
       blockNumber: Long = 0L,
       seqNum: Int = 0
@@ -322,9 +322,9 @@ class InterpreterUtilTest
 
   def computeDeployCosts(
       runtimeManager: RuntimeManager[Task],
-      dag: BlockDagRepresentation[Task],
+      dag: DagRepresentation,
       deploy: Signed[DeployData]*
-  )(implicit blockStore: BlockStore[Task]): Task[Seq[PCost]] =
+  )(implicit blockStore: BlockStore[Task], bds: BlockDagStorage[Task]): Task[Seq[PCost]] =
     for {
       computeResult <- computeDeploysCheckpoint[Task](
                         Seq(genesis),

--- a/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/rholang/Resources.scala
@@ -4,7 +4,7 @@ import cats.effect.{Concurrent, ContextShift, Resource, Sync}
 import cats.syntax.all._
 import cats.{Applicative, Parallel}
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.DagRepresentation
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager.rnodeDbMapping
@@ -103,39 +103,9 @@ object Resources {
       .forEach(source => Files.copy(source, dest.resolve(src.relativize(source)), REPLACE_EXISTING))
   }
 
-  def mkDummyCasperSnapshot[F[_]: Applicative]: F[CasperSnapshot[F]] = {
-    val dummyRepresentation = new BlockDagRepresentation[F] {
-      override def lookup(blockHash: BlockHash): F[Option[BlockMetadata]] = ???
-
-      override def contains(blockHash: BlockHash): F[Boolean] = ???
-
-      override def latestMessageHash(validator: Validator): F[Option[BlockHash]] = ???
-
-      override def latestMessageHashes: F[Map[Validator, BlockHash]] = ???
-
-      override def invalidBlocks: F[Set[BlockMetadata]] = ???
-
-      override def latestBlockNumber: F[Long] = ???
-
-      override def lookupByDeployId(deployId: DeployId): F[Option[BlockHash]] = ???
-
-      override def find(truncatedHash: String): F[Option[BlockHash]] = ???
-
-      override def getHeightMap: F[SortedMap[Long, Set[BlockHash]]] = ???
-
-      override def topoSort(
-          startBlockNumber: Long,
-          maybeEndBlockNumber: Option[Long]
-      ): F[Vector[Vector[BlockHash]]] = ???
-
-      override def isFinalized(blockHash: BlockHash): F[Boolean] = ???
-
-      override def children(vertex: BlockHash): F[Option[Set[BlockHash]]] = ???
-
-      override def lastFinalizedBlock: BlockHash = ???
-    }
-    CasperSnapshot[F](
-      dummyRepresentation,
+  def mkDummyCasperSnapshot[F[_]: Applicative]: F[CasperSnapshot] = {
+    CasperSnapshot(
+      DagRepresentation.empty,
       ByteString.EMPTY,
       ByteString.EMPTY,
       IndexedSeq.empty,

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/reporting/TransactionBalances.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/reporting/TransactionBalances.scala
@@ -214,7 +214,7 @@ object TransactionBalances {
 
     import coop.rchain.blockstorage.syntax._
     for {
-      blocks    <- dag.topoSort(blockNumber.toLong, Some(blockNumber.toLong))
+      blocks    <- dag.topoSortUnsafe(blockNumber.toLong, Some(blockNumber.toLong))
       blockHash = blocks.flatten.head
       block     <- blockStore.get1(blockHash)
       blockMes  = block.get
@@ -289,7 +289,7 @@ object TransactionBalances {
             blockMeta <- blockMetaOpt.liftTo(
                           new Exception(s"Block ${blockHash.toHexString} not found in dag")
                         )
-            isFinalized         <- dagRepresantation.isFinalized(blockHash)
+            isFinalized         = dagRepresantation.isFinalized(blockHash)
             isBeforeTargetBlock = blockMeta.blockNum <= targetBlock.body.state.blockNumber
           } yield TransactionBlockInfo(t, blockMeta.blockNum, isFinalized && isBeforeTargetBlock)
         }

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/reporting/TransactionBalances.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/reporting/TransactionBalances.scala
@@ -4,7 +4,7 @@ import cats.Parallel
 import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.blockstorage.dag.BlockDagRepresentation
+import coop.rchain.blockstorage.dag.DagRepresentation
 import coop.rchain.blockstorage.blockStore
 import coop.rchain.blockstorage.blockStore.BlockStore
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
@@ -208,15 +208,18 @@ object TransactionBalances {
 
   def getBlockHashByHeight[F[_]: Sync](
       blockNumber: Long,
-      dag: BlockDagRepresentation[F],
+      dag: DagRepresentation,
       blockStore: BlockStore[F]
-  ): F[BlockMessage] =
+  ): F[BlockMessage] = {
+
+    import coop.rchain.blockstorage.syntax._
     for {
       blocks    <- dag.topoSort(blockNumber.toLong, Some(blockNumber.toLong))
       blockHash = blocks.flatten.head
       block     <- blockStore.get1(blockHash)
       blockMes  = block.get
     } yield blockMes
+  }
 
   def main[F[_]: Concurrent: Parallel: ContextShift](
       dataDir: Path,
@@ -262,15 +265,15 @@ object TransactionBalances {
         def findTransaction(transaction: TransactionInfo): F[ByteString] =
           transaction.transactionType match {
             case PreCharge(deployId) =>
-              dagRepresantation
+              blockDagStorage
                 .lookupByDeployId(deployId.unsafeHexToByteString)
                 .flatMap(_.liftTo(DeployNotFound(transaction)))
             case Refund(deployId) =>
-              dagRepresantation
+              blockDagStorage
                 .lookupByDeployId(deployId.unsafeHexToByteString)
                 .flatMap(_.liftTo(DeployNotFound(transaction)))
             case UserDeploy(deployId) =>
-              dagRepresantation
+              blockDagStorage
                 .lookupByDeployId(deployId.unsafeHexToByteString)
                 .flatMap(_.liftTo(DeployNotFound(transaction)))
             case CloseBlock(blockHash) =>
@@ -279,6 +282,7 @@ object TransactionBalances {
               blockHash.unsafeHexToByteString.pure[F]
           }
         allTransactions.toList.traverse { t =>
+          implicit val bds = blockDagStorage
           for {
             blockHash    <- findTransaction(t)
             blockMetaOpt <- dagRepresantation.lookup(blockHash)

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -115,11 +115,13 @@ object Setup {
       deployStorage <- KeyValueDeployStorage[F](rnodeStoreManager)
 
       synchronyConstraintChecker = {
-        implicit val bs = blockStore
+        implicit val bs  = blockStore
+        implicit val bds = blockDagStorage
         SynchronyConstraintChecker[F]
       }
       lastFinalizedHeightConstraintChecker = {
-        implicit val bs = blockStore
+        implicit val bs  = blockStore
+        implicit val bds = blockDagStorage
         LastFinalizedHeightConstraintChecker[F]
       }
 
@@ -285,7 +287,7 @@ object Setup {
       // Broadcast fork choice tips request if current fork choice is more then `forkChoiceStaleThreshold` minutes old.
       // For why - look at updateForkChoiceTipsIfStuck method description.
       updateForkChoiceLoop = {
-        implicit val (ec, bs, cu) = (engineCell, blockStore, commUtil)
+        implicit val (ec, bs, cu, bds) = (engineCell, blockStore, commUtil, blockDagStorage)
         for {
           _ <- Time[F].sleep(conf.casper.forkChoiceCheckIfStaleInterval)
           _ <- Running.updateForkChoiceTipsIfStuck(conf.casper.forkChoiceStaleThreshold)

--- a/node/src/test/scala/coop/rchain/node/mergeablity/ComputeMerge.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/ComputeMerge.scala
@@ -157,14 +157,17 @@ trait ComputeMerge {
                     s"${rejectRight}, ${deployIds}, ${rightDeployIds}, ${leftDeployIds}"
                 )
             }
-            mergedState <- DagMerger.merge[F](
-                            dag,
-                            bBlock.blockHash,
-                            baseCheckpoint.root,
-                            indices(_).deployChains.pure[F],
-                            historyRepo,
-                            rejectAlg
-                          )
+            mergedState <- {
+              implicit val bds = dagStore
+              DagMerger.merge[F](
+                dag,
+                bBlock.blockHash,
+                baseCheckpoint.root,
+                indices(_).deployChains.pure[F],
+                historyRepo,
+                rejectAlg
+              )
+            }
             result <- checkFunction(runtime, historyRepo, mergedState)
           } yield result
       }

--- a/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
@@ -408,6 +408,7 @@ class MergingBranchMergerSpec extends FlatSpec with Matchers {
             dagStore: BlockDagStorage[Task]
         ): Task[BlockMessage] = {
 
+          implicit val bds     = dagStore
           val baseState        = baseBlock.body.state.postStateHash
           val seqNum           = baseBlock.seqNum + 1
           val mergingBlocksNum = (baseBlock.seqNum * 2 + 1).toLong


### PR DESCRIPTION
## Overview
This is preparatory PR that extracts the state of BlockDagRepresentation into case class. The state is residing now inside Ref and `getRepresentation` method just reads the Ref. 

To minimise changes, `insert` method is untouched, and state Ref is updated in the end of insert method inside the lock. This should be fixed later (see comment).

PR does not change anything logic related.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
