### PR TITLE
Changed type of fields value/ptr in classes Leaf and NodePtr, adaptation of code 

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/history/History.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/History.scala
@@ -21,7 +21,7 @@ trait History[F[_]] {
   /**
     * Read operation on the Merkle tree
     */
-  def read(key: ByteVector): F[Option[ByteVector]]
+  def read(key: ByteVector): F[Option[Blake2b256Hash]]
 
   /**
     * Insert/update/delete operations on the underlying Merkle tree (key-value store)

--- a/rspace/src/main/scala/coop/rchain/rspace/history/RadixTree.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/RadixTree.scala
@@ -97,22 +97,16 @@ object RadixTree {
       val calcSize = node.foldLeft(0) {
         case (size, EmptyItem) => size
 
-        case (size, Leaf(leafPrefix, value)) =>
+        case (size, Leaf(leafPrefix, _)) =>
           val sizePrefix = leafPrefix.size.toInt
           assert(sizePrefix <= 127, "Error during serialization: size of prefix more than 127.")
-          assert(
-            value.bytes.size == defSize,
-            "Error during serialization: size of leafValue not equal 32."
-          )
+          // No need for validation size of value because the size of Blake2b256Hash is always 32 bytes
           size + headSize + sizePrefix + defSize
 
-        case (size, NodePtr(ptrPrefix, ptr)) =>
+        case (size, NodePtr(ptrPrefix, _)) =>
           val sizePrefix = ptrPrefix.size.toInt
           assert(sizePrefix <= 127, "Error during serialization: size of prefix more than 127.")
-          assert(
-            ptr.bytes.size == defSize,
-            "Error during serialization: size of ptrPrefix not equal 32."
-          )
+          // No need for validation size of value because the size of Blake2b256Hash is always 32 bytes
           size + headSize + sizePrefix + defSize
       }
 

--- a/rspace/src/main/scala/coop/rchain/rspace/history/instances/RSpaceHistoryReaderImpl.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/instances/RSpaceHistoryReaderImpl.scala
@@ -62,7 +62,7 @@ class RSpaceHistoryReaderImpl[F[_]: Concurrent, C, P, A, K](
   ): F[Option[PersistedData]] =
     targetHistory
       .read(prefix +: key.bytes)
-      .flatMap(_.map(Blake2b256Hash.fromByteVector).flatTraverse(leafStore.get1))
+      .flatMap(_.flatTraverse(leafStore.get1))
 
   override def base: HistoryReaderBase[F, C, P, A, K] = {
     val historyReader = this

--- a/rspace/src/main/scala/coop/rchain/rspace/state/RSpaceExporter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/state/RSpaceExporter.scala
@@ -24,7 +24,7 @@ object RSpaceExporter {
       startPath: Seq[(Blake2b256Hash, Option[Byte])],
       skip: Int,
       take: Int,
-      getFromHistory: ByteVector => F[Option[ByteVector]]
+      getFromHistory: Blake2b256Hash => F[Option[ByteVector]]
   ): F[Vector[TrieNode[Blake2b256Hash]]] = {
 
     val settings = ExportDataSettings(

--- a/rspace/src/main/scala/coop/rchain/rspace/state/RSpaceExporter.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/state/RSpaceExporter.scala
@@ -46,16 +46,9 @@ object RSpaceExporter {
         prefix128.take(sizePrefix.toLong).some
       }
 
-    def constructNodes(leafKeys: Seq[ByteVector], nodeKeys: Seq[ByteVector]) = {
-      val dataKeys = leafKeys.map { key =>
-        val hash = Blake2b256Hash.fromByteVector(key)
-        TrieNode(hash, isLeaf = true, Vector())
-      }.toVector
-
-      val historyKeys = nodeKeys.map { key =>
-        val hash = Blake2b256Hash.fromByteVector(key)
-        TrieNode(hash, isLeaf = false, Vector())
-      }.toVector
+    def constructNodes(leafKeys: Seq[Blake2b256Hash], nodeKeys: Seq[Blake2b256Hash]) = {
+      val dataKeys    = leafKeys.map(TrieNode(_, isLeaf = true, Vector())).toVector
+      val historyKeys = nodeKeys.map(TrieNode(_, isLeaf = false, Vector())).toVector
 
       dataKeys ++ historyKeys
     }
@@ -83,12 +76,10 @@ object RSpaceExporter {
     }
 
     def constructLastNode(
-        lastKey: ByteVector,
+        lastHash: Blake2b256Hash,
         lastPath: Vector[(Blake2b256Hash, None.type)]
-    ) = {
-      val hash = Blake2b256Hash.fromByteVector(lastKey)
-      Vector(TrieNode(hash, isLeaf = false, lastPath))
-    }
+    ) =
+      Vector(TrieNode(lastHash, isLeaf = false, lastPath))
 
     if (startPath.isEmpty) Vector[TrieNode[Blake2b256Hash]]().pure
     else
@@ -99,7 +90,7 @@ object RSpaceExporter {
         // TODO: Implemented a temporary solution with lastPrefix coding in 5 blake256 hashes.
         lastPrefix = createLastPrefix(prefixSeq)
 
-        expRes <- sequentialExport(rootHash.bytes, lastPrefix, skip, take, getFromHistory, settings)
+        expRes <- sequentialExport(rootHash, lastPrefix, skip, take, getFromHistory, settings)
 
         (data, newLastPrefixOpt)                = expRes
         ExportData(_, nodeKeys, _, _, leafKeys) = data

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionTests.scala
@@ -24,7 +24,7 @@ class HistoryActionTests extends FlatSpec with Matchers with InMemoryHistoryTest
       emptyHistory <- emptyHistoryF
       newHistory   <- emptyHistory.process(data)
       readValue    <- newHistory.read(_zeros)
-      _            = readValue shouldBe data.head.hash.bytes.some
+      _            = readValue shouldBe data.head.hash.some
     } yield ()
   }
 
@@ -35,7 +35,7 @@ class HistoryActionTests extends FlatSpec with Matchers with InMemoryHistoryTest
       newHistory      <- emptyHistory.process(data)
       historyOneReset <- emptyHistory.reset(newHistory.root)
       readValue       <- historyOneReset.read(_zeros)
-      _               = readValue shouldBe data.head.hash.bytes.some
+      _               = readValue shouldBe data.head.hash.some
     } yield ()
   }
 
@@ -45,7 +45,7 @@ class HistoryActionTests extends FlatSpec with Matchers with InMemoryHistoryTest
       emptyHistory <- emptyHistoryF
       newHistory   <- emptyHistory.process(data)
       readValues   <- data.traverse(action => newHistory.read(action.key))
-      _            = readValues shouldBe data.map(_.hash.bytes.some)
+      _            = readValues shouldBe data.map(_.hash.some)
     } yield ()
   }
 
@@ -57,7 +57,7 @@ class HistoryActionTests extends FlatSpec with Matchers with InMemoryHistoryTest
         emptyHistory <- emptyHistoryF
         newHistory   <- emptyHistory.process(data)
         readValues   <- data.traverse(action => newHistory.read(action.key))
-        _            = readValues shouldBe data.map(_.hash.bytes.some)
+        _            = readValues shouldBe data.map(_.hash.some)
       } yield ()
   }
 
@@ -255,7 +255,7 @@ class HistoryActionTests extends FlatSpec with Matchers with InMemoryHistoryTest
                           for {
                             re <- newHistory.read(k)
                             _ = re match {
-                              case Some(v) => assert(v == value.bytes)
+                              case Some(v) => assert(v == value)
                               case _       => fail("Can not get value")
                             }
                           } yield ()


### PR DESCRIPTION
## Overview
Second step of Refactoring of History and RadixTree according to the [issue](https://github.com/rchain/rchain/issues/3670)


### Notes
1. Replaced type of fields ptr and value (in classes Leaf and NodePtr) from ByteVector to Blake2b256Hash 
2. Adaptation of modules RadixTree, History, RadixHistory, RSpaceExporter and RSpaceImporter for new data types
3. Made performance measurement before and after the recfactoring. The measurement results are shown in the table below. 

|              Step                                                                                                                 	|  timeI(sec) 	|  timeR(sec) 	|  timeD(sec) 	|  timeExp(sec) 	|  timeValid(sec) 	|     numNode 	|
|------------------------------------------------------------------------------------------------------------------------------------	|-------------	|-------------	|-------------	|---------------	|-----------------	|-------------	|
| Before refactoring                                                                                                                 	| 0.723       	| 0.555       	| 0.283       	| 0.478         	| 0.356           	| 29990       	|
| After refactoring 	| 0.666       	| 0.549       	| 0.376       	| 0.516         	| 0.373           	| 29990       	|

Note: numIRD = 100000, typeStore = Lmdb, typeHistory = Radix



### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
