### PR TITLE
Remove signature in insertSigned

### DIFF
--- a/casper/src/main/resources/AuthKey.rho
+++ b/casper/src/main/resources/AuthKey.rho
@@ -19,7 +19,8 @@ new
   rs(`rho:registry:insertSigned:secp256k1`),
   uriOut,
   _authKey,
-  stdout(`rho:io:stdout`)
+  stdout(`rho:io:stdout`),
+  deployerId(`rho:rchain:deployerId`)
 in {
 
   // An `AuthKey` is a means for creating a safe authentication token based on a process / unfograble name
@@ -68,9 +69,8 @@ in {
   } |
 
   rs!(
-    "04f4b4417f930e6fab5765ac0defcf9fce169982acfd046e7c27f9b14c0804014623c0439e5c8035e9607599a549303b5b6b90cd9685e6965278bddca65dac7510".hexToBytes(),
     (9223372036854775807, bundle+{*AuthKey}),
-    "304402205d2dc163a40804a445237ef6bd181249a68598d146e66d0c96484c6cfeaaaffd02205e537f1e7bae82b99abbdc25c8472c44f5848085a3a3f23357507c05524be4a7".hexToBytes(),
+    *deployerId,
     *uriOut
   )
 }

--- a/casper/src/main/resources/Either.rho
+++ b/casper/src/main/resources/Either.rho
@@ -14,7 +14,8 @@
  9.  | 4,         | registry           | uri = rho:id:qrh6mgfp5z6orgchgszyxnuonanz7hw3amgrprqtciia6astt66ypn
  ----+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------
  */
-new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry:lookup`), ListOpsCh in {
+new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry:lookup`), ListOpsCh,
+  deployerId(`rho:rchain:deployerId`) in {
   rl!(`rho:lang:listOps`, *ListOpsCh) |
   for(@(_, ListOps) <- ListOpsCh) {
 
@@ -262,9 +263,8 @@ new  Either, rs(`rho:registry:insertSigned:secp256k1`), uriOut, rl(`rho:registry
   } |
   
   rs!(
-    "04c71f6c7b87edf4bec14f16f715ee49c6fea918549abdf06c734d384b60ba922990317cc4bf68da8c85b455a65595cf7007f1e54bfd6be26ffee53d1ea6d7406b".hexToBytes(),
     (9223372036854775807, bundle+{*Either}),
-    "3045022100aa2bbdd706e157efb6df78156f1520c6422ff651728ccff69d5bffbf901767eb0220799a0451c72c284b1da128f0e4031125dbed9ac8b9de6ce5b0e4d35562ade877".hexToBytes(),
+    *deployerId,
     *uriOut
   )
 }

--- a/casper/src/main/resources/ListOps.rho
+++ b/casper/src/main/resources/ListOps.rho
@@ -14,7 +14,8 @@
  9.  | 4,         | registry           | uri = rho:id:6fzorimqngeedepkrizgiqms6zjt76zjeciktt1eifequy4osz35ks
  ----+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------
  */
-new  ListOps, rs(`rho:registry:insertSigned:secp256k1`), uriOut in {
+new  ListOps, rs(`rho:registry:insertSigned:secp256k1`), uriOut,
+  deployerId(`rho:rchain:deployerId`) in {
   contract ListOps(@"prepend", @head, @tail, return) = {
     return!([head] ++ tail)
   } |
@@ -446,9 +447,8 @@ new  ListOps, rs(`rho:registry:insertSigned:secp256k1`), uriOut in {
   } |
 
   rs!(
-    "040126690519dc9b0f52876cb13458e15697794dd87d7c6477707c7efa4cce8a36b634eab5056bd4e3ba385ab14a638e4ac7d3b3e4968da3d66933fc04bc7038b5".hexToBytes(),
     (9223372036854775807, bundle+{*ListOps}),
-    "3045022100dc97997d235773957dc6610491441707c64f9f23efeee6fb6ba8ac04003cd1d302201aa4cfd144dfc866d7c92673dddaa86436609c4df61a8a512ac2dd34e131b3ee".hexToBytes(),
+    *deployerId,
     *uriOut
   )
 }

--- a/casper/src/main/resources/MakeMint.rho
+++ b/casper/src/main/resources/MakeMint.rho
@@ -15,7 +15,8 @@
  */
 new
   MakeMint, rs(`rho:registry:insertSigned:secp256k1`), uriOut,
-  rl(`rho:registry:lookup`), NonNegativeNumberCh
+  rl(`rho:registry:lookup`), NonNegativeNumberCh,
+  deployerId(`rho:rchain:deployerId`)
 in {
   rl!(`rho:lang:nonNegativeNumber`, *NonNegativeNumberCh) |
   for(@(_, NonNegativeNumber) <- NonNegativeNumberCh) {
@@ -181,9 +182,8 @@ in {
     }
   } |
   rs!(
-    "0470256c078e105d2958b9cf66f2161d83368f483c0219790277fb726a459be7f56a9a48bbecf72bcaed6a3515bd0a144faf6a6a8de8f6c9b3b7dff297eb371f28".hexToBytes(),
     (9223372036854775807, bundle+{*MakeMint}),
-    "304402202fa3b242149821b91b35b058faa3943efdd5ce938cb8c6873a4cb5b2694ed53202200a7a443b29411e659806b1c8e1583eec1e0404b218d43f45fef6a3c418326649".hexToBytes(),
+    *deployerId,
     *uriOut
   )
 }

--- a/casper/src/main/resources/MultiSigRevVault.rho
+++ b/casper/src/main/resources/MultiSigRevVault.rho
@@ -21,7 +21,8 @@ new MultiSigRevVault,
     _multiSigRevVault,
     RevVaultCh,
     AuthKeyCh,
-    ListOpsCh
+    ListOpsCh,
+    deployerId(`rho:rchain:deployerId`)
 in {
   rl!(`rho:lang:listOps`, *ListOpsCh) |
   rl!(`rho:rchain:authKey`, *AuthKeyCh) |
@@ -260,9 +261,8 @@ in {
       } // quorum size
     } |
     rs!(
-      "04fe2eb1e0e7462b1a8f64600389e1e76727f8b2d38804eaa4b48f7a7d6715130fc24d3c4dac2d8bdc19e0b49879dbaf07c30773cd9740a9d14a092ef76339207a".hexToBytes(),
       (9223372036854775807, bundle+{*MultiSigRevVault}),
-      "30450221008539caafe08b2a27cfcabdcf9c7c345a1c1a926330a1a320ca614cf9240f6c77022024ad8465597c8a673431007b8e33317bd49c9c68dacb41eef6a4316d933909c4".hexToBytes(),
+      *deployerId,
       *uriOut
     )
   }

--- a/casper/src/main/resources/NonNegativeNumber.rho
+++ b/casper/src/main/resources/NonNegativeNumber.rho
@@ -14,7 +14,8 @@
  9.  | 4,         | registry           | uri = rho:id:hxyadh1ffypra47ry9mk6b8r1i33ar1w9wjsez4khfe9huzrfcytx9
  ----+------------+--------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------
  */
-new  NonNegativeNumber, MergeableTag, rs(`rho:registry:insertSigned:secp256k1`), uriOut in {
+new  NonNegativeNumber, MergeableTag, rs(`rho:registry:insertSigned:secp256k1`), uriOut,
+  deployerId(`rho:rchain:deployerId`) in {
   contract NonNegativeNumber(@init, return) = {
     new this, valueStore in {
       contract this(@"add", @x, success) = {
@@ -61,9 +62,8 @@ new  NonNegativeNumber, MergeableTag, rs(`rho:registry:insertSigned:secp256k1`),
   } |
 
   rs!(
-    "04e1559d809924e564dce57e34646e155b144d2a504ce7ee519d7a5108fd42f1038d08d745e5ea21cb53d6aa7c7174a768fa373207a83bc947a20c6a02ece7a60e".hexToBytes(),
     (9223372036854775807, bundle+{*NonNegativeNumber}),
-    "304402202b27c904bcecd83a7355db7f235fbe447c692079325deeefacba62c8ee236eb9022077b97df4e21784897e6da490b4b60c420a1db64b5807ad98acefa0a38c7f6f22".hexToBytes(),
+    *deployerId,
     *uriOut
   )
 }

--- a/casper/src/main/resources/PoS.rhox
+++ b/casper/src/main/resources/PoS.rhox
@@ -85,7 +85,8 @@ new PoS,
     PendingRewards, MergeIntMaps, treeHashMapCh,
     sysAuthTokenOps(`sys:authToken:ops`),
     multiSigRevVaultCh, coopVaultCh,
-    uriOut, sumFromPair
+    uriOut, sumFromPair,
+    deployerId(`rho:rchain:deployerId`)
 in {
   // Simultaneously retrieves RevVault, ListOps, TreeHashMap, and MultiSigRevVault contracts from the registry.
   registryLookup!(`rho:rchain:revVault`, *revVaultCh) |
@@ -707,9 +708,8 @@ in {
     }|
     // Registers signed write-only PoS contract bundle.
     rs!(
-      "047b43d6548b72813b89ac1b9f9ca67624a8b372feedd71d4e2da036384a3e1236812227e524e6f237cde5f80dbb921cac12e6500791e9a9ed1254a745a816fe1f".hexToBytes(),
       (9223372036854775807, bundle+{*PoS}),
-      "3044022054ff4bae3984252b116e41e28d98bb5533eaa39aec2729228159166e2784f641022066a0fd99e7ea33df812fab095cbe61250f9548bce6da3ec4c6a90c741b94087f".hexToBytes(),
+      *deployerId,
       *uriOut)
   }
 }

--- a/casper/src/main/resources/Registry.rho
+++ b/casper/src/main/resources/Registry.rho
@@ -7,8 +7,6 @@ new _registryStore,
     bootstrapInsertSigned(`rho:registry:insertSigned:secp256k1`),
     buildUri,
     ops(`rho:registry:ops`),
-    secpVerify(`rho:crypto:secp256k1Verify`),
-    blake2b256(`rho:crypto:blake2b256Hash`),
     TreeHashMap
 in {
 
@@ -392,49 +390,38 @@ in {
   bootstrapInsertSigned!(*insertSignedCh) | // this will work only once
   for (insertSigned <- insertSignedCh) {
 
-    contract insertSigned(@pubKeyBytes, @value, @sig, ret) = {
-      match value {
-        (nonce, data) => {
-          new uriCh, hashCh, verifyCh in {
-            blake2b256!((nonce, data).toByteArray(), *hashCh) |
-            for (@hash <- hashCh) {
-              secpVerify!(hash, sig, pubKeyBytes, *verifyCh) |
-              for (@verified <- verifyCh) {
-                if (verified) {
-                  ops!("buildUri", pubKeyBytes, *uriCh) |
-                  for (@uri <- uriCh) {
-                    for (@map <<- _registryStore) {
-                      new responseCh in {
-                        TreeHashMap!("get", map, uri, *responseCh) |
-                        for (@response <- responseCh) {
-                          match response {
-                            Nil => {
-                              new ack in {
-                                TreeHashMap!("set", map, uri, (nonce, data), *ack) |
-                                for (_ <- ack) {
-                                  ret!(uri)
-                                }
-                              }
-                            }
-                            (oldNonce, _) => {
-                              if (nonce > oldNonce) {
-                                new ack in {
-                                  TreeHashMap!("set", map, uri, (nonce, data), *ack) |
-                                  for (_ <- ack) {
-                                    ret!(uri)
-                                  }
-                                }
-                              } else {
-                                ret!(Nil)
-                              }
-                            }
-                          }
+    contract insertSigned(@(nonce, data), deployerID, ret) = {
+      new uriCh, hashCh, verifyCh, deployerIdOps(`rho:rchain:deployerId:ops`), deployerPubKeyBytesCh in {
+        deployerIdOps!("pubKeyBytes", *deployerID, *deployerPubKeyBytesCh) |
+        for (@pubKeyBytes <- deployerPubKeyBytesCh){
+          ops!("buildUri", pubKeyBytes, *uriCh) |
+          for (@uri <- uriCh) {
+            for (@map <<- _registryStore) {
+              new responseCh in {
+                TreeHashMap!("get", map, uri, *responseCh) |
+                for (@response <- responseCh) {
+                  match response {
+                    Nil => {
+                      new ack in {
+                        TreeHashMap!("set", map, uri, (nonce, data), *ack) |
+                        for (_ <- ack) {
+                          ret!(uri)
                         }
                       }
                     }
+                    (oldNonce, _) => {
+                      if (nonce > oldNonce) {
+                        new ack in {
+                          TreeHashMap!("set", map, uri, (nonce, data), *ack) |
+                          for (_ <- ack) {
+                            ret!(uri)
+                          }
+                        }
+                      } else {
+                        ret!(Nil)
+                      }
+                    }
                   }
-                } else {
-                  ret!(Nil)
                 }
               }
             }

--- a/casper/src/main/resources/RevVault.rho
+++ b/casper/src/main/resources/RevVault.rho
@@ -23,7 +23,8 @@ new
   _create,
   _revVault,
   _transferTemplate,
-  _depositTemplate
+  _depositTemplate,
+  deployerId(`rho:rchain:deployerId`)
 in {
   rl!(`rho:rchain:makeMint`, *MakeMintCh) |
   rl!(`rho:rchain:authKey`, *AuthKeyCh) |
@@ -270,9 +271,8 @@ in {
           } |
 
           rs!(
-            "040f035630a5d2199184890b4b6b83440c842da0b6becca539f788f7b35d6e873561f673cd6ebe2e32236398a86f29dad992e8fba32534734300fcc5104bcfea0e".hexToBytes(),
             (9223372036854775807, bundle+{*RevVault}),
-            "30450221008af89d676c4cd6b3d41e90da89b03a1e83f161fc8c4ad22c9edc903db3a9f4c402204e35e29e40a5f2b2f431d3cc63b87fb52c33716b3ce331a2a19b9660c3690c18".hexToBytes(),
+            *deployerId,
             *uriOut
           )
         }

--- a/casper/src/test/resources/RegistryTest.rho
+++ b/casper/src/test/resources/RegistryTest.rho
@@ -22,6 +22,7 @@ match (
     insertSigned(`rho:registry:insertSigned:secp256k1`),
     insertArbitrary(`rho:registry:insertArbitrary`),
     sign(`rho:test:crypto:secp256k1Sign`),
+    makeDeployerID(`rho:test:deployerId:make`),
     secpVerify(`rho:crypto:secp256k1Verify`),
     blake2b256(`rho:crypto:blake2b256Hash`),
     test_secp,
@@ -40,9 +41,8 @@ match (
           ("Verifying a signature should work", *test_secp),
           ("InsertSigned and lookup should work", *test_insertSignedAndLookup),
           ("InsertArbitrary and lookup should work", *test_insertArbitraryAndLookup),
-          ("InsertArbitrary should work with increased nonce", *test_insertSignedValidNonce),
-          ("InsertArbitrary should return Nil for invalid nonce", *test_insertSignedInvalidNonce),
-          ("InsertArbitrary should return Nil for invalid signature", *test_insertSignedInvalidSig),
+          ("InsertSigned should work with increased nonce", *test_insertSignedValidNonce),
+          ("InsertSigned should return Nil for invalid nonce", *test_insertSignedInvalidNonce),
           ("Lookup should return Nil for unknown uri", *test_unknownLookup)
         ])
     } |
@@ -69,7 +69,7 @@ match (
 
     contract test_insertSignedAndLookup(rhoSpec, _, ackCh) = {
       new uriCh, valueCh in {
-        insertSignedHelper!(1, "foo", pk1, sk1, *uriCh) |
+        insertSignedHelper!(1, "foo", pk1, *uriCh) |
         for (@uri <- uriCh) {
           lookup!(uri, *valueCh) |
           rhoSpec!("assert", ((1, "foo"), "== <-", *valueCh), "Expecting a tuple with the inserted nonce and data", *ackCh)
@@ -89,9 +89,9 @@ match (
 
     contract test_insertSignedValidNonce(rhoSpec, _, ackCh) = {
       new uriCh, retCh in {
-        insertSignedHelper!(42, "foo", pk2, sk2, *uriCh) |
+        insertSignedHelper!(42, "foo", pk2, *uriCh) |
         for (@uri <- uriCh) {
-          insertSignedHelper!(43, "bar", pk2, sk2, *retCh) |
+          insertSignedHelper!(43, "bar", pk2, *retCh) |
           rhoSpec!("assert", (uri, "== <-", *retCh), "Expecting the uris to be the same", *ackCh)
         }
       }
@@ -99,18 +99,11 @@ match (
 
     contract test_insertSignedInvalidNonce(rhoSpec, _, ackCh) = {
       new uriCh, retCh in {
-        insertSignedHelper!(42, "foo", pk3, sk3, *uriCh) |
+        insertSignedHelper!(42, "foo", pk3, *uriCh) |
         for (@uri <- uriCh) {
-          insertSignedHelper!(42, "bar", pk3, sk3, *retCh) |
+          insertSignedHelper!(42, "bar", pk3, *retCh) |
           rhoSpec!("assert", (Nil, "== <-", *retCh), "Expecting Nil", *ackCh)
         }
-      }
-    } |
-
-    contract test_insertSignedInvalidSig(rhoSpec, _, ackCh) = {
-      new retCh in {
-        insertSigned!(pk3, (1, "foo"), "foo".toByteArray(), *retCh) |
-        rhoSpec!("assert", (Nil, "== <-", *retCh), "Expecting Nil", *ackCh)
       }
     } |
 
@@ -121,14 +114,11 @@ match (
       }
     } |
 
-    contract insertSignedHelper(@nonce, @data, @pk, @sk, ret) = {
-      new hashCh, signCh in {
-        blake2b256!((nonce, data).toByteArray(), *hashCh) |
-        for (@hash <- hashCh) {
-          sign!(hash, sk, *signCh) |
-          for (@sig <- signCh) {
-            insertSigned!(pk, (nonce, data), sig, *ret)
-          }
+    contract insertSignedHelper(@nonce, @data, @pubkey, ret) = {
+      new deployerCh, signCh in {
+        makeDeployerID!("deployerId", pubkey, *deployerCh) |
+        for (@deployerID <- deployerCh) {
+          insertSigned!((nonce, data), deployerID, *ret)
         }
       }
     }

--- a/casper/src/test/resources/RegistryTest.rho
+++ b/casper/src/test/resources/RegistryTest.rho
@@ -5,7 +5,9 @@ match (
   "04db580f781a3759ea92284e8734588c37e3c326049401ad8565da8e25c20287b2c6818b40ec4d8b6455a41d1939e1f1bc75417d95a73172cd4bf4cbeef45e47ab".hexToBytes(),
   "c319f6eee832ea313faf64af6d4ea325fc014d579c4a59d069ee4a1cda4c0078".hexToBytes(),
   "041b5f17da6e7d828ce3890a545725631b6807fd3893b2b984eeb863fc9861e465996d6f403ec570c377a1ea21ada77dd288191fa10d7fadb1b22b8afa637123d5".hexToBytes(),
-  "8171de2528878058f0de32644918fb98240188cdf35a70713e4a3161a6f691e5".hexToBytes()
+  "8171de2528878058f0de32644918fb98240188cdf35a70713e4a3161a6f691e5".hexToBytes(),
+  "0412eea943c13ed3e99d2de048a57dbaf4c977df83a50bf7ec79ae58255cf8d891a1cbe3cd51aeafec34241a1a9c9a54e861aa5b373667793c617c0310eab26653".hexToBytes(),
+  "87369d132ed6a7626dc4c5dfbaf41e954dd0ec55830e613a3f868c74d64a7a22".hexToBytes()
 ) {
   (
     pk1,
@@ -13,7 +15,9 @@ match (
     pk2,
     sk2,
     pk3,
-    sk3
+    sk3,
+    pk4,
+    sk4
   ) => {
 
   new
@@ -31,6 +35,7 @@ match (
     test_insertSignedValidNonce,
     test_insertSignedInvalidNonce,
     test_insertSignedInvalidSig,
+    test_insertSignedLongMaxNonce,
     test_unknownLookup,
     insertSignedHelper
   in {
@@ -43,6 +48,7 @@ match (
           ("InsertArbitrary and lookup should work", *test_insertArbitraryAndLookup),
           ("InsertSigned should work with increased nonce", *test_insertSignedValidNonce),
           ("InsertSigned should return Nil for invalid nonce", *test_insertSignedInvalidNonce),
+          ("InsertSigned with Long.Max + 1", *test_insertSignedLongMaxNonce),
           ("Lookup should return Nil for unknown uri", *test_unknownLookup)
         ])
     } |
@@ -111,6 +117,22 @@ match (
       new retCh in {
         lookup!(`rho:id:unknown`, *retCh) |
         rhoSpec!("assert", (Nil, "== <-", *retCh), "Expecting Nil", *ackCh)
+      }
+    } |
+
+    contract test_insertSignedLongMaxNonce(rhoSpec, _, ackCh) = {
+      new uriCh, retCh, valueCh in {
+        insertSignedHelper!(9223372036854775807, "foo", pk4, *uriCh) |
+        for (@uri <- uriCh) {
+          insertSignedHelper!(9223372036854775807+1, "bar", pk4, *retCh) |
+          for (@res <- retCh){
+            lookup!(uri, *valueCh) |
+            rhoSpec!("assertMany", [
+              ((Nil, "==", res), "Expecting Nil"),
+              (((9223372036854775807 , "foo"), "== <-", *valueCh), "Value foo should not be changed")
+              ], *ackCh)
+          }
+        }
       }
     } |
 

--- a/casper/src/test/resources/RhoSpecContract.rho
+++ b/casper/src/test/resources/RhoSpecContract.rho
@@ -22,7 +22,8 @@ new
   ListOpsCh,
   assert(`rho:test:assertAck`),
   testSuiteCompleted(`rho:test:testSuiteCompleted`),
-  uriOut
+  uriOut,
+  deployerId(`rho:rchain:deployerId`)
 in {
   stdlog!("debug", "Loading RhoSpec") |
   rl!(`rho:lang:listOps`, *ListOpsCh) |
@@ -149,9 +150,8 @@ in {
   } |
 
   rs!(
-    "0401f5d998c9be9b1a753771920c6e968def63fe95b20c71a163a7f7311b6131ac65a49f796b5947fa9d94b0542895e7b7ebe8b91eefcbc5c7604aaf281922ccac".hexToBytes(),
     (9223372036854775807, bundle+{*RhoSpec}),
-    "3045022100da7b26ef5f88fa5fd52f01d58a5b8d997b82fd8850a4f8a1683d0474a80203ed02205d95090a6915f45c8e4241558775831049d48b8a9d9103a0c0a3e34ede4a007c".hexToBytes(),
+    *deployerId,
     *uriOut
   )
 }

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/mainnet1/StateBalanceMain.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/mainnet1/StateBalanceMain.scala
@@ -59,7 +59,7 @@ object StateBalanceMain {
   // The way to get this Unforgeable name needs reporting casper to get all the concrete comm events.
   // Anyway, as long as RevVault.rho and genesis doesn't change, this value would be fixed.
   val genesisVaultMapPar: Par = GPrivate(
-    "5e8200d74ba8689013cf86f075775a18a42f1bd3a5ea122e82dfca9ba485a924".unsafeHexToByteString
+    "b4eaa1e833c310affa0927042fab4fca13482da0f1863253fbfd556ff54f4988".unsafeHexToByteString
   )
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))


### PR DESCRIPTION
## Overview
<!-- What this PR does, and why it's needed -->

The pr is intended to address #3669 .

After this pr the `insertSigned` would be
https://github.com/zsluedem/rchain/blob/c7d7c945afe4dd633e99f7c694b1025281c0e714/casper/src/main/resources/Either.rho#L264-L269

Previously it is like 

https://github.com/rchain/rchain/blob/ced5a7251bcb8c2f9a995c843d82b12d79845ebd/casper/src/main/resources/Either.rho#L264-L269

Currently we only need:
```
          rs!(
            (9223372036854775807, bundle+{*RevVault}),
            *deployerId,
            *uriOut
          )
```

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->

Breaking changes which people use `insertSigned` should change their codes.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
