### PR TITLE
Find deploy method

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
+++ b/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
@@ -233,6 +233,18 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
   override def addDeploy(d: Signed[DeployData]): F[Unit] = deployStore.put(d.sig, d)
 
   override def pooledDeploys: F[Map[DeployId, Signed[DeployData]]] = deployStore.toMap
+
+  // Map of deploys being executed and execution results
+  private val execMap    = TrieMap.empty[DeployId, Option[String]]
+
+  def commitExecutionStarted(
+      d: DeployId
+  ): F[Unit] = Sync[F].delay { execMap.update(d, none[String]) }
+
+  def commitExecutionComplete(
+      d: DeployId,
+      status: String
+  ): F[Unit] = Sync[F].delay { execMap.update(d, status.some) }
 }
 
 object BlockDagKeyValueStorage {

--- a/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeDeployResult.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeDeployResult.scala
@@ -1,0 +1,16 @@
+package coop.rchain.casper.rholang
+import coop.rchain.casper.protocol.{ProcessedDeploy, ProcessedSystemDeploy}
+import coop.rchain.rholang.interpreter.EvaluateResult
+import coop.rchain.rspace.merger.MergingLogic.NumberChannelsEndVal
+
+object RuntimeDeployResult {
+  final case class UserDeployRuntimeResult(
+      deploy: ProcessedDeploy,
+      mergeable: NumberChannelsEndVal,
+      evalResult: EvaluateResult
+  )
+  final case class SystemDeployRuntimeResult(
+      deploy: ProcessedSystemDeploy,
+      mergeable: NumberChannelsEndVal
+  )
+}

--- a/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeDeployResult.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeDeployResult.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.rholang
 import coop.rchain.casper.protocol.{ProcessedDeploy, ProcessedSystemDeploy}
 import coop.rchain.rholang.interpreter.EvaluateResult
-import coop.rchain.rspace.merger.MergingLogic.NumberChannelsEndVal
+import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsEndVal
 
 object RuntimeDeployResult {
   final case class UserDeployRuntimeResult(

--- a/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/RuntimeManager.scala
@@ -111,8 +111,12 @@ final case class RuntimeManagerImpl[F[_]: Concurrent: Metrics: Span: Log: Contex
       runtime                                 <- spawnRuntime
       computed                                <- runtime.computeState(startHash, terms, systemDeploys, blockData)
       (stateHash, usrDeployRes, sysDeployRes) = computed
-      (usrProcessed, usrMergeable)            = usrDeployRes.unzip
-      (sysProcessed, sysMergeable)            = sysDeployRes.unzip
+      (usrProcessed, usrMergeable, _) = usrDeployRes
+        .map(UserTransition.unapply(_).get)
+        .unzip3
+      (sysProcessed, sysMergeable) = sysDeployRes
+        .map(SystemTransition.unapply(_).get)
+        .unzip
 
       // Concat user and system deploys mergeable channel maps
       mergeableChs = usrMergeable ++ sysMergeable

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeReplaySyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeReplaySyntax.scala
@@ -41,19 +41,20 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsEndVal
 import coop.rchain.rspace.util.ReplayException
 import coop.rchain.shared.Log
+import RuntimeReplaySyntax._
+import coop.rchain.casper.syntax._
 
 trait RuntimeReplaySyntax {
-  implicit final def casperSyntaxRholangRuntimeReplay[F[_]: Sync: Span: Log](
+  implicit final def casperSyntaxRholangRuntimeReplay[F[_]](
       runtime: ReplayRhoRuntime[F]
-  ): RuntimeReplayOps[F] =
-    new RuntimeReplayOps[F](runtime)
+  ): RuntimeReplayOps[F] = new RuntimeReplayOps[F](runtime)
 }
 
-final class RuntimeReplayOps[F[_]: Sync: Span: Log](
-    private val runtime: ReplayRhoRuntime[F]
-) extends RuntimeSyntax {
-
+object RuntimeReplaySyntax {
   implicit val RuntimeMetricsSource = Metrics.Source(CasperMetricsSource, "replay-rho-runtime")
+}
+
+final class RuntimeReplayOps[F[_]](private val runtime: ReplayRhoRuntime[F]) extends AnyVal {
 
   /* REPLAY Compute state with deploys (genesis block) and System deploys (regular block) */
 
@@ -65,6 +66,10 @@ final class RuntimeReplayOps[F[_]: Sync: Span: Log](
       systemDeploys: Seq[ProcessedSystemDeploy],
       blockData: BlockData,
       withCostAccounting: Boolean
+  )(
+      implicit sync: Sync[F],
+      span: Span[F],
+      log: Log[F]
   ): F[Either[ReplayFailure, (Blake2b256Hash, Seq[NumberChannelsEndVal])]] =
     Span[F].traceI("replay-compute-state") {
       for {
@@ -90,6 +95,9 @@ final class RuntimeReplayOps[F[_]: Sync: Span: Log](
       systemDeploys: Seq[ProcessedSystemDeploy],
       replayDeploy: ProcessedDeploy => F[Either[ReplayFailure, NumberChannelsEndVal]],
       replaySystemDeploy: ProcessedSystemDeploy => F[Either[ReplayFailure, NumberChannelsEndVal]]
+  )(
+      implicit s: Sync[F],
+      span: Span[F]
   ): F[Either[ReplayFailure, (Blake2b256Hash, Vector[NumberChannelsEndVal])]] = {
     type Params[D] = (Seq[D], Vector[NumberChannelsEndVal])
 
@@ -134,11 +142,19 @@ final class RuntimeReplayOps[F[_]: Sync: Span: Log](
     */
   def replayDeploy(withCostAccounting: Boolean)(
       processedDeploy: ProcessedDeploy
+  )(
+      implicit s: Sync[F],
+      span: Span[F],
+      log: Log[F]
   ): F[Option[ReplayFailure]] =
     replayDeployE(withCostAccounting)(processedDeploy).swap.toOption.value
 
   def replayDeployE(withCostAccounting: Boolean)(
       processedDeploy: ProcessedDeploy
+  )(
+      implicit s: Sync[F],
+      span: Span[F],
+      log: Log[F]
   ): EitherT[F, ReplayFailure, NumberChannelsEndVal] = {
     val refT = Ref.of(Set[Par]()).liftEitherT[ReplayFailure]
     refT flatMap { mergeable =>
@@ -243,6 +259,9 @@ final class RuntimeReplayOps[F[_]: Sync: Span: Log](
     */
   def replayBlockSystemDeployDiag(blockData: BlockData)(
       processedSystemDeploy: ProcessedSystemDeploy
+  )(
+      implicit s: Sync[F],
+      span: Span[F]
   ): F[Either[ReplayFailure, NumberChannelsEndVal]] =
     Span[F].withMarks("replay-system-deploy")(
       replayBlockSystemDeploy(blockData)(processedSystemDeploy).value
@@ -250,7 +269,7 @@ final class RuntimeReplayOps[F[_]: Sync: Span: Log](
 
   def replayBlockSystemDeploy(blockData: BlockData)(
       processedSysDeploy: ProcessedSystemDeploy
-  ): EitherT[F, ReplayFailure, NumberChannelsEndVal] = {
+  )(implicit s: Sync[F], span: Span[F]): EitherT[F, ReplayFailure, NumberChannelsEndVal] = {
     import processedSysDeploy._
     val sender = ByteString.copyFrom(blockData.sender.bytes)
     systemDeploy match {
@@ -289,7 +308,7 @@ final class RuntimeReplayOps[F[_]: Sync: Span: Log](
   def replaySystemDeployInternal[S <: SystemDeploy](
       systemDeploy: S,
       expectedFailureMsg: Option[String]
-  ): EitherT[F, ReplayFailure, SysEvalResult[S]] = {
+  )(implicit sync: Sync[F], span: Span[F]): EitherT[F, ReplayFailure, SysEvalResult[S]] = {
     // Evaluate system deploy
     val fe = runtime
       .evalSystemDeploy(systemDeploy)
@@ -326,14 +345,15 @@ final class RuntimeReplayOps[F[_]: Sync: Span: Log](
   def rigWithCheck[A](
       processedDeploy: ProcessedDeploy,
       action: F[Either[ReplayFailure, (A, Boolean)]]
-  ): EitherT[F, ReplayFailure, (A, Boolean)] = EitherT(rig(processedDeploy) *> action) flatMap {
-    case r @ (_, evalRes) => checkReplayDataWithFix(evalRes).as(r)
-  }
+  )(implicit s: Sync[F]): EitherT[F, ReplayFailure, (A, Boolean)] =
+    EitherT(rig(processedDeploy) *> action) flatMap {
+      case r @ (_, evalRes) => checkReplayDataWithFix(evalRes).as(r)
+    }
 
   def rigWithCheck[A](
       processedSystemDeploy: ProcessedSystemDeploy,
       action: EitherT[F, ReplayFailure, (A, EvaluateResult)]
-  ): EitherT[F, ReplayFailure, (A, EvaluateResult)] =
+  )(implicit s: Sync[F]): EitherT[F, ReplayFailure, (A, EvaluateResult)] =
     rig(processedSystemDeploy).liftEitherT[ReplayFailure] *> action flatMap {
       case r @ (_, evalRes) => checkReplayDataWithFix(evalRes.succeeded).as(r)
     }
@@ -344,7 +364,9 @@ final class RuntimeReplayOps[F[_]: Sync: Span: Log](
   def rig(processedSystemDeploy: ProcessedSystemDeploy): F[Unit] =
     runtime.rig(processedSystemDeploy.eventList.map(EventConverter.toRspaceEvent))
 
-  def checkReplayDataWithFix(evalSuccessful: Boolean): EitherT[F, ReplayFailure, Unit] =
+  def checkReplayDataWithFix(
+      evalSuccessful: Boolean
+  )(implicit s: Sync[F]): EitherT[F, ReplayFailure, Unit] =
     runtime.checkReplayData.attemptT
       .leftMap {
         case replayException: ReplayException =>

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.rholang.syntax
 
+import cats.{Applicative, Functor, Monad}
 import cats.data.{EitherT, OptionT}
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
@@ -16,7 +17,7 @@ import coop.rchain.casper.protocol.{
 }
 import coop.rchain.casper.rholang.InterpreterUtil.printDeployErrors
 import coop.rchain.casper.rholang._
-import coop.rchain.casper.rholang.syntax.RuntimeSyntax.SysEvalResult
+import coop.rchain.casper.rholang.syntax.RuntimeSyntax._
 import coop.rchain.casper.rholang.sysdeploys.{
   CloseBlockDeploy,
   PreChargeDeploy,
@@ -52,9 +53,10 @@ import coop.rchain.rspace.hashing.{Blake2b256Hash, StableHashProvider}
 import coop.rchain.rspace.history.History.emptyRootHash
 import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsEndVal
 import coop.rchain.shared.{Base16, Log}
+import RuntimeSyntax._
 
 trait RuntimeSyntax {
-  implicit final def casperSyntaxRholangRuntime[F[_]: Sync: Span: Log](
+  implicit final def casperSyntaxRholangRuntime[F[_]](
       runtime: RhoRuntime[F]
   ): RuntimeOps[F] = new RuntimeOps[F](runtime)
 }
@@ -63,22 +65,22 @@ object RuntimeSyntax {
   type SysEvalResult[S <: SystemDeploy] = (Either[SystemDeployUserError, S#Result], EvaluateResult)
 }
 
-final class RuntimeOps[F[_]: Sync: Span: Log](
-    private val runtime: RhoRuntime[F]
-) {
   implicit val RuntimeMetricsSource = Metrics.Source(CasperMetricsSource, "rho-runtime")
 
-  private val systemDeployConsumeAllPattern = {
+  val systemDeployConsumeAllPattern = {
     import coop.rchain.models.rholang.{implicits => toPar}
     BindPattern(List(toPar(Expr(EVarBody(EVar(Var(FreeVar(0))))))), freeCount = 1)
   }
+}
+
+final class RuntimeOps[F[_]](private val runtime: RhoRuntime[F]) extends AnyVal {
 
   /**
     * Because of the history legacy, the emptyStateHash does not really represent an empty trie.
     * The `emptyStateHash` is used as genesis block pre state which the state only contains registry
     * fixed channels in the state.
     */
-  def emptyStateHash: F[StateHash] =
+  def emptyStateHash(implicit m: Monad[F]): F[StateHash] =
     for {
       _          <- runtime.reset(emptyRootHash)
       _          <- bootstrapRegistry(runtime)
@@ -95,7 +97,11 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
       startHash: StateHash,
       terms: Seq[Signed[DeployData]],
       systemDeploys: Seq[SystemDeploy],
-      blockData: BlockData
+      blockData: BlockData,
+  )(
+      implicit s: Sync[F],
+      span: Span[F],
+      log: Log[F]
   ): F[
     (
         StateHash,
@@ -139,6 +145,10 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
       terms: Seq[Signed[DeployData]],
       blockTime: Long,
       blockNumber: Long
+  )(
+      implicit s: Sync[F],
+      span: Span[F],
+      log: Log[F]
   ): F[(StateHash, StateHash, Seq[(ProcessedDeploy, NumberChannelsEndVal)])] =
     Span[F].traceI("compute-genesis") {
       for {
@@ -159,8 +169,8 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
   def playDeploys(
       startHash: StateHash,
       terms: Seq[Signed[DeployData]],
-      processDeploy: Signed[DeployData] => F[(ProcessedDeploy, NumberChannelsEndVal)]
-  ): F[(StateHash, Seq[(ProcessedDeploy, NumberChannelsEndVal)])] =
+      processDeploy: Signed[DeployData] => F[UserTransition]
+  )(implicit m: Monad[F]): F[(StateHash, Seq[UserTransition])] =
     for {
       _               <- runtime.reset(startHash.toBlake2b256Hash)
       res             <- terms.toList.traverse(processDeploy)
@@ -173,7 +183,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
     */
   def playDeployWithCostAccounting(
       deploy: Signed[DeployData]
-  ): F[(ProcessedDeploy, NumberChannelsEndVal)] = {
+  )(implicit s: Sync[F], log: Log[F], span: Span[F]): F[UserTransition] = {
     // Pre-charge system deploy evaluator
     val preChargeF: F[(Vector[Event], Either[SystemDeployUserError, Unit], Set[Par])] =
       playSystemDeployInternal(
@@ -258,7 +268,9 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
   /**
     * Evaluates deploy
     */
-  def processDeploy(deploy: Signed[DeployData]): F[(ProcessedDeploy, Set[Par])] =
+  def processDeploy(
+      deploy: Signed[DeployData]
+  )(implicit s: Sync[F], span: Span[F], log: Log[F]): F[(ProcessedDeploy, EvaluateResult)] =
     Span[F].withMarks("play-deploy") {
       for {
         fallback <- runtime.createSoftCheckpoint
@@ -284,7 +296,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
 
   def processDeployWithMergeableData(
       deploy: Signed[DeployData]
-  ): F[(ProcessedDeploy, NumberChannelsEndVal)] =
+  )(implicit s: Sync[F], span: Span[F], log: Log[F]): F[UserTransition] =
     processDeploy(deploy) flatMap {
       case (pd, mergeChs) =>
         for {
@@ -292,16 +304,18 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
         } yield (pd, mergeableData)
     }
 
-  def getNumberChannelsData(channels: Set[Par]): F[NumberChannelsEndVal] =
+  def getNumberChannelsData(
+      channels: Set[Par]
+  )(implicit s: Sync[F]): F[NumberChannelsEndVal] =
     channels.toList.traverse(getNumberChannel).map(_.flatten.toMap)
 
-  def getNumberChannel(chan: Par): F[Option[(Blake2b256Hash, Long)]] =
+  def getNumberChannel(chan: Par)(implicit m: Sync[F]): F[Option[(Blake2b256Hash, Long)]] =
     // Read current channel value
     for {
       chValues <- runtime.getData(chan)
 
       r <- if (chValues.isEmpty) {
-            none.pure
+            none[(Blake2b256Hash, Long)].pure[F]
           } else {
             for {
               _ <- new Exception(s"NumberChannel must have singleton value.").raiseError
@@ -322,7 +336,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
     */
   def playSystemDeploy[S <: SystemDeploy](stateHash: StateHash)(
       systemDeploy: S
-  ): F[SystemDeployResult[S#Result]] =
+  )(implicit s: Sync[F], span: Span[F]): F[SystemDeployResult[S#Result]] =
     for {
       _ <- runtime.reset(stateHash.toBlake2b256Hash)
 
@@ -372,6 +386,9 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
 
   def playSystemDeployInternal[S <: SystemDeploy](
       systemDeploy: S
+  )(
+      implicit s: Sync[F],
+      span: Span[F]
   ): F[(Vector[Event], Either[SystemDeployUserError, S#Result], Set[Par])] =
     for {
       // Get System deploy result / throw fatal errors for unexpected results
@@ -389,7 +406,9 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
   /**
     * Evaluates System deploy (applicative errors are fatal)
     */
-  def evalSystemDeploy[S <: SystemDeploy](systemDeploy: S): F[SysEvalResult[S]] =
+  def evalSystemDeploy[S <: SystemDeploy](
+      systemDeploy: S
+  )(implicit m: Sync[F], span: Span[F]): F[SysEvalResult[S]] =
     for {
       // Evaluate Rholang term with trace diagnostics
       evalResult <- Span[F].traceI("evaluate-system-source") {
@@ -424,7 +443,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
   /**
     * Evaluates exploratory (read-only) deploy
     */
-  def playExploratoryDeploy(term: String, hash: StateHash): F[Seq[Par]] = {
+  def playExploratoryDeploy(term: String, hash: StateHash)(implicit s: Sync[F]): F[Seq[Par]] = {
     // Create a deploy with newly created private key
     val (privKey, _) = Secp256k1.newKeyPair
 
@@ -451,7 +470,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
   /**
     * Creates soft checkpoint with rollback if result is false.
     */
-  def withSoftTransaction[A](fa: F[(A, Boolean)]): F[A] =
+  def withSoftTransaction[A](fa: F[(A, Boolean)])(implicit m: Monad[F]): F[A] =
     for {
       fallback <- runtime.createSoftCheckpoint
       // Execute action
@@ -468,7 +487,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
   def captureResults(
       start: StateHash,
       deploy: Signed[DeployData]
-  ): F[Seq[Par]] = {
+  )(implicit s: Sync[F]): F[Seq[Par]] = {
     // Create return channel as first unforgeable name created in deploy term
     val rand = Tools.unforgeableNameRng(deploy.pk, deploy.data.timestamp)
     import coop.rchain.models.rholang.implicits._
@@ -476,7 +495,9 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
     captureResults(start, deploy, returnName)
   }
 
-  def captureResults(start: StateHash, deploy: Signed[DeployData], name: Par): F[Seq[Par]] =
+  def captureResults(start: StateHash, deploy: Signed[DeployData], name: Par)(
+      implicit s: Sync[F]
+  ): F[Seq[Par]] =
     captureResultsWithErrors(start, deploy, name)
       .handleErrorWith(
         ex =>
@@ -488,7 +509,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
       start: StateHash,
       deploy: Signed[DeployData],
       name: Par
-  ): F[Seq[Par]] =
+  )(implicit s: Sync[F]): F[Seq[Par]] =
     runtime.reset(start.toBlake2b256Hash) >>
       evaluate(deploy)
         .flatMap({ res =>
@@ -512,10 +533,12 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
       systemDeploy.rand
     )
 
-  def getDataPar(channel: Par): F[Seq[Par]] =
+  def getDataPar(channel: Par)(implicit f: Functor[F]): F[Seq[Par]] =
     runtime.getData(channel).map(_.flatMap(_.a.pars))
 
-  def getContinuationPar(channels: Seq[Par]): F[Seq[(Seq[BindPattern], Par)]] =
+  def getContinuationPar(
+      channels: Seq[Par]
+  )(implicit f: Functor[F]): F[Seq[(Seq[BindPattern], Par)]] =
     runtime
       .getContinuation(channels)
       .map(
@@ -536,7 +559,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
 
   /* Read only Rholang evaluator helpers */
 
-  def getActiveValidators(startHash: StateHash): F[Seq[Validator]] =
+  def getActiveValidators(startHash: StateHash)(implicit s: Sync[F]): F[Seq[Validator]] =
     playExploratoryDeploy(activateValidatorQuerySource, startHash)
       .ensureOr(
         validatorsPar =>
@@ -547,7 +570,7 @@ final class RuntimeOps[F[_]: Sync: Span: Log](
       )(validatorsPar => validatorsPar.size == 1)
       .map(validatorsPar => toValidatorSeq(validatorsPar.head))
 
-  def computeBonds(hash: StateHash): F[Seq[Bond]] =
+  def computeBonds(hash: StateHash)(implicit s: Sync[F]): F[Seq[Bond]] =
     // Create a deploy with newly created private key
     playExploratoryDeploy(bondsQuerySource, hash)
       .ensureOr(

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
@@ -105,7 +105,7 @@ final class RuntimeOps[F[_]](private val runtime: RhoRuntime[F]) extends AnyVal 
       startHash: StateHash,
       terms: Seq[Signed[DeployData]],
       systemDeploys: Seq[SystemDeploy],
-      blockData: BlockData,
+      blockData: BlockData
   )(
       implicit s: Sync[F],
       span: Span[F],

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -562,7 +562,8 @@ class ValidateTest
         runtimeManager <- RuntimeManager[Task](
                            rStore,
                            mStore,
-                           Genesis.NonNegativeMergeableTagName
+                           Genesis.NonNegativeMergeableTagName,
+                           RuntimeManager.noOpExecutionTracker[Task]
                          )
         dag <- blockDagStorage.getRepresentation
         _ <- InterpreterUtil

--- a/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/Setup.scala
@@ -68,8 +68,14 @@ object Setup {
 
     val mStore = RuntimeManager.mergeableStore(spaceKVManager).unsafeRunSync(scheduler)
     implicit val runtimeManager =
-      RuntimeManager[Task](rspace, replay, historyRepo, mStore, Genesis.NonNegativeMergeableTagName)
-        .unsafeRunSync(scheduler)
+      RuntimeManager[Task](
+        rspace,
+        replay,
+        historyRepo,
+        mStore,
+        Genesis.NonNegativeMergeableTagName,
+        RuntimeManager.noOpExecutionTracker[Task]
+      ).unsafeRunSync(scheduler)
 
     val (validatorSk, validatorPk) = context.validatorKeyPairs.head
     val bonds                      = genesisParams.proofOfStake.validators.flatMap(Validator.unapply).toMap

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -322,7 +322,8 @@ object GenesisTest {
       kvsManager     <- Resources.mkTestRNodeStoreManager[F](storePath)
       rStore         <- kvsManager.rSpaceStores
       mStore         <- RuntimeManager.mergeableStore(kvsManager)
-      runtimeManager <- RuntimeManager[F](rStore, mStore, Genesis.NonNegativeMergeableTagName)
+      t              = RuntimeManager.noOpExecutionTracker
+      runtimeManager <- RuntimeManager[F](rStore, mStore, Genesis.NonNegativeMergeableTagName, t)
       result         <- body(runtimeManager, genesisPath, log, time)
       _              <- Sync[F].delay { storePath.recursivelyDelete() }
       _              <- Sync[F].delay { gp.recursivelyDelete() }

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -429,7 +429,12 @@ object TestNode {
       rSpaceStore         <- Resource.eval(kvm.rSpaceStores)
       mStore              <- Resource.eval(RuntimeManager.mergeableStore(kvm))
       runtimeManager <- Resource.eval(
-                         RuntimeManager(rSpaceStore, mStore, Genesis.NonNegativeMergeableTagName)
+                         RuntimeManager(
+                           rSpaceStore,
+                           mStore,
+                           Genesis.NonNegativeMergeableTagName,
+                           RuntimeManager.noOpExecutionTracker[F]
+                         )
                        )
 
       shardConf = CasperShardConf(

--- a/casper/src/test/scala/coop/rchain/casper/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/Resources.scala
@@ -62,9 +62,14 @@ object Resources {
     implicit val noopSpan: Span[F] = NoopSpan[F]()
 
     for {
-      rStore         <- kvm.rSpaceStores
-      mStore         <- RuntimeManager.mergeableStore(kvm)
-      runtimeManager <- RuntimeManager(rStore, mStore, mergeableTagName)
+      rStore <- kvm.rSpaceStores
+      mStore <- RuntimeManager.mergeableStore(kvm)
+      runtimeManager <- RuntimeManager(
+                         rStore,
+                         mStore,
+                         mergeableTagName,
+                         RuntimeManager.noOpExecutionTracker[F]
+                       )
     } yield runtimeManager
   }
 
@@ -83,7 +88,8 @@ object Resources {
       runtimeManagerWithHistory <- RuntimeManager.createWithHistory(
                                     rStore,
                                     mStore,
-                                    Genesis.NonNegativeMergeableTagName
+                                    Genesis.NonNegativeMergeableTagName,
+                                    RuntimeManager.noOpExecutionTracker[F]
                                   )
     } yield runtimeManagerWithHistory
   }

--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeManagerTest.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper.rholang
 import cats.data.EitherT
 import cats.effect.{Resource, Sync}
 import cats.syntax.all._
-import cats.{Functor, Id}
+import cats.{Applicative, Functor, Id}
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.ProcessedSystemDeploy.Failed
 import coop.rchain.casper.protocol.{DeployData, ProcessedDeploy, ProcessedSystemDeploy}
@@ -82,7 +82,7 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
       (hash, Seq(result), _) = res
     } yield (hash, result)
 
-  private def replayComputeState[F[_]: Functor](runtimeManager: RuntimeManager[F])(
+  private def replayComputeState[F[_]: Applicative](runtimeManager: RuntimeManager[F])(
       stateHash: StateHash,
       processedDeploy: ProcessedDeploy
   ): F[Either[ReplayFailure, StateHash]] =
@@ -97,7 +97,6 @@ class RuntimeManagerTest extends FlatSpec with Matchers {
       ),
       withCostAccounting = true
     )
-
   "computeState" should "charge for deploys" in effectTest {
     runtimeManagerResource.use { runtimeManager =>
       val genPostState = genesis.body.state.postStateHash

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -153,7 +153,8 @@ object GenesisBuilder {
       kvsManager     <- mkTestRNodeStoreManager[Task](storageDirectory)
       rStore         <- kvsManager.rSpaceStores
       mStore         <- RuntimeManager.mergeableStore(kvsManager)
-      runtimeManager <- RuntimeManager(rStore, mStore, Genesis.NonNegativeMergeableTagName)
+      t              = RuntimeManager.noOpExecutionTracker[Task]
+      runtimeManager <- RuntimeManager(rStore, mStore, Genesis.NonNegativeMergeableTagName, t)
       genesis <- {
         implicit val rm = runtimeManager
         Genesis.createGenesisBlock[Task](genesisParameters)

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -6,6 +6,7 @@ import cats.effect.{Concurrent, ContextShift, Timer}
 import cats.mtl.ApplicativeAsk
 import cats.syntax.all._
 import coop.rchain.blockstorage.casperbuffer.CasperBufferKeyValueStorage
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.{approvedStore, BlockStore}
 import coop.rchain.casper._
 import coop.rchain.casper.api.{BlockApiImpl, BlockReportApi}
@@ -17,6 +18,7 @@ import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.{toCasperMessageProto, BlockMessage, CasperMessage, CommUtil}
 import coop.rchain.casper.reporting.{ReportStore, ReportingCasper}
 import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.RuntimeManager.ExecutionTracker
 import coop.rchain.casper.state.instances.{BlockStateManagerImpl, ProposerState}
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager
 import coop.rchain.comm.RoutingMessage
@@ -38,7 +40,7 @@ import coop.rchain.node.runtime.NodeRuntime._
 import coop.rchain.node.state.instances.RNodeStateManagerImpl
 import coop.rchain.node.web.ReportingRoutes.ReportingHttpRoutes
 import coop.rchain.node.web.{ReportingRoutes, Transaction}
-import coop.rchain.rholang.interpreter.RhoRuntime
+import coop.rchain.rholang.interpreter.{EvaluateResult, RhoRuntime}
 import coop.rchain.rspace.state.instances.RSpaceStateManagerImpl
 import coop.rchain.rspace.syntax._
 import coop.rchain.shared._
@@ -124,11 +126,24 @@ object Setup {
       // Runtime manager (play and replay runtimes)
       runtimeManagerWithHistory <- {
         implicit val sp = span
+        val executionTracker = new ExecutionTracker[F] {
+          override def callbackExecutionStarted(d: DeployId): F[Unit] =
+            blockDagStorage.commitExecutionStarted(d)
+          override def callbackExecutionComplete(d: DeployId, res: EvaluateResult): F[Unit] = {
+            val err = res.errors.map(_.getMessage).mkString("\n")
+            blockDagStorage.commitExecutionComplete(d, if (err.isBlank) "Success" else err)
+          }
+        }
         for {
           rStores    <- rnodeStoreManager.rSpaceStores
           mergeStore <- RuntimeManager.mergeableStore(rnodeStoreManager)
           rm <- RuntimeManager
-                 .createWithHistory[F](rStores, mergeStore, Genesis.NonNegativeMergeableTagName)
+                 .createWithHistory[F](
+                   rStores,
+                   mergeStore,
+                   Genesis.NonNegativeMergeableTagName,
+                   executionTracker
+                 )
         } yield rm
       }
       (runtimeManager, historyRepo) = runtimeManagerWithHistory

--- a/node/src/test/scala/coop/rchain/node/mergeablity/ComputeMerge.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/ComputeMerge.scala
@@ -9,6 +9,7 @@ import coop.rchain.casper.helper.TestRhoRuntime.rhoRuntimeEff
 import coop.rchain.casper.merging.{BlockIndex, DagMerger, DeployChainIndex}
 import coop.rchain.casper.protocol.DeployData
 import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.syntax.RuntimeSyntax.UserTransition
 import coop.rchain.casper.syntax._
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.metrics.{Metrics, Span}
@@ -61,7 +62,9 @@ trait ComputeMerge {
             baseDeploysRes <- baseDeploySources.toList.traverse(
                                runtime.processDeployWithMergeableData
                              )
-            (baseDeploys, baseMergeChs) = baseDeploysRes.unzip
+            (baseDeploys, baseMergeChs, _) = baseDeploysRes
+              .map(UserTransition.unapply(_).get)
+              .unzip3
             _ <- Sync[F]
                   .raiseError(
                     new Exception(s"Process deploy ${baseDeploys.filter(_.isFailed)} failed")
@@ -71,7 +74,9 @@ trait ComputeMerge {
             leftDeploysRes <- leftDeploySources.toList.traverse(
                                runtime.processDeployWithMergeableData
                              )
-            (leftDeploys, leftMergeChs) = leftDeploysRes.unzip
+            (leftDeploys, leftMergeChs, _) = leftDeploysRes
+              .map(UserTransition.unapply(_).get)
+              .unzip3
             _ <- Sync[F]
                   .raiseError(
                     new Exception(s"Process deploy ${leftDeploys.filter(_.isFailed)} failed")
@@ -82,7 +87,9 @@ trait ComputeMerge {
             rightDeploysRes <- rightDeploySources.toList.traverse(
                                 runtime.processDeployWithMergeableData
                               )
-            (rightDeploys, rightMergeChs) = rightDeploysRes.unzip
+            (rightDeploys, rightMergeChs, _) = rightDeploysRes
+              .map(UserTransition.unapply(_).get)
+              .unzip3
             _ <- Sync[F]
                   .raiseError(
                     new Exception(s"Process deploy ${rightDeploys.filter(_.isFailed)} failed")

--- a/node/src/test/scala/coop/rchain/node/mergeablity/ComputeMerge.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/ComputeMerge.scala
@@ -8,8 +8,8 @@ import coop.rchain.casper.dag.BlockDagKeyValueStorage
 import coop.rchain.casper.helper.TestRhoRuntime.rhoRuntimeEff
 import coop.rchain.casper.merging.{BlockIndex, DagMerger, DeployChainIndex}
 import coop.rchain.casper.protocol.DeployData
+import coop.rchain.casper.rholang.RuntimeDeployResult.UserDeployRuntimeResult
 import coop.rchain.casper.rholang.RuntimeManager
-import coop.rchain.casper.rholang.syntax.RuntimeSyntax.UserTransition
 import coop.rchain.casper.syntax._
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.metrics.{Metrics, Span}
@@ -63,7 +63,7 @@ trait ComputeMerge {
                                runtime.processDeployWithMergeableData
                              )
             (baseDeploys, baseMergeChs, _) = baseDeploysRes
-              .map(UserTransition.unapply(_).get)
+              .map(UserDeployRuntimeResult.unapply(_).get)
               .unzip3
             _ <- Sync[F]
                   .raiseError(
@@ -75,7 +75,7 @@ trait ComputeMerge {
                                runtime.processDeployWithMergeableData
                              )
             (leftDeploys, leftMergeChs, _) = leftDeploysRes
-              .map(UserTransition.unapply(_).get)
+              .map(UserDeployRuntimeResult.unapply(_).get)
               .unzip3
             _ <- Sync[F]
                   .raiseError(
@@ -88,7 +88,7 @@ trait ComputeMerge {
                                 runtime.processDeployWithMergeableData
                               )
             (rightDeploys, rightMergeChs, _) = rightDeploysRes
-              .map(UserTransition.unapply(_).get)
+              .map(UserDeployRuntimeResult.unapply(_).get)
               .unzip3
             _ <- Sync[F]
                   .raiseError(


### PR DESCRIPTION
## Overview
Implementation of logic for <https://github.com/rchain/rchain/issues/3537>
Makes `BlockDagKeyValueStorage` implementation providing status of particular deploy through `deployStatus` method.
To track deploy execution status `ExecutionTracker` trait is supplied to `RuntimeManagerImpl` and connected with  new API methods. `BlockDagKeyValueStorage`


### Notes
Connecting `BlockDagKeyValueStorage.deployStatus` method to external RPC and web API should be done in the followup PR.


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
