### PR TITLE
Included latest block number is status API

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockApiImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockApiImpl.scala
@@ -103,6 +103,7 @@ class BlockApiImpl[F[_]: Concurrent: RuntimeManager: BlockDagStorage: BlockStore
   override def status: F[Status] =
     for {
       netInfo                  <- networkStatus
+      latestBlockNumber        <- BlockDagStorage[F].getRepresentation.map(_.latestBlockNumber)
       (thisNode, peers, nodes) = netInfo
       status = Status(
         version = VersionInfo(api = 1.toString, node = version),
@@ -111,7 +112,8 @@ class BlockApiImpl[F[_]: Concurrent: RuntimeManager: BlockDagStorage: BlockStore
         shardId,
         peers = peers.length,
         nodes = nodes.length,
-        minPhloPrice
+        minPhloPrice,
+        latestBlockNumber
       )
     } yield status
 

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -231,12 +231,13 @@ message BlockEventInfo{
 
 message Status {
   VersionInfo version = 1 [(scalapb.field).no_box = true];
-  string address      = 2;
-  string networkId    = 3;
-  string shardId      = 4;
-  int32 peers         = 5;
-  int32 nodes         = 6;
-  int64 minPhloPrice  = 7;
+  string address          = 2;
+  string networkId        = 3;
+  string shardId          = 4;
+  int32 peers             = 5;
+  int32 nodes             = 6;
+  int64 minPhloPrice      = 7;
+  int64 latestBlockNumber = 8;
 }
 
 message VersionInfo {

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -231,7 +231,8 @@ object WebApi {
       shardId: String,
       peers: Int,
       nodes: Int,
-      minPhloPrice: Long
+      minPhloPrice: Long,
+      latestBlockNumber: Long
   )
 
   final case class VersionInfo(api: String, node: String)
@@ -254,7 +255,8 @@ object WebApi {
       shardId = status.shardId,
       peers = status.peers,
       nodes = status.nodes,
-      minPhloPrice = status.minPhloPrice
+      minPhloPrice = status.minPhloPrice,
+      latestBlockNumber = status.latestBlockNumber
     )
 
   def toSignedDeploy[F[_]: Sync](


### PR DESCRIPTION
## Overview

The `status` API method in gRPC and WebAPI returns an additional field `latest block number`. This value can be used to get `valid after block number (VABN)` value to prepare deploy.

Sample response for WebAPI (GET-request on http://localhost:40403/api/status)
```json
{
  "version": {
    "api": "1",
    "node": "RChain Node 0.13.0-alpha-280-g11d7d73 (11d7d732e70d42cc273613a6cefd24467d46930c)"
  },
  "address": "rnode://02060d18bb0bec962a0960e492d319846b31f8cd@178.141.84.128?protocol=40400&discovery=40404",
  "networkId": "testnet",
  "shardId": "root",
  "peers": 0,
  "nodes": 0,
  "minPhloPrice": 1,
  "latestBlockNumber": 1
}
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
