### PR TITLE
Add pos-vault-pub-key parameter in genesis config

### DIFF
--- a/casper/src/main/resources/Pos.rhox
+++ b/casper/src/main/resources/Pos.rhox
@@ -7,6 +7,7 @@
 // numberOfActiveValidators - max number of active validator in a shard
 // posMultiSigPublicKeys - public keys
 // posMultiSigQuorum - how many confirmations are necessary to use multi-sig vault
+// posVaultPubKey - public key for transfers from the PoS vault
 /*
 
 Life cycle in POS
@@ -147,7 +148,7 @@ in {
                         }
                       }
                     } else {
-                      transferRet!((false, "You have not permission to transfer."))
+                      transferRet!((false, "You have not permission to transfer"))
                     }
                   }
                 }
@@ -157,7 +158,7 @@ in {
           }
         }
       } |
-      createUnfVault!(*posVaultCh, "$$posPubKey$$") |
+      createUnfVault!(*posVaultCh, "$$posVaultPubKey$$") |
       for (@(posVaultUnf, posVaultAddr, posVault, humanControlHandle) <- posVaultCh){
         for (@posDeployerRevAddress <- posDeployerRevAddressCh;
             @posDeployerAuthKey    <- posDeployerAuthKeyCh)  {

--- a/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
+++ b/casper/src/main/scala/coop/rchain/casper/CasperConf.scala
@@ -34,5 +34,6 @@ final case class GenesisBlockData(
     genesisBlockNumber: Long,
     numberOfActiveValidators: Int,
     posMultiSigPublicKeys: List[String],
-    posMultiSigQuorum: Int
+    posMultiSigQuorum: Int,
+    posVaultPubKey: String
 )

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeLaunch.scala
@@ -55,6 +55,11 @@ object NodeLaunch {
 
     def createStoreBroadcastGenesis: F[Unit] =
       for {
+        _ <- Log[F]
+              .warn(
+                "Public key for PoS vault is not set, manual transfer from PoS vault will be disabled (config 'pos-vault-pub-key')"
+              )
+              .whenA(conf.genesisBlockData.posVaultPubKey.isEmpty)
         genesisBlock <- createGenesisBlockFromConfig(conf)
         genBlockStr  = PrettyPrinter.buildString(genesisBlock)
         _            <- Log[F].info(s"Sending ApprovedBlock $genBlockStr to peers...")
@@ -181,7 +186,8 @@ object NodeLaunch {
       conf.genesisBlockData.quarantineLength,
       conf.genesisBlockData.numberOfActiveValidators,
       conf.genesisBlockData.posMultiSigPublicKeys,
-      conf.genesisBlockData.posMultiSigQuorum
+      conf.genesisBlockData.posMultiSigQuorum,
+      conf.genesisBlockData.posVaultPubKey
     )
 
   def createGenesisBlock[F[_]: Concurrent: ContextShift: Time: RuntimeManager: Log](
@@ -196,7 +202,8 @@ object NodeLaunch {
       quarantineLength: Int,
       numberOfActiveValidators: Int,
       posMultiSigPublicKeys: List[String],
-      posMultiSigQuorum: Int
+      posMultiSigQuorum: Int,
+      posVaultPubKey: String
   ): F[BlockMessage] =
     for {
       blockTimestamp <- Time[F].currentMillis
@@ -221,7 +228,8 @@ object NodeLaunch {
                            numberOfActiveValidators = numberOfActiveValidators,
                            validators = validators,
                            posMultiSigPublicKeys = posMultiSigPublicKeys,
-                           posMultiSigQuorum = posMultiSigQuorum
+                           posMultiSigQuorum = posMultiSigQuorum,
+                           posVaultPubKey = posVaultPubKey
                          ),
                          vaults = vaults,
                          blockNumber = blockNumber

--- a/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/contracts/ProofOfStake.scala
@@ -15,7 +15,8 @@ final case class ProofOfStake(
     quarantineLength: Int,
     numberOfActiveValidators: Int,
     posMultiSigPublicKeys: List[String],
-    posMultiSigQuorum: Int
+    posMultiSigQuorum: Int,
+    posVaultPubKey: String
 ) extends CompiledRholangTemplate(
       "Pos.rhox",
       NormalizerEnv.Empty,
@@ -26,7 +27,8 @@ final case class ProofOfStake(
       "quarantineLength"         -> quarantineLength,
       "numberOfActiveValidators" -> numberOfActiveValidators,
       "posMultiSigPublicKeys"    -> ProofOfStake.publicKeys(posMultiSigPublicKeys),
-      "posMultiSigQuorum"        -> posMultiSigQuorum
+      "posMultiSigQuorum"        -> posMultiSigQuorum,
+      "posVaultPubKey"           -> posVaultPubKey
     ) {
 
   require(minimumBond <= maximumBond)

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -301,7 +301,8 @@ object GenesisTest {
                            numberOfActiveValidators = numberOfActiveValidators,
                            validators = validators,
                            posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
-                           posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1
+                           posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1,
+                           posVaultPubKey = GenesisBuilder.defaultPosVaultPubKey
                          ),
                          vaults = vaults,
                          blockNumber = blockNumber,

--- a/casper/src/test/scala/coop/rchain/casper/genesis/PosMultiSigTransferSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/PosMultiSigTransferSpec.scala
@@ -33,6 +33,12 @@ class PosMultiSigTransferSpec extends AnyFlatSpec with Matchers with Inspectors 
     PrivateKey("87369d132ed6a7626dc4c5dfbaf41e954dd0ec55830e613a3f868c74d64a7a22".unsafeDecodeHex)
   val pub3          = Secp256k1.toPublic(p3)
   val validatorKeys = Seq((p1, pub1), (p2, pub2), (p3, pub3))
+
+  val pk1 = PrivateKey(
+    "1533219a4bea67e7b852101c8fb8e836e5812dd15f931d8d40a99eec9393ef22".unsafeDecodeHex
+  )
+
+  val genesisPubKey = Secp256k1.toPublic(pk1)
   val bonds         = Map(pub1 -> 1000000L, pub2 -> 1000000L, pub3 -> 1000000L)
 
   val genesisParam: GenesisParameters =
@@ -50,6 +56,7 @@ class PosMultiSigTransferSpec extends AnyFlatSpec with Matchers with Inspectors 
           numberOfActiveValidators = 100,
           validators = bonds.map(Validator.tupled).toSeq,
           posMultiSigPublicKeys = Seq(pub1, pub2, pub3).map(p => p.bytes.toHexString).toList,
+          posVaultPubKey = genesisPubKey.bytes.toHexString,
           posMultiSigQuorum = 2
         ),
         vaults = List((pub1, 100000000000L), (pub2, 100000000000L), (pub3, 100000000000L)).map {

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -62,6 +62,9 @@ object GenesisBuilder {
     "047f0f0f5bbe1d6d1a8dac4d88a3957851940f39a57cd89d55fe25b536ab67e6d76fd3f365c83e5bfe11fe7117e549b1ae3dd39bfc867d1c725a4177692c4e7754"
   )
 
+  val defaultPosVaultPubKey =
+    "0432946f7f91f8f767d7c3d43674faf83586dffbd1b8f9278a5c72820dc20308836299f47575ff27f4a736b72e63d91c3cd853641861f64e08ee5f9204fc708df6"
+
   def buildGenesisParameters(
       validatorKeyPairs: Iterable[(PrivateKey, PublicKey)],
       genesisVaults: Seq[(PrivateKey, Long)],
@@ -84,7 +87,8 @@ object GenesisBuilder {
           numberOfActiveValidators = 100,
           validators = bonds.map(Validator.tupled).toSeq,
           posMultiSigPublicKeys = defaultPosMultiSigPublicKeys,
-          posMultiSigQuorum = defaultPosMultiSigPublicKeys.length - 1
+          posMultiSigQuorum = defaultPosMultiSigPublicKeys.length - 1,
+          posVaultPubKey = defaultPosVaultPubKey
         ),
         vaults = genesisVaults.toList.map {
           case (p, s) => Vault(RevAddress.fromPublicKey(Secp256k1.toPublic(p)).get, s)
@@ -116,7 +120,8 @@ object GenesisBuilder {
           numberOfActiveValidators = 100,
           validators = bonds.map(Validator.tupled).toSeq,
           posMultiSigPublicKeys = defaultPosMultiSigPublicKeys,
-          posMultiSigQuorum = defaultPosMultiSigPublicKeys.length - 1
+          posMultiSigQuorum = defaultPosMultiSigPublicKeys.length - 1,
+          posVaultPubKey = defaultPosVaultPubKey
         ),
         vaults = genesisVaults.toList.map(pair => predefinedVault(pair._2)) ++
           bonds.toList.map {

--- a/integration-tests/resources/wallets/transfer_from_pos_vault.rho
+++ b/integration-tests/resources/wallets/transfer_from_pos_vault.rho
@@ -1,0 +1,25 @@
+new 
+   return, rl(`rho:registry:lookup`), poSCh, stdout(`rho:io:stdout`), 
+     deployerId(`rho:rchain:deployerId`), transferRetCh 
+in {
+   rl!(`rho:rchain:pos`, *poSCh) |
+   stdout!(("start rholang code")) |
+   match (
+    "%TARGET_ADDR",
+    %AMOUNT
+   ) {
+       (targetAddr, amount) => {
+         stdout!(("start contract")) |
+         for(@(_, PoS) <- poSCh) {
+           @PoS!("posVaultTransfer", targetAddr, amount, *deployerId, *transferRetCh) |
+           stdout!(("contract executed")) | 
+           for (@result <- transferRetCh){
+             match result{
+               (true, _) =>{stdout!("%LOG_MARKER Successfully reason: ${reason}" %%{"reason": "Nil"})}
+               (false, reason) => {stdout!("%LOG_MARKER Failing reason: ${reason}" %%{"reason": reason})}
+            }
+          }   
+        } 
+      }
+    }
+}

--- a/integration-tests/test/rnode.py
+++ b/integration-tests/test/rnode.py
@@ -514,6 +514,7 @@ def make_bootstrap_node(
     number_of_active_validators: int = 10,
     epoch_length: int = 10000,
     quarantine_length: int = 50000,
+    pos_vault_pub_key: str = '0432946f7f91f8f767d7c3d43674faf83586dffbd1b8f9278a5c72820dc20308836299f47575ff27f4a736b72e63d91c3cd853641861f64e08ee5f9204fc708df6',
     min_phlo_price: int = 1,
     shard_id: str = default_shard_id
 ) -> Node:
@@ -537,6 +538,7 @@ def make_bootstrap_node(
         "--number-of-active-validators":    number_of_active_validators,
         "--epoch-length":                   epoch_length,
         "--quarantine-length":              quarantine_length,
+        "--pos-vault-pub-key":              pos_vault_pub_key,
         "--min-phlo-price":                 min_phlo_price,
         "--shard-name":                     shard_id
     }
@@ -749,7 +751,8 @@ def started_bootstrap(
     epoch_length: int = 10000,
     quarantine_length: int = 50000,
     min_phlo_price: int = 1,
-    shard_id: str = default_shard_id
+    shard_id: str = default_shard_id,
+    pos_vault_pub_key: str = '0432946f7f91f8f767d7c3d43674faf83586dffbd1b8f9278a5c72820dc20308836299f47575ff27f4a736b72e63d91c3cd853641861f64e08ee5f9204fc708df6'
 ) -> Generator[Node, None, None]:
     bootstrap_node = make_bootstrap_node(
         docker_client=context.docker,
@@ -765,7 +768,8 @@ def started_bootstrap(
         epoch_length=epoch_length,
         quarantine_length=quarantine_length,
         min_phlo_price=min_phlo_price,
-        shard_id=shard_id
+        shard_id=shard_id,
+        pos_vault_pub_key=pos_vault_pub_key
     )
     try:
         wait_for_node_started(context, bootstrap_node)
@@ -773,7 +777,7 @@ def started_bootstrap(
     finally:
         bootstrap_node.cleanup()
 
-
+#pylint: disable=R0913
 @contextlib.contextmanager
 def started_bootstrap_with_network(
     context: TestingContext,
@@ -786,6 +790,8 @@ def started_bootstrap_with_network(
     shard_id: str = default_shard_id,
     extra_volumes: Optional[List[str]] = None,
     wait_for_approved_block: bool = False,
+    pos_vault_pub_key: str = ''
+
 ) -> Generator[Node, None, None]:
     with docker_network(context, context.docker) as network:
         with started_bootstrap(
@@ -798,11 +804,12 @@ def started_bootstrap_with_network(
                 epoch_length=epoch_length,
                 quarantine_length=quarantine_length,
                 min_phlo_price=min_phlo_price,
-                shard_id=shard_id
+                shard_id=shard_id,
+                pos_vault_pub_key=pos_vault_pub_key
         ) as bootstrap:
             if wait_for_approved_block:
                 wait_for_approved_block_received_handler_state(context, bootstrap)
             yield bootstrap
 
 ready_bootstrap_with_network = functools.partial(started_bootstrap_with_network,
-        wait_for_approved_block=True)
+                                                 wait_for_approved_block=True)

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -287,6 +287,10 @@ casper {
     # How many confirmations are necessary to use multi-sig vault.
     # The value should be less or equal the number of PoS multi-sig public keys.
     pos-multi-sig-quorum = 2
+
+    # Public key for transfers from the PoS vault
+    # This public key is used to make transfer from PoS vault defined in PoS contract
+    pos-vault-pub-key = ""
   }
 
   # If node has to create genesis block but no bonds file is provided, bonds file with a list of

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -81,6 +81,7 @@ object ConfigMapper {
       add("casper.genesis-block-data.epoch-length", run.epochLength)
       add("casper.genesis-block-data.quarantine-length", run.quarantineLength)
       add("casper.genesis-block-data.number-of-active-validators", run.numberOfActiveValidators)
+      add("casper.genesis-block-data.pos-vault-pub-key", run.posVaultPubKey)
       add("casper.genesis-block-data.genesis-block-number", run.genesisBlockNumber)
 
       add("casper.autogen-shard-size", run.autogenShardSize)

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -463,6 +463,10 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       descr = "the number of the active validators"
     )
 
+    val posVaultPubKey = opt[String](
+      descr = "Public key for transfers from the PoS vault"
+    )
+
     val prometheus = opt[Flag](
       descr = "Enable the Prometheus metrics reporter"
     )

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -85,6 +85,7 @@ class ConfigMapperSpec extends AnyFunSuite with Matchers {
         "--quarantine-length 111111",
         "--genesis-block-number 222",
         "--number-of-active-validators 111111",
+        "--pos-vault-pub-key 0432946f7f91f8f767d7c3d43674faf83586dffbd1b8f9278a5c72820dc20308836299f47575ff27f4a736b72e63d91c3cd853641861f64e08ee5f9204fc708df6",
         "--disable-lfs",
         "--prometheus",
         "--influxdb",
@@ -213,7 +214,8 @@ class ConfigMapperSpec extends AnyFunSuite with Matchers {
           numberOfActiveValidators = 111111,
           genesisBlockNumber = 222,
           posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
-          posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1
+          posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1,
+          posVaultPubKey = GenesisBuilder.defaultPosVaultPubKey
         ),
         autogenShardSize = 111111,
         minPhloPrice = 1

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -130,7 +130,8 @@ class HoconConfigurationSpec extends AnyFunSuite with Matchers {
           numberOfActiveValidators = 100,
           genesisBlockNumber = 0,
           posMultiSigPublicKeys = GenesisBuilder.defaultPosMultiSigPublicKeys,
-          posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1
+          posMultiSigQuorum = GenesisBuilder.defaultPosMultiSigPublicKeys.length - 1,
+          posVaultPubKey = ""
         ),
         minPhloPrice = 1,
         autogenShardSize = 5


### PR DESCRIPTION
## Overview
Add genesis-pos-vault-pub-key parameter in genesis config ([issue](https://github.com/rchain/rchain/issues/3571))


### Notes
1. Added default value  `pos-vault-pubkey`(maybe some other names) in defaults.conf
2. Added one more option `posVaultPubKey`
3. New config rendered in `ProofOfStake` class
4. Added `posVaultPubKey` to`PoS.rhox`
5. Added `pos-vault-pub-key` command args in make_bootstrap_node
6. Added output of warinig if `pos-vault-pub-key` is empty
7. Added new intergation test that check correctness of transfer money from PoS vault with `pos-vault-pub-key`. 
8. Added check that transfer of money from PoS with not `pos-vault-pub-key` fails

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
