### PR TITLE
Rename event log merging logic

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
@@ -9,7 +9,7 @@ import coop.rchain.casper.util.EventConverter
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.HistoryRepository
-import coop.rchain.rspace.merger.MergingLogic.{computeRelatedSets, NumberChannelsDiff}
+import coop.rchain.rspace.merger.EventLogMergingLogic.{computeRelatedSets, NumberChannelsDiff}
 import coop.rchain.rspace.merger._
 import coop.rchain.rspace.trace.Produce
 
@@ -115,7 +115,7 @@ object BlockIndex {
         * Therefore there won't be any conflicts between event logs. But there can be dependencies. */
       deployChains = computeRelatedSets[DeployIndex](
         deployIndices.toSet,
-        (l, r) => MergingLogic.depends(l.eventLogIndex, r.eventLogIndex)
+        (l, r) => EventLogMergingLogic.depends(l.eventLogIndex, r.eventLogIndex)
       )
       index <- deployChains.toVector
                 .traverse(

--- a/casper/src/main/scala/coop/rchain/casper/merging/ConflictSetMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/ConflictSetMerger.scala
@@ -6,7 +6,7 @@ import coop.rchain.models.ListParWithRandom
 import coop.rchain.rspace.HotStoreTrieAction
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.HistoryReaderBinary
-import coop.rchain.rspace.merger.MergingLogic._
+import coop.rchain.rspace.merger.EventLogMergingLogic._
 import coop.rchain.rspace.merger.StateChange._
 import coop.rchain.rspace.merger._
 import coop.rchain.rspace.serializers.ScodecSerialize.DatumB

--- a/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DagMerger.scala
@@ -10,8 +10,13 @@ import coop.rchain.rholang.interpreter.RhoRuntime.RhoHistoryRepository
 import coop.rchain.rholang.interpreter.merging.RholangMergingLogic
 import coop.rchain.rspace.HotStoreTrieAction
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.merger.MergingLogic.NumberChannelsDiff
-import coop.rchain.rspace.merger.{ChannelChange, MergingLogic, StateChange, StateChangeMerger}
+import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsDiff
+import coop.rchain.rspace.merger.{
+  ChannelChange,
+  EventLogMergingLogic,
+  StateChange,
+  StateChangeMerger
+}
 import coop.rchain.rspace.syntax._
 import coop.rchain.shared.Log
 import scodec.bits.ByteVector
@@ -43,7 +48,7 @@ object DagMerger {
 
       branchesAreConflicting = (as: Set[DeployChainIndex], bs: Set[DeployChainIndex]) =>
         (as.flatMap(_.deploysWithCost.map(_.id)) intersect bs.flatMap(_.deploysWithCost.map(_.id))).nonEmpty ||
-          MergingLogic.areConflicting(
+          EventLogMergingLogic.areConflicting(
             as.map(_.eventLogIndex).toList.combineAll,
             bs.map(_.eventLogIndex).toList.combineAll
           )
@@ -72,8 +77,8 @@ object DagMerger {
       r <- ConflictSetMerger.merge[F, DeployChainIndex](
             actualSet = actualSet,
             lateSet = lateSet,
-            depends =
-              (target, source) => MergingLogic.depends(target.eventLogIndex, source.eventLogIndex),
+            depends = (target, source) =>
+              EventLogMergingLogic.depends(target.eventLogIndex, source.eventLogIndex),
             conflicts = branchesAreConflicting,
             cost = rejectionCostF,
             stateChanges = _.stateChanges.pure,

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeManagerSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeManagerSyntax.scala
@@ -13,7 +13,7 @@ import coop.rchain.rholang.interpreter.merging.RholangMergingLogic.{
   NumberChannel
 }
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.merger.MergingLogic.{NumberChannelsDiff, NumberChannelsEndVal}
+import coop.rchain.rspace.merger.EventLogMergingLogic.{NumberChannelsDiff, NumberChannelsEndVal}
 import coop.rchain.shared.AttemptOpsF.RichAttempt
 import coop.rchain.shared.syntax._
 import scodec.bits.ByteVector

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeReplaySyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeReplaySyntax.scala
@@ -38,7 +38,7 @@ import coop.rchain.models.syntax._
 import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
 import coop.rchain.rholang.interpreter.{EvaluateResult, ReplayRhoRuntime}
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.merger.MergingLogic.NumberChannelsEndVal
+import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsEndVal
 import coop.rchain.rspace.util.ReplayException
 import coop.rchain.shared.Log
 

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
@@ -50,7 +50,7 @@ import coop.rchain.rholang.interpreter.merging.RholangMergingLogic
 import coop.rchain.rholang.interpreter.{storage, EvaluateResult, RhoRuntime}
 import coop.rchain.rspace.hashing.{Blake2b256Hash, StableHashProvider}
 import coop.rchain.rspace.history.History.emptyRootHash
-import coop.rchain.rspace.merger.MergingLogic.NumberChannelsEndVal
+import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsEndVal
 import coop.rchain.shared.{Base16, Log}
 
 trait RuntimeSyntax {

--- a/casper/src/main/scala/coop/rchain/casper/rholang/types/SystemDeployResult.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/types/SystemDeployResult.scala
@@ -2,7 +2,7 @@ package coop.rchain.casper.rholang.types
 
 import coop.rchain.casper.protocol.{Event, ProcessedSystemDeploy, SystemDeployData}
 import coop.rchain.casper.rholang.RuntimeManager.StateHash
-import coop.rchain.rspace.merger.MergingLogic.NumberChannelsEndVal
+import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsEndVal
 
 sealed trait SystemDeployResult[A]
 

--- a/casper/src/slowcooker/scala/coop.rchain.casper/MergingBenchmarkSpec.scala
+++ b/casper/src/slowcooker/scala/coop.rchain.casper/MergingBenchmarkSpec.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper
 
 import coop.rchain.casper.merging.DeployChainIndex
-import coop.rchain.rspace.merger.MergingLogic.computeRejectionOptions
+import coop.rchain.rspace.merger.EventLogMergingLogic.computeRejectionOptions
 import coop.rchain.shared.Stopwatch
 import org.scalatest.FlatSpec
 

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
@@ -11,8 +11,8 @@ import coop.rchain.models.Validator.Validator
 import coop.rchain.models.syntax.modelsSyntaxByteString
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
-import coop.rchain.rspace.merger.MergingLogic.computeRelatedSets
-import coop.rchain.rspace.merger.{EventLogIndex, MergingLogic}
+import coop.rchain.rspace.merger.EventLogMergingLogic.computeRelatedSets
+import coop.rchain.rspace.merger.{EventLogIndex, EventLogMergingLogic}
 import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.shared.{Log, Time}
 import monix.eval.Task
@@ -87,12 +87,12 @@ class MergingCases extends FlatSpec with Matchers {
                        mergeChs
                      )
                  }
-          firstDepends  = MergingLogic.depends(idxs.head, idxs(1))
-          secondDepends = MergingLogic.depends(idxs(1), idxs.head)
-          conflicts     = MergingLogic.areConflicting(idxs.head, idxs(1))
+          firstDepends  = EventLogMergingLogic.depends(idxs.head, idxs(1))
+          secondDepends = EventLogMergingLogic.depends(idxs(1), idxs.head)
+          conflicts     = EventLogMergingLogic.areConflicting(idxs.head, idxs(1))
           deployChains = computeRelatedSets[EventLogIndex](
             idxs.toSet,
-            MergingLogic.depends
+            EventLogMergingLogic.depends
           )
           // deploys inside one state transition never conflict, as executed in a sequence (for now)
           _ = conflicts shouldBe false

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/EventLogIndex.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/EventLogIndex.scala
@@ -4,7 +4,10 @@ import cats.effect.Concurrent
 import cats.effect.concurrent.Ref
 import cats.kernel.Monoid
 import cats.syntax.all._
-import coop.rchain.rspace.merger.MergingLogic.{combineProducesCopiedByPeek, NumberChannelsDiff}
+import coop.rchain.rspace.merger.EventLogMergingLogic.{
+  combineProducesCopiedByPeek,
+  NumberChannelsDiff
+}
 import coop.rchain.rspace.trace.{COMM, Consume, Event, Produce}
 import coop.rchain.shared.syntax._
 

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/EventLogMergingLogic.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/EventLogMergingLogic.scala
@@ -7,7 +7,8 @@ import fs2.Stream
 import scala.Function.tupled
 import scala.annotation.tailrec
 
-object MergingLogic {
+/** Logic for merging event logs. */
+object EventLogMergingLogic {
 
   /**
     * Map used to represent mergeable (numeric) channels with intermediate values

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/StateChange.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/StateChange.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 import coop.rchain.rspace.hashing.{Blake2b256Hash, StableHashProvider}
 import coop.rchain.rspace.history.{ColdStoreInstances, DataLeaf, HistoryReaderBinary}
 import coop.rchain.rspace.internal.Datum
-import coop.rchain.rspace.merger.MergingLogic._
+import coop.rchain.rspace.merger.EventLogMergingLogic._
 import coop.rchain.rspace.serializers.ScodecSerialize
 import coop.rchain.rspace.serializers.ScodecSerialize.{serializeToCodecDatumMemo, RichAttempt}
 import coop.rchain.rspace.trace.Produce

--- a/rspace/src/main/scala/coop/rchain/rspace/merger/StateChangeMerger.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/merger/StateChangeMerger.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 import coop.rchain.rspace._
 import coop.rchain.rspace.hashing.{Blake2b256Hash, StableHashProvider}
 import coop.rchain.rspace.history.HistoryReaderBinary
-import coop.rchain.rspace.merger.MergingLogic.NumberChannelsDiff
+import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsDiff
 import scodec.bits.ByteVector
 
 object StateChangeMerger {

--- a/rspace/src/test/scala/coop/rchain/rspace/merging/EventsMergingLogicSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/merging/EventsMergingLogicSpec.scala
@@ -1,10 +1,10 @@
 package coop.rchain.rspace.merging
 
-import coop.rchain.rspace.merger.MergingLogic._
+import coop.rchain.rspace.merger.EventLogMergingLogic._
 import coop.rchain.shared.Stopwatch
 import org.scalatest.{FlatSpec, Matchers}
 
-class MergingLogicSpec extends FlatSpec with Matchers {
+class EventsMergingLogicSpec extends FlatSpec with Matchers {
   // some random conflict maps and rejection options, computed manually
   "rejection options" should "be computed correctly" in {
     computeRejectionOptions(


### PR DESCRIPTION
## Overview
This PR just renames MergingLogic class to EventLogMergingLogic, as this is what it is.
There will be another MergingLogic n the block level


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
