### PR TITLE
Introduce new random seed for rholang deploy(part 1)

### DIFF
--- a/rholang/src/main/scala/BlockRandomSeed.scala
+++ b/rholang/src/main/scala/BlockRandomSeed.scala
@@ -1,10 +1,9 @@
 import coop.rchain.crypto.PublicKey
-import coop.rchain.crypto.hash.Blake2b256.hash
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import scodec.bits.ByteVector
+import scodec.codecs.{bytes, uint8, ulong, utf8, variableSizeBytes}
 import scodec.{Codec, TransformSyntax}
-import scodec.codecs.{bytes, uint16, uint8, ulong, utf8, variableSizeBytes}
 
 final case class BlockRandomSeed(
     shardId: String,
@@ -17,18 +16,13 @@ final case class BlockRandomSeed(
 object BlockRandomSeed {
   private val codecPublicKey: Codec[PublicKey] = variableSizeBytes(uint8, bytes)
     .xmap[PublicKey](bv => PublicKey(bv.toArray), pk => ByteVector(pk.bytes))
-  private val codecBlakeHash: Codec[Blake2b256Hash] =
-    variableSizeBytes(uint16, bytes)
-      .xmap[Blake2b256Hash](bv => Blake2b256Hash.fromByteVector(bv), _.bytes)
 
   private val codecBlockRandomSeed: Codec[BlockRandomSeed] = (utf8 :: ulong(bits = 64) ::
-    codecPublicKey :: codecPublicKey :: codecBlakeHash).as[BlockRandomSeed]
+    codecPublicKey :: codecPublicKey :: Blake2b256Hash.codecPureBlake2b256Hash).as[BlockRandomSeed]
 
   private def encode(blockRandomSeed: BlockRandomSeed): Array[Byte] =
     codecBlockRandomSeed.encode(blockRandomSeed).require.toByteArray
 
-  def randomSeed(blockRandomSeed: BlockRandomSeed): Blake2b512Random = {
-    val serialized = encode(blockRandomSeed)
-    Blake2b512Random(serialized)
-  }
+  def generateRandomNumber(blockRandomSeed: BlockRandomSeed): Blake2b512Random =
+    Blake2b512Random(encode(blockRandomSeed))
 }

--- a/rholang/src/main/scala/BlockRandomSeed.scala
+++ b/rholang/src/main/scala/BlockRandomSeed.scala
@@ -1,0 +1,34 @@
+import coop.rchain.crypto.PublicKey
+import coop.rchain.crypto.hash.Blake2b256.hash
+import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.rspace.hashing.Blake2b256Hash
+import scodec.bits.ByteVector
+import scodec.{Codec, TransformSyntax}
+import scodec.codecs.{bytes, uint16, uint8, ulong, utf8, variableSizeBytes}
+
+final case class BlockRandomSeed(
+    shardId: String,
+    blockNumber: Long,
+    sender: PublicKey,
+    validatorPublicKey: PublicKey,
+    preStateHash: Blake2b256Hash
+)
+
+object BlockRandomSeed {
+  private val codecPublicKey: Codec[PublicKey] = variableSizeBytes(uint8, bytes)
+    .xmap[PublicKey](bv => PublicKey(bv.toArray), pk => ByteVector(pk.bytes))
+  private val codecBlakeHash: Codec[Blake2b256Hash] =
+    variableSizeBytes(uint16, bytes)
+      .xmap[Blake2b256Hash](bv => Blake2b256Hash.fromByteVector(bv), _.bytes)
+
+  private val codecBlockRandomSeed: Codec[BlockRandomSeed] = (utf8 :: ulong(bits = 64) ::
+    codecPublicKey :: codecPublicKey :: codecBlakeHash).as[BlockRandomSeed]
+
+  private def encode(blockRandomSeed: BlockRandomSeed): Array[Byte] =
+    codecBlockRandomSeed.encode(blockRandomSeed).require.toByteArray
+
+  def randomSeed(blockRandomSeed: BlockRandomSeed): Blake2b512Random = {
+    val serialized = encode(blockRandomSeed)
+    Blake2b512Random(serialized)
+  }
+}


### PR DESCRIPTION
## Overview
First part of the [issue](https://github.com/rchain/rchain/issues/3691)

## Overview
Added case class BlockRandomSeed with Codec[BlockRandomSeed] and method returning Blake2b512Random object


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
