### PR TITLE
Removed `prepare-deploy` API method and related code

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockApi.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockApi.scala
@@ -48,12 +48,6 @@ trait BlockApi[F[_]] {
 
   def getBlock(hash: String): F[ApiErr[BlockInfo]]
 
-  def previewPrivateNames(
-      deployer: ByteString,
-      timestamp: Long,
-      nameQty: Int
-  ): F[ApiErr[Seq[ByteString]]]
-
   def bondStatus(
       publicKey: ByteString,
       targetBlock: Option[BlockMessage] = none[BlockMessage]

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockApiImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockApiImpl.scala
@@ -514,17 +514,6 @@ class BlockApiImpl[F[_]: Concurrent: RuntimeManager: BlockDagStorage: BlockStore
       message      <- blockHashOpt.flatTraverse(BlockStore[F].get1)
     } yield message
 
-  override def previewPrivateNames(
-      deployer: ByteString,
-      timestamp: Long,
-      nameQty: Int
-  ): F[ApiErr[Seq[ByteString]]] = {
-    val rand                = Tools.unforgeableNameRng(PublicKey(deployer.toByteArray), timestamp)
-    val safeQty             = nameQty min 1024
-    val ids: Seq[BlockHash] = (0 until safeQty).map(_ => ByteString.copyFrom(rand.next()))
-    ids.asRight[String].pure[F]
-  }
-
   override def lastFinalizedBlock: F[ApiErr[BlockInfo]] =
     for {
       dag                <- BlockDagStorage[F].getRepresentation

--- a/docs/rnode-api/index.md
+++ b/docs/rnode-api/index.md
@@ -34,8 +34,6 @@
     - [ListeningNameDataResponse](#coop.rchain.casper.protocol.ListeningNameDataResponse)
     - [MaybeBlockMessage](#coop.rchain.casper.protocol.MaybeBlockMessage)
     - [NoApprovedBlockAvailable](#coop.rchain.casper.protocol.NoApprovedBlockAvailable)
-    - [PrivateNamePreviewQuery](#coop.rchain.casper.protocol.PrivateNamePreviewQuery)
-    - [PrivateNamePreviewResponse](#coop.rchain.casper.protocol.PrivateNamePreviewResponse)
     - [ProcessedDeploy](#coop.rchain.casper.protocol.ProcessedDeploy)
     - [ProduceEvent](#coop.rchain.casper.protocol.ProduceEvent)
     - [RChainState](#coop.rchain.casper.protocol.RChainState)
@@ -647,39 +645,7 @@ Note: deploys are uniquely keyed by `user`, `timestamp`.
 | identifier | [string](#string) |  |  |
 | nodeIdentifer | [string](#string) |  |  |
 
-
-
-
-
-
-<a name="coop.rchain.casper.protocol.PrivateNamePreviewQuery"/>
-
-### PrivateNamePreviewQuery
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| user | [bytes](#bytes) |  | public key a la DeployData |
-| timestamp | [int64](#int64) |  | millisecond timestamp |
-| nameQty | [int32](#int32) |  | how many names to preview? (max: 1024) |
-
-
-
-
-
-
-<a name="coop.rchain.casper.protocol.PrivateNamePreviewResponse"/>
-
-### PrivateNamePreviewResponse
-
-
-
-| Field | Type | Label | Description |
-| ----- | ---- | ----- | ----------- |
-| ids | [bytes](#bytes) | repeated | a la GPrivate |
-
-
+  
 
 
 
@@ -812,7 +778,6 @@ To get results back, use `listenForDataAtName`.
 | listenForDataAtName | [DataAtNameQuery](#coop.rchain.casper.protocol.DataAtNameQuery) | [ListeningNameDataResponse](#coop.rchain.casper.protocol.DataAtNameQuery) | Find data sent to a name. |
 | listenForContinuationAtName | [ContinuationAtNameQuery](#coop.rchain.casper.protocol.ContinuationAtNameQuery) | [ListeningNameContinuationResponse](#coop.rchain.casper.protocol.ContinuationAtNameQuery) | Find processes receiving on a name. |
 | findBlockWithDeploy | [FindDeployInBlockQuery](#coop.rchain.casper.protocol.FindDeployInBlockQuery) | [BlockQueryResponse](#coop.rchain.casper.protocol.FindDeployInBlockQuery) | Find block from a deploy. |
-| previewPrivateNames | [PrivateNamePreviewQuery](#coop.rchain.casper.protocol.PrivateNamePreviewQuery) | [PrivateNamePreviewResponse](#coop.rchain.casper.protocol.PrivateNamePreviewQuery) | Preview new top-level unforgeable names (for example, to compute signatures over them). |
 
 
 

--- a/integration-tests/test/http_client.py
+++ b/integration-tests/test/http_client.py
@@ -30,12 +30,6 @@ class ApiStatus:
 
 
 @dataclass
-class PrepareResponse:
-    names: List[str]
-    seq_number: int
-
-
-@dataclass
 class DataResponse:
     exprs: List[Union[str, int]]
     length: int
@@ -67,20 +61,6 @@ class HttpClient():
             peers=message['peers'],
             nodes=message['nodes'])
 
-    def prepare_deploy(self, deployer: Optional[str] =None, timestamp: Optional[int] = None, name_qty: Optional[int] = None) -> PrepareResponse:
-        prepare_deploy_url = self.url + '/prepare-deploy'
-        if deployer and timestamp and name_qty:
-            data = {
-                "deployer":deployer,
-                "timestamp": timestamp,
-                "nameQty": name_qty
-            }
-            rep = requests.post(prepare_deploy_url,json=data)
-        else:
-            rep = requests.get(prepare_deploy_url)
-        _check_reponse(rep)
-        message = rep.json()
-        return PrepareResponse(names=message['names'], seq_number=message['seqNumber'])
 
     def deploy(self, term: str, phlo_limit: int, phlo_price: int, valid_after_block_number: int, deployer: PrivateKey, shard_id: str = '') -> str:
         timestamp = int(time.time()* 1000)

--- a/integration-tests/test/test_web_api.py
+++ b/integration-tests/test/test_web_api.py
@@ -30,10 +30,6 @@ def test_web_api(node_with_blocks: Tuple[Node, List[str], List[str]]) -> None :
 
     status = client.status()
     assert status.version
-    prepare_rep = client.prepare_deploy()
-    assert prepare_rep.seq_number == 3
-    prepare_rep_2 = client.prepare_deploy(STANDALONE_KEY.get_public_key().to_hex(), 1, 1)
-    assert prepare_rep_2.seq_number == 3
 
     data_at_name = client.data_at_name(deploy_hash[0], 1, "UnforgDeploy")
     assert data_at_name.length == 0

--- a/models/src/main/protobuf/DeployServiceCommon.proto
+++ b/models/src/main/protobuf/DeployServiceCommon.proto
@@ -71,12 +71,6 @@ message MachineVerifyQuery {
   int32 depth = 1;
 }
 
-message PrivateNamePreviewQuery {
-  bytes  user      = 1; // public key a la DeployData
-  int64  timestamp = 2; // millisecond timestamp
-  int32  nameQty   = 3; // how many names to preview? (max: 1024)
-}
-
 message LastFinalizedBlockQuery {
 }
 

--- a/models/src/main/protobuf/DeployServiceV1.proto
+++ b/models/src/main/protobuf/DeployServiceV1.proto
@@ -50,8 +50,6 @@ service DeployService {
   rpc listenForContinuationAtName(ContinuationAtNameQuery) returns (ContinuationAtNameResponse) {}
   // Find block containing a deploy.
   rpc findDeploy(FindDeployQuery) returns (FindDeployResponse) {}
-  // Preview new top-level unforgeable names (for example, to compute signatures over them).
-  rpc previewPrivateNames(PrivateNamePreviewQuery) returns (PrivateNamePreviewResponse) {}
   // Get details about a particular block.
   rpc lastFinalizedBlock(LastFinalizedBlockQuery) returns (LastFinalizedBlockResponse) {}
   // Check if a given block is finalized.
@@ -167,14 +165,6 @@ message FindDeployResponse {
   oneof message {
     ServiceError error        = 1;
     LightBlockInfo blockInfo  = 2;
-  }
-}
-
-// previewPrivateNames
-message PrivateNamePreviewResponse {
-  oneof message {
-    ServiceError error                 = 1;
-    PrivateNamePreviewPayload payload  = 2;
   }
 }
 

--- a/models/src/main/scala/coop/rchain/models/EqualsM.scala
+++ b/models/src/main/scala/coop/rchain/models/EqualsM.scala
@@ -152,8 +152,6 @@ object EqualM extends EqualMDerivation {
 
   implicit val PCostHash              = gen[PCost]
   implicit val TaggedContinuationHash = gen[TaggedContinuation]
-
-  implicit val PrivateNamePreviewQueryHash = gen[PrivateNamePreviewQuery]
 }
 
 trait EqualMDerivation {

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -171,8 +171,6 @@ object HashM extends HashMDerivation {
   implicit val PCostHash              = gen[PCost]
   implicit val TaggedContinuationHash = gen[TaggedContinuation]
 
-  implicit val PrivateNamePreviewQueryHash = gen[PrivateNamePreviewQuery]
-
   // deploy service V1
   implicit val ContinuationAtNamePayloadV2Hash  = gen[v1.ContinuationAtNamePayload]
   implicit val BlockResponseV2Hash              = gen[v1.BlockResponse]

--- a/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
+++ b/node/src/main/scala/coop/rchain/node/api/DeployGrpcServiceV1.scala
@@ -176,18 +176,6 @@ object DeployGrpcServiceV1 {
           FindDeployResponse(r.fold[Message](Error, BlockInfo))
         }
 
-      def previewPrivateNames(request: PrivateNamePreviewQuery): Task[PrivateNamePreviewResponse] =
-        defer(blockApi.previewPrivateNames(request.user, request.timestamp, request.nameQty)) { r =>
-          import PrivateNamePreviewResponse.Message
-          import PrivateNamePreviewResponse.Message._
-          PrivateNamePreviewResponse(
-            r.fold[Message](
-              Error,
-              ids => Payload(PrivateNamePreviewPayload(ids))
-            )
-          )
-        }
-
       def lastFinalizedBlock(request: LastFinalizedBlockQuery): Task[LastFinalizedBlockResponse] =
         defer(blockApi.lastFinalizedBlock) { r =>
           import LastFinalizedBlockResponse.Message

--- a/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
+++ b/node/src/main/scala/coop/rchain/node/web/WebApiRoutes.scala
@@ -97,26 +97,16 @@ object WebApiRoutes {
     implicit val lightBlockListEnc          = jsonEncoderOf[F, List[LightBlockInfo]]
     implicit val dataAtNameRespEncoder      = jsonEncoderOf[F, DataAtNameResponse]
     implicit val dataAtParRespEncoder       = jsonEncoderOf[F, RhoDataResponse]
-    implicit val prepareEncoder             = jsonEncoderOf[F, PrepareResponse]
     implicit val transactionResponseEncoder = jsonEncoderOf[F, TransactionResponse]
     // Decoders
     implicit val deployRequestDecoder     = jsonOf[F, DeployRequest]
     implicit val dataAtNameRequestDecoder = jsonOf[F, DataAtNameRequest]
     implicit val dataAtParRequestDecoder  = jsonOf[F, DataAtNameByBlockHashRequest]
-    implicit val prepareDecoder           = jsonOf[F, PrepareRequest]
     implicit val ExploreDeployRequest     = jsonOf[F, ExploreDeployRequest]
 
     HttpRoutes.of[F] {
       case GET -> Root / "status" =>
         webApi.status.handle
-
-      // Prepare deploy
-
-      case GET -> Root / "prepare-deploy" =>
-        webApi.prepareDeploy(none).handle
-
-      case req @ POST -> Root / "prepare-deploy" =>
-        req.handle[PrepareRequest, PrepareResponse](x => webApi.prepareDeploy(x.some))
 
       // Deploy
 


### PR DESCRIPTION
## Overview

This PR implements 2nd and 3rd part of the [issue](https://github.com/rchain/rchain/issues/3690).

`prepare-deploy` API method and related code removed from WebAPI and gRPC.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
