### PR TITLE
Block message version 2 (hash & validation)

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -284,7 +284,6 @@ jobs:
           - test_finalization
           - test_genesis_ceremony
           - test_propose
-          - test_slash_invalid_block_hash
           - test_slash_invalid_block_number
           - test_slash_invalid_block_seq
           - test_slash_justification_not_correct

--- a/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockStatus.scala
@@ -26,7 +26,6 @@ object BlockStatus {
   def neglectedEquivocation: BlockError    = InvalidBlock.NeglectedEquivocation
   def invalidTransaction: BlockError       = InvalidBlock.InvalidTransaction
   def invalidBondsCache: BlockError        = InvalidBlock.InvalidBondsCache
-  def invalidBlockHash: BlockError         = InvalidBlock.InvalidBlockHash
   def containsExpiredDeploy: BlockError    = InvalidBlock.ContainsExpiredDeploy
   def containsFutureDeploy: BlockError     = InvalidBlock.ContainsFutureDeploy
   def notOfInterest: BlockError            = InvalidBlock.NotOfInterest
@@ -82,7 +81,6 @@ object InvalidBlock {
   case object NeglectedEquivocation   extends InvalidBlock
   case object InvalidTransaction      extends InvalidBlock
   case object InvalidBondsCache       extends InvalidBlock
-  case object InvalidBlockHash        extends InvalidBlock
   case object InvalidRejectedDeploy   extends InvalidBlock
   case object ContainsExpiredDeploy   extends InvalidBlock
   case object ContainsFutureDeploy    extends InvalidBlock
@@ -104,7 +102,6 @@ object InvalidBlock {
       NeglectedEquivocation,
       InvalidTransaction,
       InvalidBondsCache,
-      InvalidBlockHash,
       ContainsExpiredDeploy,
       ContainsFutureDeploy
     )

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -8,6 +8,7 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagRepresentation
 import coop.rchain.blockstorage.syntax._
+import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.{ApprovedBlock, BlockMessage, Justification}
 import coop.rchain.casper.util.ProtoUtil.bonds
 import coop.rchain.casper.util.rholang.RuntimeManager
@@ -17,7 +18,7 @@ import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.dag.DagOps
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
-import coop.rchain.models.BlockMetadata
+import coop.rchain.models.{BlockMetadata, BlockVersion}
 import coop.rchain.models.Validator.Validator
 import coop.rchain.shared.{Base16, _}
 
@@ -138,16 +139,17 @@ object Validate {
       true.pure
     }
 
-  def version[F[_]: Monad: Log](b: BlockMessage, version: Long): F[Boolean] = {
+  def version[F[_]: Monad: Log](b: BlockMessage): F[Boolean] = {
     val blockVersion = b.header.version
-    if (blockVersion == version) {
+    if (BlockVersion.Supported.contains(blockVersion)) {
       true.pure
     } else {
+      val versionsStr = BlockVersion.Supported.mkString(" or ")
       Log[F]
         .warn(
           ignore(
             b,
-            s"received block version $blockVersion is the expected version $version."
+            s"received block version $blockVersion is not the expected version $versionsStr."
           )
         )
         .as(false)
@@ -165,8 +167,6 @@ object Validate {
       expirationThreshold: Int
   ): F[ValidBlockProcessing] =
     (for {
-      _ <- EitherT.liftF(Span[F].mark("before-block-hash-validation"))
-      _ <- EitherT(Validate.blockHash(block))
       _ <- EitherT.liftF(Span[F].mark("before-timestamp-validation"))
       _ <- EitherT(Validate.timestamp(block))
       _ <- EitherT.liftF(Span[F].mark("before-repeat-deploy-validation"))
@@ -433,22 +433,18 @@ object Validate {
       } yield BlockStatus.invalidShardId.asLeft[ValidBlock]
     }
 
-  // TODO: Double check this validation isn't shadowed by the blockSignature validation
-  def blockHash[F[_]: Applicative: Log](b: BlockMessage): F[ValidBlockProcessing] = {
+  def blockHash[F[_]: Sync: Log](b: BlockMessage): F[Boolean] = Sync[F].defer {
     val blockHashComputed = ProtoUtil.hashBlock(b)
     if (b.blockHash == blockHashComputed)
-      BlockStatus.valid.asRight[BlockError].pure
+      true.pure[F]
     else {
       val computedHashString = PrettyPrinter.buildString(blockHashComputed)
       val hashString         = PrettyPrinter.buildString(b.blockHash)
-      for {
-        _ <- Log[F].warn(
-              ignore(
-                b,
-                s"block hash $hashString does not match to computed value $computedHashString."
-              )
-            )
-      } yield BlockStatus.invalidBlockHash.asLeft[ValidBlock]
+      Log[F]
+        .warn(
+          ignore(b, s"block hash $hashString does not match to computed value $computedHashString.")
+        )
+        .as(false)
     }
   }
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/Initializing.scala
@@ -221,7 +221,7 @@ class Initializing[F[_]
       // TODO: validate genesis (zero) block correctly
       true.pure
     } else
-      Validate.blockHash(block).map(_ == Right(Valid))
+      Validate.blockHash(block)
   }
 
   private def populateDag(

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -10,6 +10,7 @@ import coop.rchain.casper.util.Sorting.byteArrayOrdering
 import coop.rchain.casper.util.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.rholang.RuntimeManager
 import coop.rchain.crypto.signatures.Signed
+import coop.rchain.models.BlockVersion
 
 final case class Genesis(
     shardId: String,
@@ -100,8 +101,7 @@ object Genesis {
       rejectedDeploys = List.empty,
       systemDeploys = List.empty
     )
-    val version = 1L //FIXME make this part of Genesis, and pass it from upstream
-    val header  = blockHeader(body, List.empty[StateHash], version, timestamp)
+    val header = blockHeader(body, List.empty[StateHash], BlockVersion.Current, timestamp)
 
     unsignedBlockProto(body, header, List.empty[Justification], shardId)
   }

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -491,21 +491,22 @@ class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspecto
   it should "succeed at slashing" in effectTest {
     TestNode.networkEff(genesis, networkSize = 3).use { nodes =>
       for {
-        deployData   <- ConstructDeploy.basicDeployData[Effect](0)
-        signedBlock  <- nodes(0).casperEff.deploy(deployData) >> nodes(0).createBlockUnsafe()
-        invalidBlock = signedBlock.copy(seqNum = 47)
-        status1      <- nodes(1).processBlock(invalidBlock)
-        status2      <- nodes(2).processBlock(invalidBlock)
-        signedBlock2 <- nodes(1).createBlockUnsafe()
-        status3      <- nodes(1).processBlock(signedBlock2)
-        bonds        <- nodes(1).runtimeManager.computeBonds(ProtoUtil.postStateHash(signedBlock2))
-        _            = bonds.map(_.stake).min should be(0) // Slashed validator has 0 stake
-        _            <- nodes(2).handleReceive()
-        signedBlock3 <- nodes(2).createBlockUnsafe()
-        status4      <- nodes(2).processBlock(signedBlock3)
+        deployData    <- ConstructDeploy.basicDeployData[Effect](0)
+        signedBlock   <- nodes(0).casperEff.deploy(deployData) >> nodes(0).createBlockUnsafe()
+        modifiedBlock = signedBlock.copy(seqNum = 47)
+        invalidBlock  = nodes(0).validatorId.get.signBlock(modifiedBlock)
+        status1       <- nodes(1).processBlock(invalidBlock)
+        status2       <- nodes(2).processBlock(invalidBlock)
+        signedBlock2  <- nodes(1).createBlockUnsafe()
+        status3       <- nodes(1).processBlock(signedBlock2)
+        bonds         <- nodes(1).runtimeManager.computeBonds(ProtoUtil.postStateHash(signedBlock2))
+        _             = bonds.map(_.stake).min should be(0) // Slashed validator has 0 stake
+        _             <- nodes(2).handleReceive()
+        signedBlock3  <- nodes(2).createBlockUnsafe()
+        status4       <- nodes(2).processBlock(signedBlock3)
       } yield {
-        status1 should be(Left(InvalidBlockHash))
-        status2 should be(Left(InvalidBlockHash))
+        status1 should be(Left(InvalidSequenceNumber))
+        status2 should be(Left(InvalidSequenceNumber))
         status3 should be(Right(Valid))
         status4 should be(Right(Valid))
         // TODO: assert no effect as already slashed

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -1,11 +1,14 @@
 package coop.rchain.casper.batch2
 
-import cats.Monad
+import cats.{Id, Monad}
+import cats.conversions.all.autoWidenBifunctor
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.dag.{BlockDagRepresentation, IndexedBlockDagStorage}
 import coop.rchain.blockstorage.syntax._
+import coop.rchain.casper._
+import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{
@@ -18,20 +21,22 @@ import coop.rchain.casper.util.GenesisBuilder.buildGenesis
 import coop.rchain.casper.util._
 import coop.rchain.casper.util.rholang.Resources.mkTestRNodeStoreManager
 import coop.rchain.casper.util.rholang.{InterpreterUtil, RuntimeManager}
-import coop.rchain.casper._
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
 import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.BlockVersion
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.blockImplicits._
+import coop.rchain.models.syntax._
 import coop.rchain.p2p.EffectsTestInstances.LogStub
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
-import coop.rchain.models.syntax._
-import coop.rchain.shared.{Base16, Time}
+import coop.rchain.shared.Time
 import coop.rchain.shared.scalatestcontrib._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
+import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest._
+import org.scalatest.prop.PropertyChecks
 
 import java.nio.file.Files
 import scala.collection.immutable.HashMap
@@ -42,7 +47,8 @@ class ValidateTest
     with BeforeAndAfterEach
     with BlockGenerator
     with BlockDagStorageFixture
-    with UnlimitedParentsEstimatorFixture {
+    with UnlimitedParentsEstimatorFixture
+    with PropertyChecks {
   import InvalidBlock._
   import ValidBlock._
 
@@ -804,40 +810,41 @@ class ValidateTest
       } yield ()
   }
 
-  "Block hash format validation" should "fail on invalid hash" in withStorage {
-    _ => implicit blockDagStorage =>
-      val context  = buildGenesis()
-      val (sk, pk) = context.validatorKeyPairs.head
-      val sender   = ByteString.copyFrom(pk.bytes)
-      for {
-        _                <- blockDagStorage.insert(genesis, false, approved = true)
-        dag              <- blockDagStorage.getRepresentation
-        latestMessageOpt <- dag.latestMessage(sender)
-        seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
-        genesis = ValidatorIdentity(sk)
-          .signBlock(context.genesisBlock.copy(seqNum = seqNum))
-        _ <- Validate.blockHash[Task](genesis) shouldBeF Right(Valid)
-        result <- Validate.blockHash[Task](
-                   genesis.copy(blockHash = ByteString.copyFromUtf8("123"))
-                 ) shouldBeF Left(InvalidBlockHash)
-      } yield result
+  "Block hash format validation" should "fail on invalid hash" in {
+    implicit val aBlock = arbBlockMessage
+
+    forAll { (block: BlockMessage) =>
+      val hash           = ProtoUtil.hashBlock(block)
+      val blockValidHash = block.copy(blockHash = hash)
+
+      // Test valid block hash
+      val hashValid = Validate.blockHash[Task](blockValidHash).runSyncUnsafe()
+
+      hashValid shouldBe true
+
+      val blockInValidHash = block.copy(blockHash = ByteString.copyFromUtf8("123"))
+
+      // Test invalid block hash
+      val hashInValid = Validate.blockHash[Task](blockInValidHash).runSyncUnsafe()
+
+      hashInValid shouldBe false
+    }
   }
 
-  "Block version validation" should "work" in withStorage { _ => implicit blockDagStorage =>
-    val context  = buildGenesis()
-    val (sk, pk) = context.validatorKeyPairs.head
-    val sender   = ByteString.copyFrom(pk.bytes)
-    for {
-      _                <- blockDagStorage.insert(genesis, false, approved = true)
-      dag              <- blockDagStorage.getRepresentation
-      latestMessageOpt <- dag.latestMessage(sender)
-      seqNum           = latestMessageOpt.fold(0)(_.seqNum) + 1
-      genesis = ValidatorIdentity(sk).signBlock(
-        context.genesisBlock.copy(seqNum = seqNum)
-      )
-      _      <- Validate.version[Task](genesis, -1) shouldBeF false
-      result <- Validate.version[Task](genesis, 1) shouldBeF true
-    } yield result
+  "Block version validation" should "allow supported versions" in {
+    implicit val aBlock = arbBlockMessage
+
+    forAll { (block: BlockMessage, version: Long) =>
+      val header           = block.header.copy(version = version)
+      val blockWithVersion = block.copy(header = header)
+
+      // Expected one of hard-coded block versions supported by this version of RNode software
+      val expectedValid = BlockVersion.Supported.contains(version)
+      // Actual validation
+      val actualValid = Validate.version[Task](blockWithVersion).runSyncUnsafe()
+
+      actualValid shouldBe expectedValid
+    }
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockHashSignatureSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockHashSignatureSpec.scala
@@ -2,25 +2,74 @@ package coop.rchain.casper.util
 
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.{BlockMessage, Justification}
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
 import coop.rchain.models.blockImplicits._
+import org.scalacheck.Prop.{forAll, AnyOperators}
+import org.scalatest.FlatSpec
+import org.scalatest.prop.Checkers.check
 
-class BlockHashSignatureSpec extends FlatSpec with Matchers with PropertyChecks {
+class BlockHashSignatureSpec extends FlatSpec {
 
-  implicit val aBlock     = arbBlockMessage
-  implicit val aValidator = arbitraryValidator
+  implicit val aBlock = arbBlockMessage
 
-  "block hash" should "be created from all fields except signature" in {
-    forAll { (block: BlockMessage, bytes: ByteString) =>
-      val hash = ProtoUtil.hashBlock(block)
-      val blockModifiedJustifications = block.copy(
-        justifications = List(Justification(bytes, bytes))
-      )
-      val hashModified = ProtoUtil.hashBlock(blockModifiedJustifications)
+  "block hash" should "not match for changed block hash" in {
+    implicit val aBlockHash = arbitraryBlockHash
+    check {
+      forAll { (block: BlockMessage, genBlockHash: ByteString) =>
+        val isModified    = genBlockHash != block.blockHash
+        val hash          = block.blockHash
+        val blockModified = block.copy(blockHash = genBlockHash)
+        val hashModified  = ProtoUtil.hashBlock(blockModified)
 
-      hashModified shouldBe hash
+        // Check hashes are different for modified block
+        hashModified !== hash ?= isModified
+      }
     }
   }
 
+  "block hash" should "not match for changed sequence number" in {
+    check {
+      forAll { (block: BlockMessage, genSeqNum: Int) =>
+        val isModified    = genSeqNum != block.seqNum
+        val hash          = ProtoUtil.hashBlock(block)
+        val blockModified = block.copy(seqNum = genSeqNum)
+        val hashModified  = ProtoUtil.hashBlock(blockModified)
+
+        // Check hashes are different for modified block
+        hashModified !== hash ?= isModified
+      }
+    }
+  }
+
+  "block hash" should "not match for changed block number" in {
+    check {
+      forAll { (block: BlockMessage, genBlockNumber: Long) =>
+        val isModified = genBlockNumber != block.body.state.blockNumber
+        val hash       = ProtoUtil.hashBlock(block)
+        val blockModified = block.copy(
+          body = block.body.copy(state = block.body.state.copy(blockNumber = genBlockNumber))
+        )
+        val hashModified = ProtoUtil.hashBlock(blockModified)
+
+        // Check hashes are different for modified block
+        hashModified !== hash ?= isModified
+      }
+    }
+  }
+
+  "block hash" should "not match for changed justifications" in {
+    implicit val aJustification = arbitraryJustification
+    check {
+      forAll { (block: BlockMessage, genJustifications: List[Justification]) =>
+        val isModified    = genJustifications != block.justifications
+        val hash          = ProtoUtil.hashBlock(block)
+        val blockModified = block.copy(justifications = genJustifications)
+        val hashModified  = ProtoUtil.hashBlock(blockModified)
+
+        // Check hashes are different for modified block
+        hashModified !== hash ?= isModified
+      }
+    }
+  }
+
+  // TODO: add more tests when BlockMessage changes from BM branch are merged
 }

--- a/casper/src/test/scala/coop/rchain/casper/util/BlockHashSignatureSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/BlockHashSignatureSpec.scala
@@ -1,0 +1,26 @@
+package coop.rchain.casper.util
+
+import com.google.protobuf.ByteString
+import coop.rchain.casper.protocol.{BlockMessage, Justification}
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+import coop.rchain.models.blockImplicits._
+
+class BlockHashSignatureSpec extends FlatSpec with Matchers with PropertyChecks {
+
+  implicit val aBlock     = arbBlockMessage
+  implicit val aValidator = arbitraryValidator
+
+  "block hash" should "be created from all fields except signature" in {
+    forAll { (block: BlockMessage, bytes: ByteString) =>
+      val hash = ProtoUtil.hashBlock(block)
+      val blockModifiedJustifications = block.copy(
+        justifications = List(Justification(bytes, bytes))
+      )
+      val hashModified = ProtoUtil.hashBlock(blockModifiedJustifications)
+
+      hashModified shouldBe hash
+    }
+  }
+
+}

--- a/integration-tests/test/test_slash.py
+++ b/integration-tests/test/test_slash.py
@@ -377,10 +377,10 @@ def test_slash_GHOST_disobeyed(command_line_options: CommandLineOptions, random_
 @pytest.mark.skipif(sys.platform in ('win32', 'cygwin', 'darwin'), reason="Only Linux docker support connection between host and container which node client needs")
 def test_node_working_right_after_slashing(command_line_options: CommandLineOptions, random_generator: Random, docker_client: DockerClient) -> None:
     """
-    Slash a validator which proposes an invalid block contains invalid block hash
+    Slash a validator which proposes an invalid block contains invalid block number
 
     1. v1 proposes a valid block b1
-    2. v1 proposes an invalid block b2 with invalid block hash and send it to v2
+    2. v1 proposes an invalid block b2 with invalid block number and send it to v2
     3. v2 records b2 as invalid block (InvalidBlockHash)
     4. v2 proposes a new block which slashes v1
     5. v2 should propose normally
@@ -396,15 +396,16 @@ def test_node_working_right_after_slashing(command_line_options: CommandLineOpti
         block_info = validator1.get_block(blockhash)
 
         block_msg = client.block_request(block_info.blockInfo.blockHash, validator1)
-        evil_block_hash = generate_block_hash()
 
+        # Modify block number to make invalid block
+        block_msg.body.state.blockNumber = 1000  # pylint: disable=maybe-no-member
+        evil_block_hash = gen_block_hash_from_block(block_msg)
         block_msg.blockHash = evil_block_hash
         block_msg.sig = BONDED_VALIDATOR_KEY_1.sign_block_hash(evil_block_hash)
-        block_msg.header.timestamp = int(time.time()*1000)
 
         client.send_block(block_msg, validator2)
 
-        record_invalid = re.compile("Recording invalid block {}... for InvalidBlockHash".format(evil_block_hash.hex()[:10]))
+        record_invalid = re.compile("Recording invalid block {}... for InvalidBlockNumber".format(evil_block_hash.hex()[:10]))
         wait_for_log_match(context, validator2, record_invalid)
 
         validator2.deploy(contract, BONDED_VALIDATOR_KEY_2)

--- a/models/src/main/scala/coop/rchain/models/BlockVersion.scala
+++ b/models/src/main/scala/coop/rchain/models/BlockVersion.scala
@@ -1,0 +1,16 @@
+package coop.rchain.models
+
+object BlockVersion {
+
+  /**
+    * Current block version
+    */
+  val Current = 2L
+
+  /**
+    * All supported block versions by this version of RNode software.
+    *  - previous versions are supported in transition period from previous to current version
+    *  - version 1 is still supported to validate previous blocks correctly
+    */
+  val Supported = List(Current, 1L)
+}

--- a/models/src/test/scala/coop/rchain/models/blockImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/blockImplicits.scala
@@ -189,6 +189,8 @@ object blockImplicits {
       ret = block.copy(blockHash = blockHash)
     } yield ret
 
+  val arbBlockMessage = Arbitrary(blockElementGen())
+
   def blockElementsWithParentsGen(genesis: BlockMessage): Gen[List[BlockMessage]] =
     Gen.sized { size =>
       (0 until size).foldLeft(Gen.listOfN(0, blockElementGen())) {

--- a/models/src/test/scala/coop/rchain/models/blockImplicits.scala
+++ b/models/src/test/scala/coop/rchain/models/blockImplicits.scala
@@ -156,7 +156,7 @@ object blockImplicits {
                       Random.shuffle(bonds).headOption.getOrElse(bondGen.sample.get).validator
                     )
                   else Gen.const(setValidator.get)
-      version   = if (setVersion.isEmpty) 1L else setVersion.get
+      version   = if (setVersion.isEmpty) BlockVersion.Current else setVersion.get
       timestamp <- if (setTimestamp.isEmpty) arbitrary[Long] else Gen.const(setTimestamp.get)
       shardId   = if (setShardId.isEmpty) "root" else setShardId.get
       block = BlockMessage(

--- a/node/src/main/scala/coop/rchain/node/instances/BlockProcessorInstance.scala
+++ b/node/src/main/scala/coop/rchain/node/instances/BlockProcessorInstance.scala
@@ -31,7 +31,7 @@ object BlockProcessorInstance {
           val (c, b)                             = i
           val blockStr                           = PrettyPrinter.buildString(b, short = true)
           val logNotOfInterest                   = Log[F].info(s"Block $blockStr is not of interest. Dropped")
-          val logMalformed                       = Log[F].info(s"Block $blockStr is not of malformed. Dropped")
+          val logMalformed                       = Log[F].info(s"Block $blockStr is malformed. Dropped")
           val logMissingDeps                     = Log[F].info(s"Block $blockStr missing dependencies.")
           val logStarted                         = Log[F].info(s"Block $blockStr processing started.")
           def logResult(r: ValidBlockProcessing) = Log[F].info(s"Block $blockStr validated: ${r}")


### PR DESCRIPTION
## Overview

This PR fixes the major bug in block hashing function. To support compatibility to replay previous blocks, block version field is used mark _version 1_ with existing hashing and _version 2_ with the fix.

Details about the bug are specified in the linked issue.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
