### PR TITLE
Changed Web API data-at-name-by-block-hash to accept Par object

### DIFF
--- a/integration-tests/test/http_client.py
+++ b/integration-tests/test/http_client.py
@@ -91,6 +91,14 @@ class HttpClient():
         message = rep.json()
         return DataResponse(exprs=message['exprs'], length=message['length'])
 
+    def data_at_name_by_block_hash(self, name: str, data, block_hash: str, use_pre_state_hash: bool):
+        data_at_name_by_block_hash_url = self.url + '/data-at-name-by-block-hash'
+        rep = requests.post(data_at_name_by_block_hash_url,
+                            json={"name": {name: {"data": data}}, "blockHash": block_hash,
+                                  "usePreStateHash": use_pre_state_hash})
+        _check_reponse(rep)
+        return rep.json()
+
     def last_finalized_block(self) -> Dict:
         last_finalized_block_url = self.url + '/last-finalized-block'
         rep = requests.get(last_finalized_block_url)

--- a/integration-tests/test/test_web_api.py
+++ b/integration-tests/test/test_web_api.py
@@ -52,3 +52,5 @@ def test_web_api(node_with_blocks: Tuple[Node, List[str], List[str]]) -> None :
     ret = client.deploy("@2!(1)", 100000, 1, 5, STANDALONE_KEY, shard_id='test')
     assert ret is not None
 
+    data_at_name_by_block_hash = client.data_at_name_by_block_hash('ExprString', 'test', block_hash[0], False)
+    assert len(data_at_name_by_block_hash['expr']) == 0

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -354,7 +354,7 @@ object WebApi {
       // Binary data is encoded as base16 string
       case ExprBytes(data) =>
         exprToPar(Expr().withGByteArray(data.unsafeHexToByteString))
-      case ExprUnforg(data) => unforgToPar(data)
+      case ExprUnforg(data) => unforgToParProto(data)
     }
   }
 
@@ -364,12 +364,12 @@ object WebApi {
     case UnforgDeployer(name) => GDeployerIdBody(GDeployerId(name.unsafeHexToByteString))
   }
 
-  private def unforgToPar(unforg: RhoUnforg): Par =
+  private def unforgToParProto(unforg: RhoUnforg): Par =
     Par(unforgeables = Seq(GUnforgeable(unforgToUnforgProto(unforg))))
 
   // Data request/response protobuf wrappers
 
-  private def toPar(req: DataAtNameRequest): Par = unforgToPar(req.name)
+  private def toPar(req: DataAtNameRequest): Par = unforgToParProto(req.name)
 
   private def toPar(req: DataAtNameByBlockHashRequest): Par = rhoExprToParProto(req.name)
 

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -339,9 +339,9 @@ object WebApi {
     // Nested expressions (Par, Tuple, List and Set are converted to JSON list)
     case data: ExprPar   => exprParToParProto(data)
     case ExprTuple(data) => Expression(Expr().withETupleBody(ETuple(data.map(rhoExprToParProto))))
-    case ExprList(data)  => RhoList(data.map(rhoExprToParProto))
-    case ExprSet(data)   => RhoSet(data.map(rhoExprToParProto))
-    case ExprMap(data)   => RhoMap(data.map { case (k, v) => (String(k), rhoExprToParProto(v)) })
+    case ExprList(data)  => List(data.map(rhoExprToParProto))
+    case ExprSet(data)   => Set(data.map(rhoExprToParProto))
+    case ExprMap(data)   => Map(data.map { case (k, v) => (String(k), rhoExprToParProto(v)) })
     // Terminal expressions (here is the data)
     case ExprBool(data)   => Boolean(data)
     case ExprInt(data)    => Number(data)
@@ -383,12 +383,13 @@ object WebApi {
 
   private def toDataAtNameResponse(req: (Seq[DataWithBlockInfo], Int)): DataAtNameResponse = {
     val (dbs, length) = req
-    val exprsWithBlock = dbs.foldLeft(List[RhoExprWithBlock]()) { (acc, data) =>
-      val exprs = data.postBlockData.flatMap(exprFromParProto)
-      // Implements semantic of Par with Unit: P | Nil ==> P
-      val expr  = if (exprs.size == 1) exprs.head else ExprPar(exprs.toList)
-      val block = data.block
-      RhoExprWithBlock(expr, block) +: acc
+    val exprsWithBlock = dbs.foldLeft(collection.immutable.List[RhoExprWithBlock]()) {
+      (acc, data) =>
+        val exprs = data.postBlockData.flatMap(exprFromParProto)
+        // Implements semantic of Par with Unit: P | Nil ==> P
+        val expr  = if (exprs.size == 1) exprs.head else ExprPar(exprs.toList)
+        val block = data.block
+        RhoExprWithBlock(expr, block) +: acc
     }
     DataAtNameResponse(exprsWithBlock, length)
   }

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -262,7 +262,7 @@ object WebApi {
 
   // RhoExpr from protobuf
 
-  private def exprFromParProto(par: Par): Option[RhoExpr] = {
+  def exprFromParProto(par: Par): Option[RhoExpr] = {
     val exprs =
       par.exprs.flatMap(exprFromExprProto) ++
         par.unforgeables.flatMap(unforgFromProto) ++

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -373,7 +373,7 @@ object WebApi {
   }
 
   private def unforgToParProto(unforg: RhoUnforg): Par =
-    Par(unforgeables = Seq(GUnforgeable(unforgToUnforgProto(unforg))))
+    Unforgeable(GUnforgeable(unforgToUnforgProto(unforg)))
 
   // Data request/response protobuf wrappers
 

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -355,7 +355,7 @@ object WebApi {
       case ExprInt(data)    => exprProtoToParProto(Expr().withGInt(data))
       case ExprString(data) => exprProtoToParProto(Expr().withGString(data))
       case ExprUri(data)    => exprProtoToParProto(Expr().withGUri(data))
-      // Binary data is encoded as base16 string
+      // Binary data is decoded from base16 string
       case ExprBytes(data) =>
         exprProtoToParProto(Expr().withGByteArray(data.unsafeHexToByteString))
       case ExprUnforg(data) => unforgToParProto(data)

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -12,7 +12,7 @@ import coop.rchain.models._
 import coop.rchain.models.syntax._
 import coop.rchain.node.api.WebApi._
 import coop.rchain.node.web.{CacheTransactionAPI, TransactionResponse}
-import coop.rchain.rholang.interpreter.RhoType.Expression
+import coop.rchain.rholang.interpreter.RhoType.{Boolean, ByteArray, Expression, Number, String, Uri}
 
 trait WebApi[F[_]] {
   def status: F[ApiStatus]
@@ -345,12 +345,12 @@ object WebApi {
         case (k, v) => (rhoExprToParProto(ExprString(k)), rhoExprToParProto(v))
       }.toList)))
     // Terminal expressions (here is the data)
-    case ExprBool(data)   => Expression(Expr().withGBool(data))
-    case ExprInt(data)    => Expression(Expr().withGInt(data))
-    case ExprString(data) => Expression(Expr().withGString(data))
-    case ExprUri(data)    => Expression(Expr().withGUri(data))
+    case ExprBool(data)   => Boolean(data)
+    case ExprInt(data)    => Number(data)
+    case ExprString(data) => String(data)
+    case ExprUri(data)    => Uri(data)
     // Binary data is decoded from base16 string
-    case ExprBytes(data)  => Expression(Expr().withGByteArray(data.unsafeHexToByteString))
+    case ExprBytes(data)  => ByteArray(data.unsafeHexToByteString.toByteArray)
     case ExprUnforg(data) => unforgToParProto(data)
   }
 

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -12,7 +12,7 @@ import coop.rchain.models._
 import coop.rchain.models.syntax._
 import coop.rchain.node.api.WebApi._
 import coop.rchain.node.web.{CacheTransactionAPI, TransactionResponse}
-import coop.rchain.rholang.interpreter.RhoType.{Boolean, ByteArray, Expression, Number, String, Uri}
+import coop.rchain.rholang.interpreter.RhoType._
 
 trait WebApi[F[_]] {
   def status: F[ApiStatus]
@@ -338,12 +338,9 @@ object WebApi {
     // Nested expressions (Par, Tuple, List and Set are converted to JSON list)
     case ExprPar(data)   => Expression(Expr().withEListBody(EList(data.map(rhoExprToParProto))))
     case ExprTuple(data) => Expression(Expr().withETupleBody(ETuple(data.map(rhoExprToParProto))))
-    case ExprList(data)  => Expression(Expr().withEListBody(EList(data.map(rhoExprToParProto))))
-    case ExprSet(data)   => Expression(Expr().withESetBody(ParSet(data.map(rhoExprToParProto))))
-    case ExprMap(data) =>
-      Expression(Expr().withEMapBody(ParMap(data.map {
-        case (k, v) => (rhoExprToParProto(ExprString(k)), rhoExprToParProto(v))
-      }.toList)))
+    case ExprList(data)  => RhoList(data.map(rhoExprToParProto))
+    case ExprSet(data)   => RhoSet(data.map(rhoExprToParProto))
+    case ExprMap(data)   => RhoMap(data.map { case (k, v) => (String(k), rhoExprToParProto(v)) })
     // Terminal expressions (here is the data)
     case ExprBool(data)   => Boolean(data)
     case ExprInt(data)    => Number(data)

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -129,7 +129,7 @@ object WebApi {
   final case class ExprPar(data: List[RhoExpr])        extends RhoExpr
   final case class ExprTuple(data: List[RhoExpr])      extends RhoExpr
   final case class ExprList(data: List[RhoExpr])       extends RhoExpr
-  final case class ExprSet(data: List[RhoExpr])        extends RhoExpr
+  final case class ExprSet(data: Set[RhoExpr])         extends RhoExpr
   final case class ExprMap(data: Map[String, RhoExpr]) extends RhoExpr
   // Terminal expressions (here is the data)
   final case class ExprBool(data: Boolean)  extends RhoExpr
@@ -294,7 +294,7 @@ object WebApi {
       ExprList(exp.getEListBody.ps.flatMap(exprFromParProto).toList).some
     // Set
     else if (exp.exprInstance.isESetBody)
-      ExprSet(exp.getESetBody.ps.flatMap(exprFromParProto).toList).some
+      ExprSet(exp.getESetBody.ps.flatMap(exprFromParProto).toSet).some
     // Map
     else if (exp.exprInstance.isEMapBody) {
       val fields = for {
@@ -363,7 +363,7 @@ object WebApi {
     case ExprPar(data)   => data.map(rhoExprToParProto).combineAll
     case ExprTuple(data) => TupleN(data.map(rhoExprToParProto))
     case ExprList(data)  => List(data.map(rhoExprToParProto))
-    case ExprSet(data)   => Set(data.map(rhoExprToParProto))
+    case ExprSet(data)   => Set(data.map(rhoExprToParProto).toSeq)
     case ExprMap(data)   => Map(data.map { case (k, v) => (String(k), rhoExprToParProto(v)) })
     // Terminal expressions (here is the data)
     case ExprBool(data)   => Boolean(data)

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -334,26 +334,30 @@ object WebApi {
   // RhoExpr to protobuf
 
   private def rhoExprToParProto(exp: RhoExpr): Par = {
-    def exprToPar(exp: Expr): Par = Par(exprs = Seq(exp))
+    def exprProtoToParProto(exp: Expr): Par = Par(exprs = Seq(exp))
 
     exp match {
       // Nested expressions (Par, Tuple, List and Set are converted to JSON list)
-      case ExprPar(data)   => exprToPar(Expr().withEListBody(EList(data.map(rhoExprToParProto))))
-      case ExprTuple(data) => exprToPar(Expr().withETupleBody(ETuple(data.map(rhoExprToParProto))))
-      case ExprList(data)  => exprToPar(Expr().withEListBody(EList(data.map(rhoExprToParProto))))
-      case ExprSet(data)   => exprToPar(Expr().withESetBody(ParSet(data.map(rhoExprToParProto))))
+      case ExprPar(data) =>
+        exprProtoToParProto(Expr().withEListBody(EList(data.map(rhoExprToParProto))))
+      case ExprTuple(data) =>
+        exprProtoToParProto(Expr().withETupleBody(ETuple(data.map(rhoExprToParProto))))
+      case ExprList(data) =>
+        exprProtoToParProto(Expr().withEListBody(EList(data.map(rhoExprToParProto))))
+      case ExprSet(data) =>
+        exprProtoToParProto(Expr().withESetBody(ParSet(data.map(rhoExprToParProto))))
       case ExprMap(data) =>
-        exprToPar(Expr().withEMapBody(ParMap(data.map {
+        exprProtoToParProto(Expr().withEMapBody(ParMap(data.map {
           case (k, v) => (rhoExprToParProto(ExprString(k)), rhoExprToParProto(v))
         }.toList)))
       // Terminal expressions (here is the data)
-      case ExprBool(data)   => exprToPar(Expr().withGBool(data))
-      case ExprInt(data)    => exprToPar(Expr().withGInt(data))
-      case ExprString(data) => exprToPar(Expr().withGString(data))
-      case ExprUri(data)    => exprToPar(Expr().withGUri(data))
+      case ExprBool(data)   => exprProtoToParProto(Expr().withGBool(data))
+      case ExprInt(data)    => exprProtoToParProto(Expr().withGInt(data))
+      case ExprString(data) => exprProtoToParProto(Expr().withGString(data))
+      case ExprUri(data)    => exprProtoToParProto(Expr().withGUri(data))
       // Binary data is encoded as base16 string
       case ExprBytes(data) =>
-        exprToPar(Expr().withGByteArray(data.unsafeHexToByteString))
+        exprProtoToParProto(Expr().withGByteArray(data.unsafeHexToByteString))
       case ExprUnforg(data) => unforgToParProto(data)
     }
   }

--- a/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
@@ -27,14 +27,8 @@ class RhoExprToParSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks w
     // def genExprPar   = withList(ExprPar)
     def genExprTuple = withList(ExprTuple)
     def genExprList  = withList(ExprList)
-
-    // Generated data should not have duplicates and be sorted
-    // def genExprSet =
-    //   Gen
-    //     .listOfN(numOfElements, genRhoExpr)
-    //     .map(data => ExprSet(data.toSet.toList.sorted)) // withList(ExprSet)
-
-    def genExprMap = Gen.mapOfN(numOfElements, arbTuple2[String, RhoExpr].arbitrary).map(ExprMap)
+    def genExprSet   = Gen.listOfN(numOfElements, genRhoExpr).map(data => ExprSet(data.toSet))
+    def genExprMap   = Gen.mapOfN(numOfElements, arbTuple2[String, RhoExpr].arbitrary).map(ExprMap)
 
     def genExprBool   = arbBool.arbitrary.map(b => ExprBool(b))
     def genExprInt    = arbLong.arbitrary.map(l => ExprInt(l))
@@ -56,7 +50,7 @@ class RhoExprToParSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks w
           // genExprPar,
           genExprTuple,
           genExprList,
-          // genExprSet,
+          genExprSet,
           genExprMap,
           genExprBool,
           genExprInt,

--- a/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
@@ -1,0 +1,41 @@
+package coop.rchain.node
+
+import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.models.syntax._
+import coop.rchain.node.api.WebApi._
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
+
+class RhoExprToParSpec extends AnyWordSpec with Matchers {
+  private def roundTripTest(expr: RhoExpr): Option[RhoExpr] =
+    exprFromParProto(rhoExprToParProto(expr))
+
+  "WebAPI RhoExpr <-> Par conversion" should {
+    "work correct with simple types" in {
+      roundTripTest(ExprBool(true)).collect { case ExprBool(data)            => data } shouldBe true.some
+      roundTripTest(ExprInt(42)).collect { case ExprInt(data)                => data } shouldBe 42.some
+      roundTripTest(ExprString("abc")).collect { case ExprString(data)       => data } shouldBe "abc".some
+      roundTripTest(ExprUri("http://test.com")).collect { case ExprUri(data) => data } shouldBe "http://test.com".some
+
+      val bytesAsString = ByteString.copyFrom(Array[Byte](1, 2, 3)).toHexString
+      roundTripTest(ExprBytes(bytesAsString)).collect { case ExprBytes(data) => data } shouldBe bytesAsString.some
+      roundTripTest(ExprUnforg(UnforgDeploy(bytesAsString))).collect {
+        case ExprUnforg(data) => data
+      } shouldBe UnforgDeploy(
+        bytesAsString
+      ).some
+    }
+    "work correct with nested types" in {
+      val listExpr = List[RhoExpr](ExprBool(true), ExprInt(42))
+      roundTripTest(ExprPar(listExpr)).collect { case ExprPar(data)     => data } shouldBe listExpr.some
+      roundTripTest(ExprTuple(listExpr)).collect { case ExprTuple(data) => data } shouldBe listExpr.some
+      roundTripTest(ExprList(listExpr)).collect { case ExprList(data)   => data } shouldBe listExpr.some
+      roundTripTest(ExprSet(listExpr)).collect { case ExprSet(data)     => data } shouldBe listExpr.some
+
+      val mapExpr =
+        Map[String, RhoExpr]("a" -> ExprBool(true), "b" -> ExprInt(42), "c" -> ExprList(listExpr))
+      roundTripTest(ExprMap(mapExpr)).collect { case ExprMap(data) => data } shouldBe mapExpr.some
+    }
+  }
+}

--- a/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
@@ -10,15 +10,14 @@ import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class RhoExprToParSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
-  property("WebAPI RhoExpr <-> Par conversion work correct") {
+  property("WebAPI RhoExpr => Par => RhoExpr conversion work correct") {
     forAll { rhoExpr: RhoExpr =>
-      // TODO: Remove after finishing debugging
-      // println(expected)
-      // println(s"  $actual")
-
-      exprFromParProto(rhoExprToParProto(rhoExpr)) shouldBe rhoExpr.some
+      rhoExprToRhoExpr(rhoExpr) shouldBe rhoExpr.some
     }
   }
+
+  // Converts RhoExpr to Par and then back to RhoExpr
+  private val rhoExprToRhoExpr = rhoExprToParProto _ andThen exprFromParProto
 
   implicit private def aArb: Arbitrary[RhoExpr] = {
 
@@ -62,8 +61,8 @@ class RhoExprToParSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks w
       )
 
     // Helpers
-    def withList[A <: RhoExpr](f: List[RhoExpr] => A): Gen[A] =
-      Gen.listOfN(numOfElements, genRhoExpr).map(data => f(data))
+    def withList[A <: RhoExpr](f: List[RhoExpr] => A) =
+      Gen.listOfN(numOfElements, genRhoExpr).map(f)
     def genHexString = Gen.listOf(arbByte.arbitrary).map(_.toArray.toHexString)
 
     Arbitrary(genRhoExpr)

--- a/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
@@ -1,125 +1,77 @@
 package coop.rchain.node
 
 import cats.syntax.all._
-import com.google.protobuf.ByteString
 import coop.rchain.models.syntax._
-import coop.rchain.models.testImplicits._
 import coop.rchain.node.api.WebApi._
-import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
+import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class RhoExprToParSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+  property("WebAPI RhoExpr <-> Par conversion work correct") {
+    forAll { rhoExpr: RhoExpr =>
+      // TODO: Remove after finishing debugging
+      // println(expected)
+      // println(s"  $actual")
 
-  private def roundTripTest(expr: RhoExpr): Option[RhoExpr] =
-    exprFromParProto(rhoExprToParProto(expr))
-
-  // Simple types
-
-  property("WebAPI ExprBool <-> Par conversion work correct") {
-    forAll { b: Boolean =>
-      roundTripTest(ExprBool(b)).collect { case ExprBool(data) => data } shouldBe b.some
+      exprFromParProto(rhoExprToParProto(rhoExpr)) shouldBe rhoExpr.some
     }
   }
 
-  property("WebAPI ExprInt <-> Par conversion work correct") {
-    forAll { i: Long =>
-      roundTripTest(ExprInt(i)).collect { case ExprInt(data) => data } shouldBe i.some
-    }
-  }
+  implicit private def aArb: Arbitrary[RhoExpr] = {
 
-  property("WebAPI ExprString <-> Par conversion work correct") {
-    forAll { s: String =>
-      roundTripTest(ExprString(s)).collect { case ExprString(data) => data } shouldBe s.some
-    }
-  }
+    val numOfElements = 2 // StackOverflowError with n >= 3
 
-  property("WebAPI ExprUri <-> Par conversion work correct") {
-    forAll { uri: String =>
-      roundTripTest(ExprUri(uri)).collect { case ExprUri(data) => data } shouldBe uri.some
-    }
-  }
+    // def genExprPar   = withList(ExprPar)
+    def genExprTuple = withList(ExprTuple)
+    def genExprList  = withList(ExprList)
 
-  property("WebAPI ExprUnforg <-> Par conversion work correct") {
-    forAll { bs: ByteString =>
-      roundTripTest(ExprBytes(bs.toHexString)).collect { case ExprBytes(data) => data } shouldBe bs.toHexString.some
-    }
-  }
+    // Generated data should not have duplicates and be sorted
+    // def genExprSet =
+    //   Gen
+    //     .listOfN(numOfElements, genRhoExpr)
+    //     .map(data => ExprSet(data.toSet.toList.sorted)) // withList(ExprSet)
 
-  property("WebAPI ExprBytes <-> Par conversion work correct") {
-    forAll { bs: ByteString =>
-      roundTripTest(ExprUnforg(UnforgDeploy(bs.toHexString))).collect {
-        case ExprUnforg(data) => data
-      } shouldBe UnforgDeploy(bs.toHexString).some
-    }
-  }
+    def genExprMap = Gen.mapOfN(numOfElements, arbTuple2[String, RhoExpr].arbitrary).map(ExprMap)
 
-  // Nested types
+    def genExprBool   = arbBool.arbitrary.map(b => ExprBool(b))
+    def genExprInt    = arbLong.arbitrary.map(l => ExprInt(l))
+    def genExprString = arbString.arbitrary.map(s => ExprString(s))
+    def genExprUri    = arbString.arbitrary.map(uri => ExprUri(uri))
+    def genExprBytes  = genHexString.map(ExprBytes)
+    def genExprUnforg =
+      Gen
+        .oneOf(
+          genHexString.map(UnforgPrivate),
+          genHexString.map(UnforgDeploy),
+          genHexString.map(UnforgDeployer)
+        )
+        .map(ExprUnforg)
 
-  implicit val listRhoExprArb: Arbitrary[List[RhoExpr]] = Arbitrary(
-    for {
-      bool <- arbBool.arbitrary
-      long <- arbLong.arbitrary
-      str  <- arbString.arbitrary
-      uri  <- arbString.arbitrary
-      bs   <- arbByteArray.arbitrary
-    } yield List[RhoExpr](
-      ExprBool(bool),
-      ExprInt(long),
-      ExprString(str),
-      ExprUri(uri),
-      ExprBytes(bs.toHexString)
-    )
-  )
+    def genRhoExpr: Gen[RhoExpr] =
+      Gen.lzy(
+        Gen.oneOf(
+          // genExprPar,
+          genExprTuple,
+          genExprList,
+          // genExprSet,
+          genExprMap,
+          genExprBool,
+          genExprInt,
+          genExprString,
+          genExprUri,
+          genExprBytes,
+          genExprUnforg
+        )
+      )
 
-  property("WebAPI ExprPar <-> Par conversion work correct") {
-    forAll { listExpr: List[RhoExpr] =>
-      roundTripTest(ExprPar(listExpr)).collect { case ExprPar(data) => data } shouldBe listExpr.some
-    }
-  }
+    // Helpers
+    def withList[A <: RhoExpr](f: List[RhoExpr] => A): Gen[A] =
+      Gen.listOfN(numOfElements, genRhoExpr).map(data => f(data))
+    def genHexString = Gen.listOf(arbByte.arbitrary).map(_.toArray.toHexString)
 
-  property("WebAPI ExprTuple <-> Par conversion work correct") {
-    forAll { listExpr: List[RhoExpr] =>
-      roundTripTest(ExprTuple(listExpr)).collect { case ExprTuple(data) => data } shouldBe listExpr.some
-    }
-  }
-
-  property("WebAPI ExprList <-> Par conversion work correct") {
-    forAll { listExpr: List[RhoExpr] =>
-      roundTripTest(ExprList(listExpr)).collect { case ExprList(data) => data } shouldBe listExpr.some
-    }
-  }
-
-  property("WebAPI ExprSet <-> Par conversion work correct") {
-    forAll { listExpr: List[RhoExpr] =>
-      roundTripTest(ExprSet(listExpr)).collect { case ExprSet(data) => data } shouldBe listExpr.some
-    }
-  }
-
-  implicit val mapRhoExprArb: Arbitrary[Map[String, RhoExpr]] = Arbitrary(
-    for {
-      bool <- arbBool.arbitrary
-      long <- arbLong.arbitrary
-      str  <- arbString.arbitrary
-      uri  <- arbString.arbitrary
-      bs   <- arbByteArray.arbitrary
-      list <- listRhoExprArb.arbitrary
-      keys = (1 to 6).map(_ => arbString.arbitrary.sample.get)
-    } yield Map[String, RhoExpr](
-      keys(0) -> ExprBool(bool),
-      keys(1) -> ExprInt(long),
-      keys(2) -> ExprString(str),
-      keys(3) -> ExprUri(uri),
-      keys(4) -> ExprBytes(bs.toHexString),
-      keys(5) -> ExprList(list)
-    )
-  )
-
-  property("WebAPI ExprMap <-> Par conversion work correct") {
-    forAll { mapExpr: Map[String, RhoExpr] =>
-      roundTripTest(ExprMap(mapExpr)).collect { case ExprMap(data) => data } shouldBe mapExpr.some
-    }
+    Arbitrary(genRhoExpr)
   }
 }

--- a/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/RhoExprToParSpec.scala
@@ -3,38 +3,122 @@ package coop.rchain.node
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.models.syntax._
+import coop.rchain.models.testImplicits._
 import coop.rchain.node.api.WebApi._
-import org.scalatest.wordspec.AnyWordSpec
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class RhoExprToParSpec extends AnyWordSpec with Matchers {
+class RhoExprToParSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+
   private def roundTripTest(expr: RhoExpr): Option[RhoExpr] =
     exprFromParProto(rhoExprToParProto(expr))
 
-  "WebAPI RhoExpr <-> Par conversion" should {
-    "work correct with simple types" in {
-      roundTripTest(ExprBool(true)).collect { case ExprBool(data)            => data } shouldBe true.some
-      roundTripTest(ExprInt(42)).collect { case ExprInt(data)                => data } shouldBe 42.some
-      roundTripTest(ExprString("abc")).collect { case ExprString(data)       => data } shouldBe "abc".some
-      roundTripTest(ExprUri("http://test.com")).collect { case ExprUri(data) => data } shouldBe "http://test.com".some
+  // Simple types
 
-      val bytesAsString = ByteString.copyFrom(Array[Byte](1, 2, 3)).toHexString
-      roundTripTest(ExprBytes(bytesAsString)).collect { case ExprBytes(data) => data } shouldBe bytesAsString.some
-      roundTripTest(ExprUnforg(UnforgDeploy(bytesAsString))).collect {
-        case ExprUnforg(data) => data
-      } shouldBe UnforgDeploy(
-        bytesAsString
-      ).some
+  property("WebAPI ExprBool <-> Par conversion work correct") {
+    forAll { b: Boolean =>
+      roundTripTest(ExprBool(b)).collect { case ExprBool(data) => data } shouldBe b.some
     }
-    "work correct with nested types" in {
-      val listExpr = List[RhoExpr](ExprBool(true), ExprInt(42))
-      roundTripTest(ExprPar(listExpr)).collect { case ExprPar(data)     => data } shouldBe listExpr.some
-      roundTripTest(ExprTuple(listExpr)).collect { case ExprTuple(data) => data } shouldBe listExpr.some
-      roundTripTest(ExprList(listExpr)).collect { case ExprList(data)   => data } shouldBe listExpr.some
-      roundTripTest(ExprSet(listExpr)).collect { case ExprSet(data)     => data } shouldBe listExpr.some
+  }
 
-      val mapExpr =
-        Map[String, RhoExpr]("a" -> ExprBool(true), "b" -> ExprInt(42), "c" -> ExprList(listExpr))
+  property("WebAPI ExprInt <-> Par conversion work correct") {
+    forAll { i: Long =>
+      roundTripTest(ExprInt(i)).collect { case ExprInt(data) => data } shouldBe i.some
+    }
+  }
+
+  property("WebAPI ExprString <-> Par conversion work correct") {
+    forAll { s: String =>
+      roundTripTest(ExprString(s)).collect { case ExprString(data) => data } shouldBe s.some
+    }
+  }
+
+  property("WebAPI ExprUri <-> Par conversion work correct") {
+    forAll { uri: String =>
+      roundTripTest(ExprUri(uri)).collect { case ExprUri(data) => data } shouldBe uri.some
+    }
+  }
+
+  property("WebAPI ExprUnforg <-> Par conversion work correct") {
+    forAll { bs: ByteString =>
+      roundTripTest(ExprBytes(bs.toHexString)).collect { case ExprBytes(data) => data } shouldBe bs.toHexString.some
+    }
+  }
+
+  property("WebAPI ExprBytes <-> Par conversion work correct") {
+    forAll { bs: ByteString =>
+      roundTripTest(ExprUnforg(UnforgDeploy(bs.toHexString))).collect {
+        case ExprUnforg(data) => data
+      } shouldBe UnforgDeploy(bs.toHexString).some
+    }
+  }
+
+  // Nested types
+
+  implicit val listRhoExprArb: Arbitrary[List[RhoExpr]] = Arbitrary(
+    for {
+      bool <- arbBool.arbitrary
+      long <- arbLong.arbitrary
+      str  <- arbString.arbitrary
+      uri  <- arbString.arbitrary
+      bs   <- arbByteArray.arbitrary
+    } yield List[RhoExpr](
+      ExprBool(bool),
+      ExprInt(long),
+      ExprString(str),
+      ExprUri(uri),
+      ExprBytes(bs.toHexString)
+    )
+  )
+
+  property("WebAPI ExprPar <-> Par conversion work correct") {
+    forAll { listExpr: List[RhoExpr] =>
+      roundTripTest(ExprPar(listExpr)).collect { case ExprPar(data) => data } shouldBe listExpr.some
+    }
+  }
+
+  property("WebAPI ExprTuple <-> Par conversion work correct") {
+    forAll { listExpr: List[RhoExpr] =>
+      roundTripTest(ExprTuple(listExpr)).collect { case ExprTuple(data) => data } shouldBe listExpr.some
+    }
+  }
+
+  property("WebAPI ExprList <-> Par conversion work correct") {
+    forAll { listExpr: List[RhoExpr] =>
+      roundTripTest(ExprList(listExpr)).collect { case ExprList(data) => data } shouldBe listExpr.some
+    }
+  }
+
+  property("WebAPI ExprSet <-> Par conversion work correct") {
+    forAll { listExpr: List[RhoExpr] =>
+      roundTripTest(ExprSet(listExpr)).collect { case ExprSet(data) => data } shouldBe listExpr.some
+    }
+  }
+
+  implicit val mapRhoExprArb: Arbitrary[Map[String, RhoExpr]] = Arbitrary(
+    for {
+      bool <- arbBool.arbitrary
+      long <- arbLong.arbitrary
+      str  <- arbString.arbitrary
+      uri  <- arbString.arbitrary
+      bs   <- arbByteArray.arbitrary
+      list <- listRhoExprArb.arbitrary
+      keys = (1 to 6).map(_ => arbString.arbitrary.sample.get)
+    } yield Map[String, RhoExpr](
+      keys(0) -> ExprBool(bool),
+      keys(1) -> ExprInt(long),
+      keys(2) -> ExprString(str),
+      keys(3) -> ExprUri(uri),
+      keys(4) -> ExprBytes(bs.toHexString),
+      keys(5) -> ExprList(list)
+    )
+  )
+
+  property("WebAPI ExprMap <-> Par conversion work correct") {
+    forAll { mapExpr: Map[String, RhoExpr] =>
       roundTripTest(ExprMap(mapExpr)).collect { case ExprMap(data) => data } shouldBe mapExpr.some
     }
   }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
@@ -161,9 +161,7 @@ object RhoType {
       }
 
     def apply(gprivate: GPrivate): Par         = GUnforgeable(GPrivateBody(gprivate))
-
-    def apply(gprivateBytes: Array[Byte]): Par = apply(GPrivate(ByteString.copyFrom(gprivateBytes)))
-
+    def apply(gprivateBytes: Array[Byte]): Par = apply(ByteString.copyFrom(gprivateBytes))
     def apply(gprivateBytes: ByteString): Par  = apply(GPrivate(gprivateBytes))
   }
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
@@ -79,6 +79,36 @@ object RhoType {
     def apply(s: String): Par = GUri(s)
   }
 
+  type RhoList = List.type
+  object RhoList {
+    def unapply(p: Par): Option[List[Par]] =
+      p.singleExpr().collect {
+        case Expr(EListBody(EList(s, _, _, _))) => s.toList
+      }
+
+    def apply(s: List[Par]): Par = EListBody(EList(s))
+  }
+
+  type RhoSet = Set.type
+  object RhoSet {
+    def unapply(p: Par): Option[Set[Par]] =
+      p.singleExpr().collect {
+        case Expr(ESetBody(ParSet(s, _, _, _))) => s.toSet
+      }
+
+    def apply(s: Seq[Par]): Par = ESetBody(ParSet(s))
+  }
+
+  type RhoMap = Map.type
+  object RhoMap {
+    def unapply(p: Par): Option[Map[Par, Par]] =
+      p.singleExpr().collect {
+        case Expr(EMapBody(ParMap(s, _, _, _))) => s.toMap
+      }
+
+    def apply(s: Map[Par, Par]): Par = EMapBody(ParMap(s.toSeq))
+  }
+
   type RhoDeployerId = DeployerId.type
   object DeployerId {
     def unapply(p: Par): Option[Array[Byte]] =

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
@@ -41,7 +41,7 @@ object RhoType {
 
   type RhoBoolean = Boolean.type
   object Boolean {
-    def apply(b: Boolean) = Expr(GBool(b))
+    def apply(b: Boolean): Par = Expr(GBool(b))
 
     def unapply(p: Par): Option[Boolean] =
       p.singleExpr().collect {

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RhoType.scala
@@ -80,7 +80,7 @@ object RhoType {
   }
 
   type RhoList = List.type
-  object RhoList {
+  object List {
     def unapply(p: Par): Option[List[Par]] =
       p.singleExpr().collect {
         case Expr(EListBody(EList(s, _, _, _))) => s.toList
@@ -90,7 +90,7 @@ object RhoType {
   }
 
   type RhoSet = Set.type
-  object RhoSet {
+  object Set {
     def unapply(p: Par): Option[Set[Par]] =
       p.singleExpr().collect {
         case Expr(ESetBody(ParSet(s, _, _, _))) => s.toSet
@@ -100,7 +100,7 @@ object RhoType {
   }
 
   type RhoMap = Map.type
-  object RhoMap {
+  object Map {
     def unapply(p: Par): Option[Map[Par, Par]] =
       p.singleExpr().collect {
         case Expr(EMapBody(ParMap(s, _, _, _))) => s.toMap


### PR DESCRIPTION
## Overview

Changed the `name` field type in the `DataAtNameByBlockHashRequest` class from `RhoUnforg` to `RhoExpr` to match the request with `getDataAtPar` in gRPC.

### Note

We don't have integration test for request `data-at-name-by-block-hash`. Lets consider to add it.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
