### PR TITLE
Upgraded scalatest, scalactic and scalacheck to the versions 3.2.10, 3.2.10 and 1.15 respectively

### DIFF
--- a/block-storage/src/test/scala/coop/rchain/blockstorage/casperbuffer/CasperBufferStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/casperbuffer/CasperBufferStorageTest.scala
@@ -7,12 +7,13 @@ import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.Log.NOPLog
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import monix.execution.Scheduler.Implicits.global
 import coop.rchain.shared.syntax._
 import coop.rchain.models.blockImplicits._
 
-class CasperBufferStorageTest extends FlatSpecLike with Matchers {
+class CasperBufferStorageTest extends AnyFlatSpecLike with Matchers {
 
   implicit val log     = new NOPLog[Task]()
   implicit val metrics = new Metrics.MetricsNOP[Task]

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -9,14 +9,14 @@ import coop.rchain.models.blockImplicits._
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 trait BlockDagStorageTest
     extends FlatSpecLike
     with Matchers
     with OptionValues
     with EitherValues
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with BeforeAndAfterAll {
   val scheduler = Scheduler.fixedPool("block-dag-storage-test-scheduler", 4)
 

--- a/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
+++ b/block-storage/src/test/scala/coop/rchain/blockstorage/dag/BlockDagStorageTest.scala
@@ -9,10 +9,12 @@ import coop.rchain.models.blockImplicits._
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 trait BlockDagStorageTest
-    extends FlatSpecLike
+    extends AnyFlatSpecLike
     with Matchers
     with OptionValues
     with EitherValues

--- a/casper/src/slowcooker/scala/coop.rchain.casper/MergingBenchmarkSpec.scala
+++ b/casper/src/slowcooker/scala/coop.rchain.casper/MergingBenchmarkSpec.scala
@@ -3,9 +3,9 @@ package coop.rchain.casper
 import coop.rchain.casper.merging.DeployChainIndex
 import coop.rchain.rspace.merger.EventLogMergingLogic.computeRejectionOptions
 import coop.rchain.shared.Stopwatch
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class MergingBenchmarkSpec extends FlatSpec {
+class MergingBenchmarkSpec extends AnyFlatSpec {
   "rejections option benchmark" should "for DeplyChainIndex" in {
     def conflictsMap[A](conflictingPairs: Set[List[A]]): Map[A, Set[A]] =
       conflictingPairs.foldLeft(Map.empty[A, Set[A]]) {

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -23,11 +23,13 @@ import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.shared.syntax._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable
 
-class MultiParentCasperAddBlockSpec extends FlatSpec with Matchers with Inspectors {
+class MultiParentCasperAddBlockSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import InvalidBlock._
   import RSpaceUtil._

--- a/casper/src/test/scala/coop/rchain/casper/addblock/ProposerSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/ProposerSpec.scala
@@ -16,9 +16,10 @@ import coop.rchain.shared.Log
 import coop.rchain.shared.scalatestcontrib._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ProposerSpec extends FlatSpec with Matchers with BlockDagStorageFixture {
+class ProposerSpec extends AnyFlatSpec with Matchers with BlockDagStorageFixture {
 
   /** declarations of input functions for proposer */
   def getCasperSnapshotF[F[_]: Applicative]: F[CasperSnapshot] =

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -22,9 +22,11 @@ import coop.rchain.store.InMemoryKeyValueStore
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class BlockQueryResponseAPITest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with Inside
     with BlockDagStorageFixture

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -15,13 +15,14 @@ import coop.rchain.shared.Log
 import coop.rchain.store.InMemoryKeyValueStore
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.HashMap
 
 // See [[/docs/casper/images/no_finalizable_block_mistake_with_no_disagreement_check.png]]
 class BlocksResponseAPITest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with BlockGenerator
     with BlockDagStorageFixture

--- a/casper/src/test/scala/coop/rchain/casper/api/BondedStatusAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BondedStatusAPITest.scala
@@ -15,10 +15,12 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.shared.scalatestcontrib._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class BondedStatusAPITest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with EitherValues
     with BlockGenerator
@@ -39,7 +41,7 @@ class BondedStatusAPITest
       blockApi <- createBlockApi(node)
       res <- blockApi
               .bondStatus(ByteString.copyFrom(publicKey.bytes), block.some)
-              .map(_.right.value)
+              .map(_.value)
     } yield res
 
   "bondStatus" should "return true for bonded validator" in effectTest {

--- a/casper/src/test/scala/coop/rchain/casper/api/ExploratoryDeployAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ExploratoryDeployAPITest.scala
@@ -15,10 +15,12 @@ import coop.rchain.models.syntax._
 import coop.rchain.shared.scalatestcontrib.effectTest
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class ExploratoryDeployAPITest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with EitherValues
     with BlockGenerator
@@ -68,7 +70,7 @@ class ExploratoryDeployAPITest
                      "new return in { for (@data <- @\"store\") {return!(data)}}",
                      b2.blockHash
                    )
-          (par, b) = result.right.value
+          (par, b) = result.value
           _        = b.blockHash shouldBe PrettyPrinter.buildStringNoLimit(b2.blockHash)
           _ = par match {
             case Seq(Par(_, _, _, Seq(expr), _, _, _, _, _, _)) =>

--- a/casper/src/test/scala/coop/rchain/casper/api/LastFinalizedAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/LastFinalizedAPITest.scala
@@ -11,11 +11,13 @@ import coop.rchain.models.syntax._
 import coop.rchain.shared.scalatestcontrib._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 // TODO finalizer test for multiparent
 class LastFinalizedAPITest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with EitherValues
     with BlockGenerator
@@ -30,7 +32,7 @@ class LastFinalizedAPITest
     for {
       blockApi <- createBlockApi(node)
       res      <- blockApi.isFinalized(block.blockHash.toHexString)
-    } yield res.right.value
+    } yield res.value
 
   /*
    * DAG Looks like this:

--- a/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/ListeningNameAPITest.scala
@@ -12,8 +12,10 @@ import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ListeningNameAPITest extends FlatSpec with Matchers with Inside with BlockApiFixture {
+class ListeningNameAPITest extends AnyFlatSpec with Matchers with Inside with BlockApiFixture {
 
   import GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/api/MachineVerifiableDagSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/MachineVerifiableDagSpec.scala
@@ -6,9 +6,10 @@ import coop.rchain.models.BlockHash.BlockHash
 
 import coop.rchain.models.syntax._
 import cats._, cats.syntax.all._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class MachineVerifiableDagSpec extends FunSpec with Matchers {
+class MachineVerifiableDagSpec extends AnyFunSpec with Matchers {
 
   import VerifiableEdge._
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperBondingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperBondingSpec.scala
@@ -1,8 +1,10 @@
 package coop.rchain.casper.batch1
 
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class MultiParentCasperBondingSpec extends FlatSpec with Matchers with Inspectors {
+class MultiParentCasperBondingSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   //TODO rewrite this test for the new PoS
   "MultiParentCasper" should "allow bonding" ignore {}

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperCommunicationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperCommunicationSpec.scala
@@ -9,9 +9,11 @@ import coop.rchain.crypto.signatures.Signed
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class MultiParentCasperCommunicationSpec extends FlatSpec with Matchers with Inspectors {
+class MultiParentCasperCommunicationSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import coop.rchain.casper.util.GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
@@ -7,10 +7,12 @@ import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
 class MultiParentCasperDeploySpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with Inspectors
     with BlockApiFixture {

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperFinalizationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperFinalizationSpec.scala
@@ -8,10 +8,12 @@ import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
 // TODO consider adjusting or removing when new finalizer test is implemented
-class MultiParentCasperFinalizationSpec extends FlatSpec with Matchers with Inspectors {
+class MultiParentCasperFinalizationSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import coop.rchain.casper.util.GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperMergeSpec.scala
@@ -7,11 +7,13 @@ import coop.rchain.casper.util.{ConstructDeploy, RSpaceUtil}
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 import coop.rchain.blockstorage.syntax._
 import monix.eval.Task
 
-class MultiParentCasperMergeSpec extends FlatSpec with Matchers with Inspectors {
+class MultiParentCasperMergeSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import RSpaceUtil._
   import coop.rchain.casper.util.GenesisBuilder._

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperReportingSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperReportingSpec.scala
@@ -13,9 +13,11 @@ import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.store.InMemoryStoreManager
 import coop.rchain.rspace.syntax._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class MultiParentCasperReportingSpec extends FlatSpec with Matchers with Inspectors {
+class MultiParentCasperReportingSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import coop.rchain.casper.util.GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperRholangSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperRholangSpec.scala
@@ -9,9 +9,11 @@ import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.Base16
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class MultiParentCasperRholangSpec extends FlatSpec with Matchers with Inspectors {
+class MultiParentCasperRholangSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import RSpaceUtil._
   import coop.rchain.casper.util.GenesisBuilder._

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperSmokeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperSmokeSpec.scala
@@ -7,9 +7,11 @@ import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class MultiParentCasperSmokeSpec extends FlatSpec with Matchers with Inspectors {
+class MultiParentCasperSmokeSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import coop.rchain.casper.util.GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/batch2/LimitedParentDepthSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LimitedParentDepthSpec.scala
@@ -8,9 +8,10 @@ import coop.rchain.casper.util.GenesisBuilder.buildGenesis
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import monix.eval.Task
 import monix.execution.Scheduler
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class LimitedParentDepthSpec extends FlatSpec with Matchers {
+class LimitedParentDepthSpec extends AnyFlatSpec with Matchers {
   implicit val scheduler = Scheduler.fixedPool("limited-parent-depth-scheduler", 2)
   implicit val timeEff   = new LogicalTime[Task]
 

--- a/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
@@ -9,13 +9,15 @@ import coop.rchain.store.{KeyValueStoreSut, LmdbStoreManager}
 import monix.eval.Task
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.reflect.io.{Directory, Path}
 import scala.util.Random
 
 class LmdbKeyValueStoreSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks
     with BeforeAndAfterAll {

--- a/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
@@ -8,10 +8,10 @@ import coop.rchain.shared.Log
 import coop.rchain.store.{KeyValueStoreSut, LmdbStoreManager}
 import monix.eval.Task
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.reflect.io.{Directory, Path}
 import scala.util.Random

--- a/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
@@ -8,7 +8,7 @@ import coop.rchain.shared.Log
 import coop.rchain.store.{KeyValueStoreSut, LmdbStoreManager}
 import monix.eval.Task
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 
 import scala.reflect.io.{Directory, Path}
@@ -17,7 +17,7 @@ import scala.util.Random
 class LmdbKeyValueStoreSpec
     extends FlatSpec
     with Matchers
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with BeforeAndAfterAll {
   implicit val scheduler = monix.execution.Scheduler.global
 

--- a/casper/src/test/scala/coop/rchain/casper/batch2/RholangBuildTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/RholangBuildTest.scala
@@ -12,9 +12,10 @@ import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.shared.{Base16, RChainScheduler}
 import coop.rchain.shared.scalatestcontrib._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RholangBuildTest extends FlatSpec with Matchers {
+class RholangBuildTest extends AnyFlatSpec with Matchers {
 
   implicit val scheduler = RChainScheduler.interpreterScheduler
   val genesis            = buildGenesis()

--- a/casper/src/test/scala/coop/rchain/casper/batch2/SingleParentCasperSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/SingleParentCasperSpec.scala
@@ -10,10 +10,12 @@ import coop.rchain.crypto.signatures.Signed
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib.effectTest
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
 // TODO Reenable after new finalizer is implemented.
-class SingleParentCasperSpec extends FlatSpec with Matchers with Inspectors {
+class SingleParentCasperSpec extends AnyFlatSpec with Matchers with Inspectors {
   implicit val timeEff = new LogicalTime[Effect]
 
   val genesis = buildGenesis()

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -32,12 +32,14 @@ import coop.rchain.shared.syntax._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.Files
 import scala.collection.immutable.HashMap
 
 class ValidateTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with BeforeAndAfterEach
     with BlockGenerator

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterEffectsSpec.scala
@@ -14,11 +14,12 @@ import coop.rchain.shared.{Log, Time}
 import fs2.Stream
 import fs2.concurrent.Queue
 import monix.eval.Task
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class LfsBlockRequesterEffectsSpec extends FlatSpec with Matchers with Fs2StreamMatchers {
+class LfsBlockRequesterEffectsSpec extends AnyFlatSpec with Matchers with Fs2StreamMatchers {
 
   def mkHash(s: String) = ByteString.copyFromUtf8(s)
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterStateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterStateSpec.scala
@@ -3,10 +3,11 @@ package coop.rchain.casper.engine
 import cats.syntax.all._
 import coop.rchain.casper.engine.LfsBlockRequester.{ReceiveInfo, ST}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class LfsBlockRequesterStateSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks {
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterStateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterStateSpec.scala
@@ -2,9 +2,9 @@ package coop.rchain.casper.engine
 
 import cats.syntax.all._
 import coop.rchain.casper.engine.LfsBlockRequester.{ReceiveInfo, ST}
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class LfsBlockRequesterStateSpec
     extends AnyFlatSpec

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterStateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsBlockRequesterStateSpec.scala
@@ -2,10 +2,13 @@ package coop.rchain.casper.engine
 
 import cats.syntax.all._
 import coop.rchain.casper.engine.LfsBlockRequester.{ReceiveInfo, ST}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
-class LfsBlockRequesterStateSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+class LfsBlockRequesterStateSpec
+    extends FlatSpec
+    with Matchers
+    with ScalaCheckDrivenPropertyChecks {
 
   "getNext" should "return empty list when called again" in {
     val st = ST(Set(10))

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterEffectsSpec.scala
@@ -14,13 +14,14 @@ import coop.rchain.shared.{Log, Time}
 import fs2.Stream
 import fs2.concurrent.Queue
 import monix.eval.Task
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.bits.ByteVector
 
 import java.nio.ByteBuffer
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-class LfsStateRequesterEffectsSpec extends FlatSpec with Matchers with Fs2StreamMatchers {
+class LfsStateRequesterEffectsSpec extends AnyFlatSpec with Matchers with Fs2StreamMatchers {
 
   def createApprovedBlock(block: BlockMessage): ApprovedBlock = ApprovedBlock(block)
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterStateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterStateSpec.scala
@@ -1,9 +1,9 @@
 package coop.rchain.casper.engine
 
 import coop.rchain.casper.engine.LfsTupleSpaceRequester.ST
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class LfsStateRequesterStateSpec
     extends AnyFlatSpec

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterStateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterStateSpec.scala
@@ -2,10 +2,11 @@ package coop.rchain.casper.engine
 
 import coop.rchain.casper.engine.LfsTupleSpaceRequester.ST
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class LfsStateRequesterStateSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ScalaCheckDrivenPropertyChecks {
 

--- a/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterStateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/LfsStateRequesterStateSpec.scala
@@ -1,10 +1,13 @@
 package coop.rchain.casper.engine
 
 import coop.rchain.casper.engine.LfsTupleSpaceRequester.ST
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
-class LfsStateRequesterStateSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+class LfsStateRequesterStateSpec
+    extends FlatSpec
+    with Matchers
+    with ScalaCheckDrivenPropertyChecks {
 
   "getNext" should "return empty list when called again" in {
     val st = ST(Seq(10))

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockRequestSpec.scala
@@ -13,9 +13,11 @@ import coop.rchain.models.BlockHash.BlockHash
 import com.google.protobuf.ByteString
 import coop.rchain.p2p.EffectsTestInstances
 import monix.eval.Coeval
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class RunningHandleHasBlockRequestSpec extends FunSpec with BeforeAndAfterEach with Matchers {
+class RunningHandleHasBlockRequestSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 
   val hash = ByteString.copyFrom("hash", "UTF-8")
   val hbr  = HasBlockRequest(hash)

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockSpec.scala
@@ -27,11 +27,13 @@ import coop.rchain.casper.engine.NodeRunning.{
 import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
 import coop.rchain.metrics.Metrics
 import monix.eval.Task
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import monix.execution.Scheduler.Implicits.global
 import cats.syntax.all._
 
-class RunningHandleHasBlockSpec extends FunSpec with BeforeAndAfterEach with Matchers {
+class RunningHandleHasBlockSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 
   val local: PeerNode = peerNode("src", 40400)
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/AuthKeyUpdateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/AuthKeyUpdateSpec.scala
@@ -13,11 +13,13 @@ import coop.rchain.rholang.interpreter.RhoType.{Boolean, String, Tuple2}
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source
 
-class AuthKeyUpdateSpec extends FlatSpec with Matchers with Inspectors {
+class AuthKeyUpdateSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import coop.rchain.casper.util.GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -24,12 +24,14 @@ import coop.rchain.shared.Time
 import coop.rchain.shared.syntax._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{EitherValues, FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.io.PrintWriter
 import java.nio.file.{Files, Path}
 
-class GenesisTest extends FlatSpec with Matchers with EitherValues with BlockDagStorageFixture {
+class GenesisTest extends AnyFlatSpec with Matchers with EitherValues with BlockDagStorageFixture {
   import GenesisTest._
 
   implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]

--- a/casper/src/test/scala/coop/rchain/casper/genesis/PosMultiSigTransferSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/PosMultiSigTransferSpec.scala
@@ -13,9 +13,11 @@ import coop.rchain.models.syntax._
 import coop.rchain.rholang.build.CompiledRholangTemplate
 import coop.rchain.rholang.interpreter.util.RevAddress
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class PosMultiSigTransferSpec extends FlatSpec with Matchers with Inspectors {
+class PosMultiSigTransferSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import coop.rchain.casper.util.GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/PosUpdateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/PosUpdateSpec.scala
@@ -15,11 +15,13 @@ import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.Inside.inside
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source
 
-class PosUpdateSpec extends FlatSpec with Matchers with Inspectors {
+class PosUpdateSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import coop.rchain.casper.util.GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/RegistryUpdateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/RegistryUpdateSpec.scala
@@ -11,11 +11,13 @@ import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.models.syntax._
 import coop.rchain.rholang.interpreter.util.RevAddress
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source
 
-class RegistryUpdateSpec extends FlatSpec with Matchers with Inspectors {
+class RegistryUpdateSpec extends AnyFlatSpec with Matchers with Inspectors {
 
   import coop.rchain.casper.util.GenesisBuilder._
 

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/FailingResultCollectorSpec.scala
@@ -7,11 +7,13 @@ import coop.rchain.casper.helper.{
 }
 import coop.rchain.models.NormalizerEnv
 import coop.rchain.rholang.build.CompiledRholangSource
-import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+import org.scalatest.AppendedClues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class FailingResultCollectorSpec extends FlatSpec with AppendedClues with Matchers {
+class FailingResultCollectorSpec extends AnyFlatSpec with AppendedClues with Matchers {
   def clue(clueMsg: String, attempt: Long) = s"$clueMsg (attempt $attempt)"
   def mkTest(test: (String, Map[Long, List[RhoTestAssertion]])): Unit =
     test match {

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/RevIssuanceTest.scala
@@ -1,8 +1,9 @@
 package coop.rchain.casper.genesis.contracts
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RevIssuanceTest extends FlatSpec with Matchers {
+class RevIssuanceTest extends AnyFlatSpec with Matchers {
 
   "Rev" should "be issued and accessible based on inputs from Ethereum" ignore {
     // See https://github.com/rchain/rchain/pull/2424#pullrequestreview-238775320 for reimplementation guidance

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/StandardDeploysSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/StandardDeploysSpec.scala
@@ -1,9 +1,9 @@
 package coop.rchain.casper.genesis.contracts
 
 import coop.rchain.shared.Base16
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class StandardDeploysSpec extends FlatSpec {
+class StandardDeploysSpec extends AnyFlatSpec {
   it should "print public keys used for signing standard (blessed) contracts" in {
     println(s"Public keys used to sign standard (blessed) contracts")
     println(s"=====================================================")

--- a/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/contracts/TimeoutResultCollectorSpec.scala
@@ -2,12 +2,14 @@ package coop.rchain.casper.genesis.contracts
 import coop.rchain.casper.helper.RhoSpec
 import coop.rchain.models.NormalizerEnv
 import coop.rchain.rholang.build.CompiledRholangSource
-import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+import org.scalatest.AppendedClues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import monix.execution.Scheduler.Implicits.global
 
-class TimeoutResultCollectorSpec extends FlatSpec with AppendedClues with Matchers {
+class TimeoutResultCollectorSpec extends AnyFlatSpec with AppendedClues with Matchers {
   it should "testFinished should be false if execution hasn't finished within timeout" in {
     new RhoSpec(
       CompiledRholangSource("TimeoutResultCollectorTest.rho", NormalizerEnv.Empty),

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -22,7 +22,9 @@ import coop.rchain.rspace.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{AppendedClues, FlatSpec, Matchers}
+import org.scalatest.AppendedClues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
@@ -31,7 +33,7 @@ class RhoSpec(
     extraNonGenesisDeploys: Seq[Signed[DeployData]],
     executionTimeout: FiniteDuration,
     genesisParameters: GenesisParameters = GenesisBuilder.buildGenesisParameters()
-) extends FlatSpec
+) extends AnyFlatSpec
     with AppendedClues
     with Matchers {
 

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -30,12 +30,12 @@ import coop.rchain.shared.Log
 import coop.rchain.shared.scalatestcontrib._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import scodec.bits.ByteVector
 
 final case class DeployTestInfo(term: String, cost: Long, sig: String)
 
-class MergeNumberChannelSpec extends FlatSpec {
+class MergeNumberChannelSpec extends AnyFlatSpec {
 
   val rhoST = """
                 |new MergeableTag, stCh  in {

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
@@ -17,9 +17,10 @@ import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.shared.{Log, Time}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MergingCases extends FlatSpec with Matchers {
+class MergingCases extends AnyFlatSpec with Matchers {
 
   val genesisContext             = GenesisBuilder.buildGenesis(validatorsNum = 5)
   val genesis                    = genesisContext.genesisBlock

--- a/casper/src/test/scala/coop/rchain/casper/rholang/DeployIdTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/DeployIdTest.scala
@@ -16,11 +16,12 @@ import coop.rchain.shared.Log
 import coop.rchain.shared.scalatestcontrib._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class DeployIdTest extends FlatSpec with Matchers {
+class DeployIdTest extends AnyFlatSpec with Matchers {
   implicit val log: Log[Task] = new Log.NOPLog[Task]()
 
   private val runtimeManager: Resource[Task, RuntimeManager[Task]] =

--- a/casper/src/test/scala/coop/rchain/casper/rholang/DeployerIdTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/DeployerIdTest.scala
@@ -16,9 +16,10 @@ import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.shared.{Base16, Log}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeployerIdTest extends FlatSpec with Matchers {
+class DeployerIdTest extends AnyFlatSpec with Matchers {
   implicit val time           = new LogicalTime[Task]
   implicit val log: Log[Task] = new Log.NOPLog[Task]()
 

--- a/casper/src/test/scala/coop/rchain/casper/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/InterpreterUtilTest.scala
@@ -26,12 +26,13 @@ import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.shared.{Log, LogSource, Time}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration.FiniteDuration
 
 class InterpreterUtilTest
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with BlockGenerator
     with BlockDagStorageFixture {

--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeManagerTest.scala
@@ -32,7 +32,8 @@ import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.shared.{Base16, Log, Time}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -52,7 +53,7 @@ object SystemDeployReplayResult {
     ReplayFailed(systemDeployError)
 }
 
-class RuntimeManagerTest extends FlatSpec with Matchers {
+class RuntimeManagerTest extends AnyFlatSpec with Matchers {
 
   implicit val timeF: Time[Task]         = new LogicalTime[Task]
   implicit val log: Log[Task]            = Log.log[Task]

--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
@@ -12,9 +12,10 @@ import coop.rchain.shared.Log
 import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RuntimeSpec extends FlatSpec with Matchers {
+class RuntimeSpec extends AnyFlatSpec with Matchers {
   import monix.execution.Scheduler.Implicits.global
 
   "emptyStateHash" should "be the same as hard-coded cached value" in effectTest {

--- a/casper/src/test/scala/coop/rchain/casper/rholang/SysAuthTokenTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/SysAuthTokenTest.scala
@@ -1,8 +1,9 @@
 package coop.rchain.casper.rholang
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SysAuthTokenTest extends FlatSpec with Matchers {
+class SysAuthTokenTest extends AnyFlatSpec with Matchers {
   "SysAuthToken" should "be accessible from "
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverRequesAllSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverRequesAllSpec.scala
@@ -25,12 +25,14 @@ import coop.rchain.p2p.EffectsTestInstances.{
 }
 import coop.rchain.shared._
 import monix.eval.Task
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import monix.execution.Scheduler.Implicits.global
 
 import scala.concurrent.duration._
 
-class BlockRetrieverRequestAllSpec extends FunSpec with BeforeAndAfterEach with Matchers {
+class BlockRetrieverRequestAllSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 
   object testReason extends BlockRetriever.AdmitHashReason
 

--- a/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverSpec.scala
@@ -7,7 +7,9 @@ import coop.rchain.casper.engine.Setup.peerNode
 import coop.rchain.casper.engine.BlockRetriever
 import coop.rchain.casper.engine.BlockRetriever.RequestState
 import coop.rchain.casper.protocol.{CommUtil, HasBlockRequest, PacketTypeTag}
-import org.scalatest.{BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import coop.rchain.catscontrib.TaskContrib._
 import monix.execution.Scheduler.Implicits.global
 import coop.rchain.casper.protocol._
@@ -24,7 +26,7 @@ import coop.rchain.p2p.EffectsTestInstances.{createRPConfAsk, LogStub, Transport
 import coop.rchain.shared.Cell
 import monix.eval.Task
 
-class BlockRetrieverSpec extends FunSpec with BeforeAndAfterEach with Matchers {
+class BlockRetrieverSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 
   object testReason extends BlockRetriever.AdmitHashReason
 

--- a/casper/src/test/scala/coop/rchain/casper/util/DeployValidationSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/DeployValidationSpec.scala
@@ -3,9 +3,10 @@ package coop.rchain.casper.util
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.{DeployData, DeployDataProto}
 import coop.rchain.crypto.signatures._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeployValidationSpec extends FlatSpec with Matchers {
+class DeployValidationSpec extends AnyFlatSpec with Matchers {
   private val SHARD_ID = "root-shard"
 
   def createFromDeployDataProto(alg: SignaturesAlg) = {

--- a/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
@@ -8,10 +8,11 @@ import coop.rchain.models.blockImplicits._
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ProtoUtilTest extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class ProtoUtilTest extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   "dependenciesHashesOf" should "return hashes of all justifications and parents of a block" in {
     forAll(blockElementGen()) { blockElement =>

--- a/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/ProtoUtilTest.scala
@@ -9,9 +9,9 @@ import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class ProtoUtilTest extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+class ProtoUtilTest extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   "dependenciesHashesOf" should "return hashes of all justifications and parents of a block" in {
     forAll(blockElementGen()) { blockElement =>

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CommUtilSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CommUtilSpec.scala
@@ -17,9 +17,11 @@ import coop.rchain.p2p.EffectsTestInstances.{LogStub, LogicalTime, TransportLaye
 import coop.rchain.shared._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class CommUtilSpec extends FunSpec with BeforeAndAfterEach with Matchers {
+class CommUtilSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 
   // TODO this is testing how CommUtil manipulates RequestedBlocks,
   //  is not a valid test anymore with introduction of BlockRetriever and us moving towards more use of TransportLayer.

--- a/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/DistanceSpec.scala
@@ -5,11 +5,12 @@ import cats.{catsInstancesForId => _, _}
 import coop.rchain.catscontrib.effect.implicits._
 import coop.rchain.comm._
 import coop.rchain.shared.Base16
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Random
 
-class DistanceSpec extends FlatSpec with Matchers {
+class DistanceSpec extends AnyFlatSpec with Matchers {
   private def randBytes(nbytes: Int): Array[Byte] = {
     val arr = Array.fill(nbytes)(0.toByte)
     Random.nextBytes(arr)

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaRPCSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaRPCSpec.scala
@@ -8,11 +8,12 @@ import cats.syntax.all._
 
 import coop.rchain.comm.{NodeIdentifier, PeerNode}
 
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
     extends KademliaRPCRuntime[F, E]
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers {
 
   val kademliaRpcName: String = this.getClass.getSimpleName.replace("Spec", "")

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaSpec.scala
@@ -7,9 +7,11 @@ import cats.Id
 import coop.rchain.catscontrib.effect.implicits._
 import coop.rchain.comm._
 
-import org.scalatest._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class KademliaSpec extends FunSpec with Matchers with BeforeAndAfterEach {
+class KademliaSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
   val local = createPeer("00000001")
   val peer0 = createPeer("00000010")
   val peer1 = createPeer("00001000")

--- a/comm/src/test/scala/coop/rchain/comm/discovery/PeerTableSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/PeerTableSpec.scala
@@ -8,8 +8,10 @@ import coop.rchain.catscontrib.effect.implicits._
 import coop.rchain.comm._
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PeerTableSpec extends FlatSpec with Matchers with Inside {
+class PeerTableSpec extends AnyFlatSpec with Matchers with Inside {
   val addressWidth = 8
   val endpoint     = Endpoint("", 0, 0)
   val home         = PeerNode(NodeIdentifier(randBytes(addressWidth)), endpoint)

--- a/comm/src/test/scala/coop/rchain/comm/rp/ClearConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/ClearConnectionsSpec.scala
@@ -17,9 +17,11 @@ import coop.rchain.p2p.EffectsTestInstances.{LogicalTime, TransportLayerStub}
 import coop.rchain.shared._
 
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 class ClearConnectionsSpec
-    extends FunSpec
+    extends AnyFunSpec
     with Matchers
     with BeforeAndAfterEach
     with AppendedClues {

--- a/comm/src/test/scala/coop/rchain/comm/rp/ConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/ConnectSpec.scala
@@ -1,7 +1,6 @@
 package coop.rchain.comm.rp
 
 import cats.{catsInstancesForId => _, _}
-import coop.rchain.catscontrib._
 import coop.rchain.catscontrib.effect.implicits._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm.CommError._
@@ -12,11 +11,11 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.shared._
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
 class ConnectSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
 
   val defaultTimeout: FiniteDuration = FiniteDuration(1, MILLISECONDS)

--- a/comm/src/test/scala/coop/rchain/comm/rp/ConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/ConnectSpec.scala
@@ -15,7 +15,9 @@ import org.scalatest._
 
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 
-class ConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+class ConnectSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
 
   val defaultTimeout: FiniteDuration = FiniteDuration(1, MILLISECONDS)
   val src: PeerNode                  = peerNode("src", 40400)

--- a/comm/src/test/scala/coop/rchain/comm/rp/ConnectionsSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/ConnectionsSpec.scala
@@ -9,8 +9,10 @@ import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.shared._
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ConnectionsSpec extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class ConnectionsSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
 
   implicit val logEff    = new Log.NOPLog[Id]
   implicit val timeEff   = new LogicalTime[Id]

--- a/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/FindAndConnectSpec.scala
@@ -6,6 +6,8 @@ import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.metrics.Metrics
 import scala.concurrent.duration._
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.enablers.Containing
 import cats.{catsInstancesForId => _, _}, cats.data._, cats.syntax.all._
 import coop.rchain.catscontrib._, Catscontrib._, ski._
@@ -14,7 +16,11 @@ import coop.rchain.shared._
 import coop.rchain.comm.transport._
 import coop.rchain.comm.rp.ProtocolHelper._
 
-class FindAndConnectSpec extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class FindAndConnectSpec
+    extends AnyFunSpec
+    with Matchers
+    with BeforeAndAfterEach
+    with AppendedClues {
 
   import ScalaTestCats._
 

--- a/comm/src/test/scala/coop/rchain/comm/transport/GrpcTransportSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/GrpcTransportSpec.scala
@@ -11,11 +11,13 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import monix.reactive.Observable
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.collection.mutable
 import scala.util.Random
 
-class GrpcTransportSpec extends WordSpecLike with Matchers with Inside {
+class GrpcTransportSpec extends AnyWordSpecLike with Matchers with Inside {
 
   implicit val metrics: Metrics[Task] = new Metrics.MetricsNOP
   implicit val scheduler: Scheduler   = Scheduler.Implicits.global

--- a/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
@@ -6,12 +6,12 @@ import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalacheck.Gen
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Random
 
-class PacketStoreRestoreSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+class PacketStoreRestoreSpec extends FunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   import PacketOps._
 

--- a/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/PacketStoreRestoreSpec.scala
@@ -5,13 +5,14 @@ import coop.rchain.comm.protocol.routing._
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalacheck.Gen
-import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Random
 
-class PacketStoreRestoreSpec extends FunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class PacketStoreRestoreSpec extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   import PacketOps._
 

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -10,12 +10,14 @@ import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import monix.reactive.Observable
-import org.scalatest._
+import org.scalatest.Inside
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.concurrent.TrieMap
 import scala.util.Random
 
-class StreamHandlerSpec extends FunSpec with Matchers with Inside {
+class StreamHandlerSpec extends AnyFunSpec with Matchers with Inside {
 
   implicit val log: Log.NOPLog[Task] = new Log.NOPLog[Task]()
 

--- a/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/TransportLayerSpec.scala
@@ -8,10 +8,12 @@ import coop.rchain.comm.protocol.routing.Packet
 import coop.rchain.comm.rp.ProtocolHelper
 import coop.rchain.comm.syntax._
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 abstract class TransportLayerSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
     extends TransportLayerRuntime[F, E]
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with Inside {
 

--- a/comm/src/test/scala/coop/rchain/p2p/URIParseSpec.scala
+++ b/comm/src/test/scala/coop/rchain/p2p/URIParseSpec.scala
@@ -1,9 +1,10 @@
 package coop.rchain.p2p
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import coop.rchain.comm._
 
-class URIParseSpec extends FlatSpec with Matchers {
+class URIParseSpec extends AnyFlatSpec with Matchers {
   def badAddressError(s: String): Either[ParseError, PeerNode] =
     Left(ParseError(s"bad address: $s"))
 

--- a/crypto/src/test/scala/coop/rchain/crypto/PrivateKeySpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/PrivateKeySpec.scala
@@ -1,9 +1,9 @@
 package coop.rchain.crypto
 
 import coop.rchain.shared.EqualitySpecUtils
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class PrivateKeySpec extends FlatSpec {
+class PrivateKeySpec extends AnyFlatSpec {
 
   "PrivateKey" must "define value-based equality and hashCode" in {
     EqualitySpecUtils.checkValueBasedEquality(

--- a/crypto/src/test/scala/coop/rchain/crypto/PublicKeySpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/PublicKeySpec.scala
@@ -1,9 +1,9 @@
 package coop.rchain.crypto
 
 import coop.rchain.shared.EqualitySpecUtils
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class PublicKeySpec extends FlatSpec {
+class PublicKeySpec extends AnyFlatSpec {
 
   "PublicKey" must "define value-based equality and hashCode" in {
     EqualitySpecUtils.checkValueBasedEquality(

--- a/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
@@ -2,10 +2,11 @@ package coop.rchain.crypto.codec
 
 import coop.rchain.shared.Base16
 import org.scalacheck.Shrink
-import org.scalatest._
-import org.scalatestplus.scalacheck._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class Base16Spec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class Base16Spec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
   property("decode after encode returns the original input") {

--- a/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/codec/Base16Spec.scala
@@ -3,9 +3,9 @@ package coop.rchain.crypto.codec
 import coop.rchain.shared.Base16
 import org.scalacheck.Shrink
 import org.scalatest._
-import prop._
+import org.scalatestplus.scalacheck._
 
-class Base16Spec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class Base16Spec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
   property("decode after encode returns the original input") {

--- a/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Spec.scala
@@ -1,9 +1,10 @@
 package coop.rchain.crypto.encryption
 
-import org.scalatest._
-import org.scalatestplus.scalacheck._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class Curve25519Spec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class Curve25519Spec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   property("encrypt and decrypt should give original message") {
     forAll((message: Array[Byte]) => {
       // given

--- a/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Spec.scala
@@ -1,9 +1,9 @@
 package coop.rchain.crypto.encryption
 
 import org.scalatest._
-import prop._
+import org.scalatestplus.scalacheck._
 
-class Curve25519Spec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class Curve25519Spec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   property("encrypt and decrypt should give original message") {
     forAll((message: Array[Byte]) => {
       // given

--- a/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/encryption/Curve25519Test.scala
@@ -2,9 +2,11 @@ package coop.rchain.crypto.encryption
 
 import coop.rchain.crypto.codec._
 import coop.rchain.shared.Base16
-import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.{AppendedClues, BeforeAndAfterEach}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Curve25519Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class Curve25519Test extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
   describe("Curve25519 elliptic curve cryptography") {
 
     val bobSec =

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b256Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b256Test.scala
@@ -2,9 +2,11 @@ package coop.rchain.crypto.hash
 
 import coop.rchain.crypto.codec._
 import coop.rchain.shared.Base16
-import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.{AppendedClues, BeforeAndAfterEach}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Blake2b256Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class Blake2b256Test extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
   describe("Blake2b256 hashing algorithm") {
     it("encodes empty") {
       val result = Base16.encode(Blake2b256.hash("".getBytes))

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
@@ -4,7 +4,8 @@ import coop.rchain.shared.Stopwatch
 import org.scalacheck.{Arbitrary, Prop}
 import coop.rchain.shared.Base16
 import org.scalatest._
-import org.scalatest.prop.{Checkers, Configuration}
+import org.scalatest.prop.Configuration
+import org.scalatestplus.scalacheck.Checkers
 
 import java.nio.charset.StandardCharsets
 import java.util.Arrays

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Blake2b512RandomTest.scala
@@ -3,7 +3,8 @@ package coop.rchain.crypto.hash
 import coop.rchain.shared.Stopwatch
 import org.scalacheck.{Arbitrary, Prop}
 import coop.rchain.shared.Base16
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.Checkers
 
@@ -19,7 +20,7 @@ import scala.concurrent.duration.FiniteDuration
   * For the rollover tests, we use the block format which is 112 bytes of path
   * info, followed by 16 bytes of length info in little endian format.
   */
-class Blake2b512RandomTest extends FlatSpec with Matchers with Checkers with Configuration {
+class Blake2b512RandomTest extends AnyFlatSpec with Matchers with Checkers with Configuration {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 1000)
 

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Keccak256Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Keccak256Test.scala
@@ -1,9 +1,11 @@
 package coop.rchain.crypto.hash
 
 import coop.rchain.shared.Base16
-import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.{AppendedClues, BeforeAndAfterEach}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Keccak256Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class Keccak256Test extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
   describe("Keccak256 hashing algorithm") {
     it("encodes empty") {
       val result = Base16.encode(Keccak256.hash("".getBytes))

--- a/crypto/src/test/scala/coop/rchain/crypto/hash/Sha256Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/hash/Sha256Test.scala
@@ -1,8 +1,10 @@
 package coop.rchain.crypto.hash
 import coop.rchain.shared.Base16
-import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.{AppendedClues, BeforeAndAfterEach}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Sha256Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class Sha256Test extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
   describe("Sha256 hashing algorithm") {
     it("encodes") {
       Base16.encode(Sha256.hash("".getBytes)) shouldBe "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/Ed25519Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/Ed25519Test.scala
@@ -1,8 +1,10 @@
 package coop.rchain.crypto.signatures
 import coop.rchain.shared.Base16
-import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.{AppendedClues, BeforeAndAfterEach}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Ed25519Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class Ed25519Test extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
   describe("Ed25519") {
 
     it("computes public key from secret key") {

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Spec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Spec.scala
@@ -1,8 +1,8 @@
 package coop.rchain.crypto.signatures
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class Secp256k1Spec extends FlatSpec {
+class Secp256k1Spec extends AnyFlatSpec {
 
   "Secp256k1" should "generate valid key pair" in {
     assert((1 to 1000).forall { _ =>

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Test.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/Secp256k1Test.scala
@@ -2,9 +2,11 @@ package coop.rchain.crypto.signatures
 import coop.rchain.crypto.hash.Sha256
 import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.shared.Base16
-import org.scalatest.{AppendedClues, BeforeAndAfterEach, FunSpec, Matchers}
+import org.scalatest.{AppendedClues, BeforeAndAfterEach}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class Secp256k1Test extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class Secp256k1Test extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
   describe("Secp256k1") {
 
     it("verifies the given secp256k1 signature in native code with keypair") {

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/SignedSpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/SignedSpec.scala
@@ -4,11 +4,12 @@ import com.google.protobuf.ByteString
 import coop.rchain.crypto.signatures.Signed.{signatureHash}
 import coop.rchain.shared.Serialize
 import org.scalacheck.{Arbitrary, Gen, Shrink}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{Matchers, PropSpec}
 import scodec.bits.ByteVector
 
-class SignedSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class SignedSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
   implicit val serializable: Serialize[Array[Byte]] = new Serialize[Array[Byte]] {

--- a/crypto/src/test/scala/coop/rchain/crypto/signatures/SignedSpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/signatures/SignedSpec.scala
@@ -4,11 +4,11 @@ import com.google.protobuf.ByteString
 import coop.rchain.crypto.signatures.Signed.{signatureHash}
 import coop.rchain.shared.Serialize
 import org.scalacheck.{Arbitrary, Gen, Shrink}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 import scodec.bits.ByteVector
 
-class SignedSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class SignedSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny
 
   implicit val serializable: Serialize[Array[Byte]] = new Serialize[Array[Byte]] {

--- a/crypto/src/test/scala/coop/rchain/crypto/util/CertificateHelperTest.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/util/CertificateHelperTest.scala
@@ -5,9 +5,10 @@ import java.security.spec.{ECGenParameterSpec, ECParameterSpec, ECPoint}
 import java.security.{AlgorithmParameters, PublicKey}
 
 import coop.rchain.crypto.util.CertificateHelper._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CertificateHelperTest extends FlatSpec with Matchers {
+class CertificateHelperTest extends AnyFlatSpec with Matchers {
   val dummyPc = new PublicKey {
     override def getAlgorithm: String    = ???
     override def getFormat: String       = ???

--- a/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
@@ -5,10 +5,10 @@ import coop.rchain.crypto.hash.Blake2b256
 import coop.rchain.crypto.signatures.{Secp256k1, Secp256k1Eth}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 
-class DERConverterSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class DERConverterSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val arbBytes: Arbitrary[Array[Byte]] = arbContainer[Array, Byte]
 
   property("DER converter check with valid and non-empty input") {

--- a/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
+++ b/crypto/src/test/scala/coop/rchain/crypto/util/DERConverterSpec.scala
@@ -6,9 +6,10 @@ import coop.rchain.crypto.signatures.{Secp256k1, Secp256k1Eth}
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 
-class DERConverterSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class DERConverterSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val arbBytes: Arbitrary[Array[Byte]] = arbContainer[Array, Byte]
 
   property("DER converter check with valid and non-empty input") {

--- a/graphz/src/test/scala/coop/rchain/graphz/GraphzSpec.scala
+++ b/graphz/src/test/scala/coop/rchain/graphz/GraphzSpec.scala
@@ -4,8 +4,10 @@ import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import monix.eval.Task
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class GraphzSpec extends FunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
+class GraphzSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach with AppendedClues {
 
   describe("Graphz") {
     it("simple graph") {

--- a/models/src/test/scala/coop/rchain/casper/protocol/DeployDataSpec.scala
+++ b/models/src/test/scala/coop/rchain/casper/protocol/DeployDataSpec.scala
@@ -3,9 +3,10 @@ package coop.rchain.casper.protocol
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 
-class DeployDataSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class DeployDataSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val ddArb: Arbitrary[DeployData] = Arbitrary(
     for {
       term                  <- arbString.arbitrary

--- a/models/src/test/scala/coop/rchain/casper/protocol/DeployDataSpec.scala
+++ b/models/src/test/scala/coop/rchain/casper/protocol/DeployDataSpec.scala
@@ -2,9 +2,9 @@ package coop.rchain.casper.protocol
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class DeployDataSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val ddArb: Arbitrary[DeployData] = Arbitrary(

--- a/models/src/test/scala/coop/rchain/casper/protocol/DeployDataSpec.scala
+++ b/models/src/test/scala/coop/rchain/casper/protocol/DeployDataSpec.scala
@@ -2,10 +2,10 @@ package coop.rchain.casper.protocol
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 
-class DeployDataSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class DeployDataSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val ddArb: Arbitrary[DeployData] = Arbitrary(
     for {
       term                  <- arbString.arbitrary

--- a/models/src/test/scala/coop/rchain/models/BundleOpsSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/BundleOpsSpec.scala
@@ -2,10 +2,10 @@ package coop.rchain.models
 
 import coop.rchain.models.BundleOps._
 import coop.rchain.models.Expr.ExprInstance.GBool
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 import coop.rchain.models.rholang.implicits._
 
-class BundleOpsSpec extends FunSuite {
+class BundleOpsSpec extends AnyFunSuite {
 
   test("should merge bundles' properties correctly") {
     val par = Par(exprs = Seq(Expr(GBool(true))))

--- a/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
@@ -6,10 +6,10 @@ import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
 import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Shrink}
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.Function.tupled
 import scala.collection.immutable.BitSet

--- a/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
@@ -7,13 +7,15 @@ import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
 import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Shrink}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.Function.tupled
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag
 
-class EqualMSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class EqualMSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(sizeRange = 25, minSuccessful = 100)

--- a/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
@@ -6,14 +6,14 @@ import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
 import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Shrink}
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 import scala.Function.tupled
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag
 
-class EqualMSpec extends FlatSpec with PropertyChecks with Matchers {
+class EqualMSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(sizeRange = 25, minSuccessful = 100)

--- a/models/src/test/scala/coop/rchain/models/HashMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/HashMSpec.scala
@@ -7,10 +7,10 @@ import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.testImplicits._
 import monix.eval.Coeval
 import org.scalacheck.Arbitrary
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag

--- a/models/src/test/scala/coop/rchain/models/HashMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/HashMSpec.scala
@@ -8,13 +8,15 @@ import coop.rchain.models.testImplicits._
 import monix.eval.Coeval
 import org.scalacheck.Arbitrary
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime
 
-class HashMSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class HashMSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(sizeRange = 100, minSuccessful = 50)

--- a/models/src/test/scala/coop/rchain/models/HashMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/HashMSpec.scala
@@ -7,14 +7,14 @@ import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.testImplicits._
 import monix.eval.Coeval
 import org.scalacheck.Arbitrary
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime
 
-class HashMSpec extends FlatSpec with PropertyChecks with Matchers {
+class HashMSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(sizeRange = 100, minSuccessful = 50)

--- a/models/src/test/scala/coop/rchain/models/MemoSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/MemoSpec.scala
@@ -1,8 +1,9 @@
 package coop.rchain.models
 import monix.eval.Coeval
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MemoSpec extends FlatSpec with Matchers {
+class MemoSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Memo"
 

--- a/models/src/test/scala/coop/rchain/models/ParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/ParMapSpec.scala
@@ -3,9 +3,10 @@ package coop.rchain.models
 import coop.rchain.models.Expr.ExprInstance.{EMapBody, GInt, GString}
 import coop.rchain.models.Var.VarInstance.BoundVar
 import coop.rchain.models.rholang.implicits._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ParMapSpec extends FlatSpec with Matchers {
+class ParMapSpec extends AnyFlatSpec with Matchers {
 
   "ParMap" should "serialize like EMap" in {
     val map = ParMap(

--- a/models/src/test/scala/coop/rchain/models/ParSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/ParSetSpec.scala
@@ -3,11 +3,12 @@ package coop.rchain.models
 import coop.rchain.models.Expr.ExprInstance.{ESetBody, GInt}
 import coop.rchain.models.Var.VarInstance.BoundVar
 import coop.rchain.models.rholang.implicits._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.BitSet
 
-class ParSetSpec extends FlatSpec with Matchers {
+class ParSetSpec extends AnyFlatSpec with Matchers {
 
   "ParSet" should "serialize like raw ESet" in {
     val parGround =

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -9,10 +9,10 @@ import coop.rchain.models.testImplicits._
 import coop.rchain.shared.Serialize
 import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Shrink}
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scalapb.GeneratedMessageCompanion
 
 import scala.collection.immutable.BitSet

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -10,13 +10,15 @@ import coop.rchain.shared.Serialize
 import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Shrink}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scalapb.GeneratedMessageCompanion
 
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag
 
-class RhoTypesTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class RhoTypesTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   //FIXME crank that up and fix the resulting errors
   implicit override val generatorDrivenConfig =
@@ -78,7 +80,7 @@ class RhoTypesTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers 
 
 }
 
-class BitSetBytesMapperTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class BitSetBytesMapperTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
   "BitSetBytesMapper" should "encode example BitSet-s as expected" in {
     checkMapping(BitSet(), byteString())
     checkMapping(BitSet(0), byteString(1))

--- a/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
+++ b/models/src/test/scala/coop/rchain/models/RhoTypesTest.scala
@@ -9,14 +9,14 @@ import coop.rchain.models.testImplicits._
 import coop.rchain.shared.Serialize
 import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Shrink}
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 import scalapb.GeneratedMessageCompanion
 
 import scala.collection.immutable.BitSet
 import scala.reflect.ClassTag
 
-class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
+class RhoTypesTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   //FIXME crank that up and fix the resulting errors
   implicit override val generatorDrivenConfig =
@@ -78,7 +78,7 @@ class RhoTypesTest extends FlatSpec with PropertyChecks with Matchers {
 
 }
 
-class BitSetBytesMapperTest extends FlatSpec with PropertyChecks with Matchers {
+class BitSetBytesMapperTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
   "BitSetBytesMapper" should "encode example BitSet-s as expected" in {
     checkMapping(BitSet(), byteString())
     checkMapping(BitSet(0), byteString(1))

--- a/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
@@ -12,12 +12,12 @@ import coop.rchain.models.rholang.sorter.ordering._
 import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.sort
 import monix.eval.Coeval
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet
 
-class SortedParHashSetSpec extends FlatSpec with PropertyChecks with Matchers {
+class SortedParHashSetSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   val pars: Seq[Par] = {
     val parGround =

--- a/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
@@ -13,11 +13,13 @@ import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.sort
 import monix.eval.Coeval
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.BitSet
 
-class SortedParHashSetSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class SortedParHashSetSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   val pars: Seq[Par] = {
     val parGround =

--- a/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParHashSetSpec.scala
@@ -12,10 +12,10 @@ import coop.rchain.models.rholang.sorter.ordering._
 import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.sort
 import monix.eval.Coeval
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.collection.immutable.BitSet
 

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -14,9 +14,11 @@ import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.sort
 import monix.eval.Coeval
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SortedParMapSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class SortedParMapSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   private[this] def toKVpair(pair: (Par, Par)): KeyValuePair = KeyValuePair(pair._1, pair._2)
 

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -13,10 +13,10 @@ import coop.rchain.models.rholang.sorter.ordering._
 import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.sort
 import monix.eval.Coeval
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class SortedParMapSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
 

--- a/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/SortedParMapSpec.scala
@@ -13,10 +13,10 @@ import coop.rchain.models.rholang.sorter.ordering._
 import coop.rchain.models.testImplicits._
 import coop.rchain.models.testUtils.TestUtils.sort
 import monix.eval.Coeval
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
-class SortedParMapSpec extends FlatSpec with PropertyChecks with Matchers {
+class SortedParMapSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   private[this] def toKVpair(pair: (Par, Par)): KeyValuePair = KeyValuePair(pair._1, pair._2)
 

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -12,7 +12,8 @@ import coop.rchain.models.testUtils.TestUtils.forAllSimilarA
 import coop.rchain.models.{New, _}
 import monix.eval.Coeval
 import org.scalacheck.Arbitrary
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.collection.immutable.BitSet
@@ -21,7 +22,7 @@ object SortTest {
   def sort[T: Sortable](t: T) = Sortable[T].sortMatch[Coeval](t).value
 }
 
-class ScoredTermSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class ScoredTermSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   behavior of "ScoredTerm"
 
@@ -191,7 +192,7 @@ class ScoredTermSpec extends FlatSpec with ScalaCheckPropertyChecks with Matcher
   }
 }
 
-class VarSortMatcherSpec extends FlatSpec with Matchers {
+class VarSortMatcherSpec extends AnyFlatSpec with Matchers {
   "Different kinds of variables" should "bin separately" in {
     val parVars = Par(
       exprs = List(
@@ -224,7 +225,7 @@ class VarSortMatcherSpec extends FlatSpec with Matchers {
   }
 }
 
-class ParSortMatcherSpec extends FlatSpec with Matchers {
+class ParSortMatcherSpec extends AnyFlatSpec with Matchers {
 
   behavior of "Par"
 

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -13,7 +13,7 @@ import coop.rchain.models.{New, _}
 import monix.eval.Coeval
 import org.scalacheck.Arbitrary
 import org.scalatest._
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.collection.immutable.BitSet
 
@@ -21,7 +21,7 @@ object SortTest {
   def sort[T: Sortable](t: T) = Sortable[T].sortMatch[Coeval](t).value
 }
 
-class ScoredTermSpec extends FlatSpec with PropertyChecks with Matchers {
+class ScoredTermSpec extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
 
   behavior of "ScoredTerm"
 

--- a/models/src/test/scala/coop/rchain/models/testUtils/TestUtils.scala
+++ b/models/src/test/scala/coop/rchain/models/testUtils/TestUtils.scala
@@ -5,7 +5,7 @@ import monix.eval.Coeval
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.Assertion
-import org.scalatest.prop.GeneratorDrivenPropertyChecks._
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks._
 
 object TestUtils {
   def sort(par: Par): Par                                            = Sortable[Par].sortMatch[Coeval](par).map(_.term).value()

--- a/node/src/test/scala/coop/rchain/node/TransactionAPISpec.scala
+++ b/node/src/test/scala/coop/rchain/node/TransactionAPISpec.scala
@@ -15,9 +15,11 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class TransactionAPISpec extends FlatSpec with Matchers with Inspectors {
+class TransactionAPISpec extends AnyFlatSpec with Matchers with Inspectors {
   val genesis: GenesisContext = buildGenesis()
 
   def checkTransactionAPI(term: String, phloLimit: Long, phloPrice: Long, deployKey: PrivateKey) =

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/Base16ConverterSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/Base16ConverterSpec.scala
@@ -1,8 +1,9 @@
 package coop.rchain.node.configuration.commandline
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class Base16ConverterSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class Base16ConverterSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   property("parse returns error for bad characters") {
 
     forAll { s: String =>

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/Base16ConverterSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/Base16ConverterSpec.scala
@@ -1,8 +1,8 @@
 package coop.rchain.node.configuration.commandline
 import org.scalatest.{Matchers, PropSpec}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
-class Base16ConverterSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class Base16ConverterSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   property("parse returns error for bad characters") {
 
     forAll { s: String =>

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -6,14 +6,15 @@ import coop.rchain.casper.util.GenesisBuilder
 import coop.rchain.comm.transport.TlsConf
 import coop.rchain.comm.{CommError, PeerNode}
 import coop.rchain.node.configuration._
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import pureconfig._
 import pureconfig.generic.auto._
 
 import java.nio.file.Paths
 import scala.concurrent.duration._
 
-class ConfigMapperSpec extends FunSuite with Matchers {
+class ConfigMapperSpec extends AnyFunSuite with Matchers {
 
   test("CLI options should override defaults") {
     val args =

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -6,14 +6,15 @@ import coop.rchain.casper.util.GenesisBuilder
 import coop.rchain.comm.transport.TlsConf
 import coop.rchain.comm.{CommError, PeerNode}
 import coop.rchain.node.configuration._
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import pureconfig.{ConfigReader, ConfigSource, ConvertHelpers}
 import pureconfig.generic.auto._
 
 import java.nio.file.Paths
 import scala.concurrent.duration._
 
-class HoconConfigurationSpec extends FunSuite with Matchers {
+class HoconConfigurationSpec extends AnyFunSuite with Matchers {
 
   test("Parse default config") {
     val defaultConfig = ConfigSource

--- a/node/src/test/scala/coop/rchain/node/mergeablity/BaseMergeability.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/BaseMergeability.scala
@@ -2,9 +2,15 @@ package coop.rchain.node.mergeablity
 
 import coop.rchain.node.mergeablity.OperationOn0Ch._
 import coop.rchain.node.mergeablity.RhoState.emptyState
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class BaseMergeability extends FlatSpec with Matchers with Inspectors with BasicMergeabilityRules {
+class BaseMergeability
+    extends AnyFlatSpec
+    with Matchers
+    with Inspectors
+    with BasicMergeabilityRules {
   it should "!X !X" in MergeableCase(S0)(S0)(Nil)(S0.rstate ++ S0.rstate)
   it should "!X !4" in MergeableCase(S0)(F1)(S1)(S0.rstate)
   it should "!X (!4)" in MergeableCase(S0)(S0, F_)(Nil)(S0.rstate)

--- a/node/src/test/scala/coop/rchain/node/mergeablity/JoinMergeability.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/JoinMergeability.scala
@@ -1,9 +1,15 @@
 package coop.rchain.node.mergeablity
 
 import coop.rchain.node.mergeablity.OperationOn0Ch._
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class JoinMergeability extends FlatSpec with Matchers with Inspectors with BasicMergeabilityRules {
+class JoinMergeability
+    extends AnyFlatSpec
+    with Matchers
+    with Inspectors
+    with BasicMergeabilityRules {
   it should "J S S" in ConflictingCase(S0)(S1)(J_)(J_.rstate ++ S0.rstate)(
     J_.rstate ++ S1.rstate
   )

--- a/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
@@ -28,9 +28,10 @@ import coop.rchain.store.InMemoryStoreManager
 import fs2.Stream
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MergingBranchMergerSpec extends FlatSpec with Matchers {
+class MergingBranchMergerSpec extends AnyFlatSpec with Matchers {
 
   val genesisContext             = GenesisBuilder.buildGenesis(validatorsNum = 5)
   val genesis                    = genesisContext.genesisBlock

--- a/node/src/test/scala/coop/rchain/node/mergeablity/PeekMergeability.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/PeekMergeability.scala
@@ -1,9 +1,15 @@
 package coop.rchain.node.mergeablity
 
 import coop.rchain.node.mergeablity.OperationOn0Ch._
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.Inspectors
+import org.scalatest.matchers.should.Matchers
 
-class PeekMergeability extends FlatSpec with Matchers with Inspectors with BasicMergeabilityRules {
+class PeekMergeability
+    extends AnyFlatSpec
+    with Matchers
+    with Inspectors
+    with BasicMergeabilityRules {
   // it should"PX !X"    in ConflictingCase(S0)(P_)(Nil)(S0.rstate)(P_.rstate) // non deteministic, depends on which exactly produce is commed
   it should "PX !4" in MergeableCase(P1)(F_)(S0)(P1.rstate)
   it should "PX (!4)" in MergeableCase(P1)(F_, S0)(Nil)(P1.rstate)

--- a/node/src/test/scala/coop/rchain/node/mergeablity/TreeHashMapMergeabilitySpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/TreeHashMapMergeabilitySpec.scala
@@ -16,7 +16,8 @@ import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Gen
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 final case class KeyValue(key: String, value: String)
@@ -47,7 +48,7 @@ final case class UpdatingKeyValue(key: String, oriValue: String, updatingValue: 
   * `set` and `update` would be mergeable when they don't modified the common NYBBLE NODEs or the same SUFFIX VALUE
   */
 class TreeHashMapMergeabilitySpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with ScalaCheckDrivenPropertyChecks
     with ComputeMerge {
 

--- a/node/src/test/scala/coop/rchain/node/mergeablity/TreeHashMapMergeabilitySpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/TreeHashMapMergeabilitySpec.scala
@@ -17,7 +17,7 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Gen
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 final case class KeyValue(key: String, value: String)
 final case class UpdatingKeyValue(key: String, oriValue: String, updatingValue: String) {
@@ -48,7 +48,7 @@ final case class UpdatingKeyValue(key: String, oriValue: String, updatingValue: 
   */
 class TreeHashMapMergeabilitySpec
     extends FlatSpec
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with ComputeMerge {
 
   private val keyValuesGen: Gen[KeyValue] = for {

--- a/node/src/test/scala/coop/rchain/node/perf/HistoryGenKeySpec.scala
+++ b/node/src/test/scala/coop/rchain/node/perf/HistoryGenKeySpec.scala
@@ -11,7 +11,9 @@ import coop.rchain.rspace.history.instances._
 import coop.rchain.shared.syntax._
 import coop.rchain.shared.{Base16, Log, Stopwatch}
 import coop.rchain.store.{InMemoryKeyValueStore, KeyValueStore, LmdbStoreManager}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.bits.ByteVector
 
 import java.io.File
@@ -21,7 +23,7 @@ import java.nio.file.Files
 import scala.reflect.io.{Directory, Path}
 import scala.util.Random
 
-class HistoryGenKeySpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class HistoryGenKeySpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
   object TypesOfHistory extends Enumeration {
     type TypeHistory = Value

--- a/node/src/test/scala/coop/rchain/node/revvaultexport/RhoTrieTraverserTest.scala
+++ b/node/src/test/scala/coop/rchain/node/revvaultexport/RhoTrieTraverserTest.scala
@@ -11,11 +11,11 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.util.Random
 
-class RhoTrieTraverserTest extends FlatSpec {
+class RhoTrieTraverserTest extends AnyFlatSpec {
   private val SHARD_ID = "root-shard"
 
   "traverse the TreeHashMap" should "work" in {

--- a/node/src/test/scala/coop/rchain/node/revvaultexport/VaultBalanceGetterTest.scala
+++ b/node/src/test/scala/coop/rchain/node/revvaultexport/VaultBalanceGetterTest.scala
@@ -7,9 +7,9 @@ import coop.rchain.node.revvaultexport.mainnet1.StateBalanceMain
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class VaultBalanceGetterTest extends FlatSpec {
+class VaultBalanceGetterTest extends AnyFlatSpec {
   val genesis               = buildGenesis()
   val genesisInitialBalance = 9000000
   "Get balance from VaultPar" should "return balance" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,7 +74,7 @@ object Dependencies {
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.2"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.5" % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.8" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -86,7 +86,7 @@ object Dependencies {
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
   val scalaCompat         = "org.scala-lang.modules"     %% "scala-collection-compat"   % "2.6.0"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.5" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.8" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,7 +73,7 @@ object Dependencies {
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.4"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.0"
-  val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5"  % "test"
+  val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0"  % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.10" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,9 +72,9 @@ object Dependencies {
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.4"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
-  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.2"
+  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.16.0"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.0.8" % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.12" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -86,7 +86,8 @@ object Dependencies {
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
   val scalaCompat         = "org.scala-lang.modules"     %% "scala-collection-compat"   % "2.6.0"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.0.8" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.12" % "test"
+  val scalatestPlus       = "org.scalatestplus"          %% "scalacheck-1-16"           % "3.2.12.0" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"
@@ -138,7 +139,7 @@ object Dependencies {
     "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
   )
 
-  private val testing = Seq(scalactic, scalatest, scalacheck)
+  private val testing = Seq(scalactic, scalatest, scalacheck, scalatestPlus)
 
   private val logging = Seq(slf4j, julToSlf4j, scalaLogging, logbackClassic, logstashLogback)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,9 +72,9 @@ object Dependencies {
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.4"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
-  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.16.0"
-  val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5" % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.12" % "test"
+  val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.0"
+  val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % "1.2.5"  % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.10" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -86,8 +86,8 @@ object Dependencies {
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
   val scalaCompat         = "org.scala-lang.modules"     %% "scala-collection-compat"   % "2.6.0"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.12" % "test"
-  val scalatestPlus       = "org.scalatestplus"          %% "scalacheck-1-16"           % "3.2.12.0" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.10"   % "test"
+  val scalatestPlus       = "org.scalatestplus"          %% "scalacheck-1-15"           % "3.2.10.0" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"

--- a/regex/src/test/scala/coop/rchain/regex/FsmUnitTests.scala
+++ b/regex/src/test/scala/coop/rchain/regex/FsmUnitTests.scala
@@ -1,7 +1,8 @@
 package coop.rchain.regex
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FsmUnitTests extends FlatSpec with Matchers {
+class FsmUnitTests extends AnyFlatSpec with Matchers {
   def ignore[A](a: => A): Unit = {
     val _: A = a
     ()

--- a/regex/src/test/scala/coop/rchain/regex/MultiplierUnitTests.scala
+++ b/regex/src/test/scala/coop/rchain/regex/MultiplierUnitTests.scala
@@ -1,8 +1,9 @@
 package coop.rchain.regex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MultiplierUnitTests extends FlatSpec with Matchers {
+class MultiplierUnitTests extends AnyFlatSpec with Matchers {
   "Multiplier tryParse" should "work" in {
     assert(Multiplier.tryParse("{10}") == (Multiplier(Some(10), Some(10)), 4))
     assert(Multiplier.tryParse("{2,}") == (Multiplier(Some(2), Multiplier.Inf), 4))

--- a/regex/src/test/scala/coop/rchain/regex/PathRegexUnitTests.scala
+++ b/regex/src/test/scala/coop/rchain/regex/PathRegexUnitTests.scala
@@ -1,8 +1,9 @@
 package coop.rchain.regex
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.language.implicitConversions
 
-class PathRegexUnitTests extends FlatSpec with Matchers {
+class PathRegexUnitTests extends AnyFlatSpec with Matchers {
 
   class ExPathRegex(value: PathRegex) {
     def accept(matchCases: (String, Seq[String])*): ExPathRegex = {

--- a/regex/src/test/scala/coop/rchain/regex/RegexPatternUnitTests.scala
+++ b/regex/src/test/scala/coop/rchain/regex/RegexPatternUnitTests.scala
@@ -1,8 +1,9 @@
 package coop.rchain.regex
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RegexPatternUnitTests extends FlatSpec with Matchers {
+class RegexPatternUnitTests extends AnyFlatSpec with Matchers {
 
   "CharClassPattern equality" should "pass checks" in {
     assert(CharClassPattern("a") == CharClassPattern("a"))

--- a/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/InterpreterSpec.scala
@@ -12,11 +12,12 @@ import coop.rchain.rholang.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class InterpreterSpec extends FlatSpec with Matchers {
+class InterpreterSpec extends AnyFlatSpec with Matchers {
   private val tmpPrefix   = "rspace-store-"
   private val maxDuration = 5.seconds
 

--- a/rholang/src/test/scala/coop/rchain/rholang/PeekSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/PeekSpec.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rholang
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.Expr.ExprInstance.{GInt, GString}
@@ -13,7 +14,7 @@ import monix.execution.Scheduler.Implicits.global
 
 import scala.concurrent.duration._
 
-class PeekSpec extends FlatSpec with Matchers {
+class PeekSpec extends AnyFlatSpec with Matchers {
 
   import Resources._
   import InterpreterUtil._

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
@@ -8,9 +8,9 @@ import monix.eval.Coeval
 import org.scalacheck.Arbitrary
 import org.scalacheck.Test.Parameters
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class ProcGenTest extends FlatSpec with PropertyChecks with Matchers {
+class ProcGenTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
   implicit val params: Parameters = Parameters.defaultVerbose.withMinSuccessfulTests(1000)
   implicit val procArbitrary = Arbitrary(
     ProcGen.topLevelGen(5).map(PrettyPrinted[Proc](_, PrettyPrinter.print))

--- a/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/ProcGenTest.scala
@@ -7,10 +7,11 @@ import coop.rchain.rholang.ast.rholang_mercury.PrettyPrinter
 import monix.eval.Coeval
 import org.scalacheck.Arbitrary
 import org.scalacheck.Test.Parameters
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class ProcGenTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class ProcGenTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
   implicit val params: Parameters = Parameters.defaultVerbose.withMinSuccessfulTests(1000)
   implicit val procArbitrary = Arbitrary(
     ProcGen.topLevelGen(5).map(PrettyPrinted[Proc](_, PrettyPrinter.print))

--- a/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StackSafetySpec.scala
@@ -16,7 +16,9 @@ import coop.rchain.shared.{Log, Serialize}
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.prop.TableDrivenPropertyChecks
-import org.scalatest.{Assertions, FlatSpec, Matchers}
+import org.scalatest.Assertions
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.annotation.tailrec
 import scala.concurrent.duration._
@@ -59,7 +61,7 @@ object StackSafetySpec extends Assertions {
 
 }
 
-class StackSafetySpec extends FlatSpec with TableDrivenPropertyChecks with Matchers {
+class StackSafetySpec extends AnyFlatSpec with TableDrivenPropertyChecks with Matchers {
   import StackSafetySpec._
 
   val mapSize     = 1024L * 1024L * 1024L
@@ -216,7 +218,7 @@ class StackSafetySpec extends FlatSpec with TableDrivenPropertyChecks with Match
 
 }
 
-class AstTypeclassesStackSafetySpec extends FlatSpec with Matchers {
+class AstTypeclassesStackSafetySpec extends AnyFlatSpec with Matchers {
 
   behavior of "AST typeclasses"
 

--- a/rholang/src/test/scala/coop/rchain/rholang/StoragePrinterSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/StoragePrinterSpec.scala
@@ -11,11 +11,12 @@ import coop.rchain.rholang.syntax._
 import coop.rchain.shared.{Base16, Log}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class StoragePrinterSpec extends FlatSpec with Matchers {
+class StoragePrinterSpec extends AnyFlatSpec with Matchers {
   private val tmpPrefix   = "rspace-store-"
   private val maxDuration = 5.seconds
   private val deployerSk = PrivateKey(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ComplexConsumeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ComplexConsumeSpec.scala
@@ -1,9 +1,10 @@
 package coop.rchain.rholang.interpreter
 
 import coop.rchain.rholang.interpreter.ParBuilderUtil.assertCompiledEqual
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ComplexConsumeSpec extends FlatSpec with Matchers {
+class ComplexConsumeSpec extends AnyFlatSpec with Matchers {
 
   "The normalizer" should "translate consumes with send-receive sources into COMMs" in {
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -23,11 +23,12 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class CostAccountingReducerTest extends FlatSpec with Matchers with TripleEqualsSupport {
+class CostAccountingReducerTest extends AnyFlatSpec with Matchers with TripleEqualsSupport {
 
   implicit val noopSpan: Span[Task]   = Span.noop
   implicit val metrics: Metrics[Task] = new Metrics.MetricsNOP[Task]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -22,7 +22,7 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{fixture, Assertion, Matchers, Outcome}
 
 import java.nio.file.Files
@@ -32,7 +32,7 @@ import scala.concurrent.duration._
 
 class CryptoChannelsSpec
     extends fixture.FlatSpec
-    with PropertyChecks
+    with ScalaCheckPropertyChecks
     with Matchers
     with TripleEqualsSupport {
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -22,10 +22,10 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{Assertion, Outcome}
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.nio.file.Files
 import scala.collection.immutable.BitSet

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -23,7 +23,9 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{fixture, Assertion, Matchers, Outcome}
+import org.scalatest.{Assertion, Outcome}
+import org.scalatest.flatspec.FixtureAnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.Files
 import scala.collection.immutable.BitSet
@@ -31,7 +33,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class CryptoChannelsSpec
-    extends fixture.FlatSpec
+    extends FixtureAnyFlatSpec
     with ScalaCheckPropertyChecks
     with Matchers
     with TripleEqualsSupport {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/EnvTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/EnvTest.scala
@@ -1,12 +1,13 @@
 package coop.rchain.rholang.interpreter
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.collection.mutable
 
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.Par
 
-class EnvSpec extends FlatSpec with Matchers {
+class EnvSpec extends AnyFlatSpec with Matchers {
 
   val source0: Par = GPrivateBuilder()
   val source1: Par = GPrivateBuilder()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
@@ -4,9 +4,11 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 import coop.rchain.rholang.interpreter.errors.{InterpreterError, UnrecognizedInterpreterError}
 import org.scalacheck.ScalacheckShapeless._
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ErrorsSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class ErrorsSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   "Using Throwable methods on InterpreterError" should "not cause exceptions itself" in {
     forAll { e: InterpreterError =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
@@ -3,10 +3,10 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 
 import coop.rchain.rholang.interpreter.errors.{InterpreterError, UnrecognizedInterpreterError}
 import org.scalacheck.ScalacheckShapeless._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{Assertion, FlatSpec, Matchers}
 
-class ErrorsSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+class ErrorsSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   "Using Throwable methods on InterpreterError" should "not cause exceptions itself" in {
     forAll { e: InterpreterError =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ErrorsSpec.scala
@@ -3,10 +3,10 @@ import java.io.{ByteArrayOutputStream, PrintStream}
 
 import coop.rchain.rholang.interpreter.errors.{InterpreterError, UnrecognizedInterpreterError}
 import org.scalacheck.ScalacheckShapeless._
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class ErrorsSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/InterpreterUtil.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/InterpreterUtil.scala
@@ -3,7 +3,7 @@ package coop.rchain.rholang.interpreter
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.rholang.syntax._
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 
 object InterpreterUtil {
   def evaluate[F[_]: Sync](runtime: RhoRuntime[F], term: String)(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LetSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LetSpec.scala
@@ -3,7 +3,9 @@ package coop.rchain.rholang.interpreter
 import coop.rchain.rholang.interpreter.ParBuilderUtil.assertCompiledEqual
 import coop.rchain.rholang.interpreter.errors.{SyntaxError, UnexpectedProcContext}
 import org.scalatest.EitherValues._
-import org.scalatest.{Assertion, Matchers, WordSpec}
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
   * This is the first Rholang test class introduced to test a new language construct that
@@ -12,7 +14,7 @@ import org.scalatest.{Assertion, Matchers, WordSpec}
   * corresponding to the same source, and (2) because this is the first construct that is
   * implemented in terms of a pre-existing Rholang constructs.
   */
-class LetSpec extends WordSpec with Matchers {
+class LetSpec extends AnyWordSpec with Matchers {
 
   "The lexer" should {
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/LexerTest.scala
@@ -5,9 +5,10 @@ import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter.errors.LexerError
 import monix.eval.Coeval
 import org.scalatest.EitherValues._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class LexerTest extends FlatSpec with Matchers {
+class LexerTest extends AnyFlatSpec with Matchers {
 
   def attemptMkTerm(input: String): Either[Throwable, Par] =
     Compiler[Coeval].sourceToADT(input).runAttempt()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ParBuilderUtil.scala
@@ -5,7 +5,7 @@ import coop.rchain.rholang.interpreter.compiler.Compiler
 import monix.eval.Coeval
 import org.scalatest.EitherValues._
 import org.scalatest.Assertion
-import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
 object ParBuilderUtil {
 
@@ -13,6 +13,6 @@ object ParBuilderUtil {
     Compiler[Coeval].sourceToADT(rho, Map.empty[String, Par]).runAttempt
 
   def assertCompiledEqual(s: String, t: String): Assertion =
-    ParBuilderUtil.mkTerm(s).right.value shouldBe ParBuilderUtil.mkTerm(t).right.value
+    ParBuilderUtil.mkTerm(s).value shouldBe ParBuilderUtil.mkTerm(t).value
 
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -24,11 +24,13 @@ import coop.rchain.rholang.interpreter.compiler.normalizer.{
 }
 import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 import monix.eval.Coeval
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.BitSet
 
-class BoolPrinterSpec extends FlatSpec with Matchers {
+class BoolPrinterSpec extends AnyFlatSpec with Matchers {
 
   "GBool(true)" should "Print as \"" + true + "\"" in {
     val btrue = new BoolTrue()
@@ -41,7 +43,7 @@ class BoolPrinterSpec extends FlatSpec with Matchers {
   }
 }
 
-class GroundPrinterSpec extends FlatSpec with Matchers {
+class GroundPrinterSpec extends AnyFlatSpec with Matchers {
 
   "GroundInt" should "Print as \"" + 7 + "\"" in {
     val gi             = new GroundInt("7")
@@ -62,7 +64,7 @@ class GroundPrinterSpec extends FlatSpec with Matchers {
   }
 }
 
-class CollectPrinterSpec extends FlatSpec with Matchers {
+class CollectPrinterSpec extends AnyFlatSpec with Matchers {
 
   val inputs = ProcVisitInputs(
     Par(),
@@ -152,7 +154,7 @@ class CollectPrinterSpec extends FlatSpec with Matchers {
   }
 }
 
-class ProcPrinterSpec extends FlatSpec with Matchers {
+class ProcPrinterSpec extends AnyFlatSpec with Matchers {
   val inputs                                   = ProcVisitInputs(Par(), BoundMapChain.empty, FreeMap.empty)
   implicit val normalizerEnv: Map[String, Par] = Map.empty
 
@@ -985,7 +987,7 @@ class ProcPrinterSpec extends FlatSpec with Matchers {
   )
 }
 
-class IncrementTester extends FlatSpec with Matchers {
+class IncrementTester extends AnyFlatSpec with Matchers {
 
   val printer = PrettyPrinter()
 
@@ -1014,7 +1016,7 @@ class IncrementTester extends FlatSpec with Matchers {
   }
 }
 
-class NamePrinterSpec extends FlatSpec with Matchers {
+class NamePrinterSpec extends AnyFlatSpec with Matchers {
 
   val inputs                                   = NameVisitInputs(BoundMapChain.empty, FreeMap.empty)
   implicit val normalizerEnv: Map[String, Par] = Map.empty

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReceiveSortMatcherSpec.scala
@@ -4,11 +4,12 @@ import coop.rchain.models.Expr.ExprInstance.GInt
 import coop.rchain.models.{Par, ReceiveBind, Var}
 import coop.rchain.models.Var.VarInstance.FreeVar
 import monix.eval.Coeval
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.compiler.{FreeMap, ReceiveBindsSortMatcher, VarSort}
 
-class ReceiveSortMatcherSpec extends FlatSpec with Matchers {
+class ReceiveSortMatcherSpec extends AnyFlatSpec with Matchers {
   val emptyMap = FreeMap.empty[VarSort]
   "Binds" should "Presort based on their channel and then pattern" in {
     val binds: List[(List[Par], Option[Var], Par, FreeMap[VarSort])] =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -20,7 +20,9 @@ import coop.rchain.shared.{Base16, Serialize}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.prop.TableDrivenPropertyChecks._
-import org.scalatest.{AppendedClues, Assertion, FlatSpec, Matchers}
+import org.scalatest.{AppendedClues, Assertion}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.SortedSet
 import scala.collection.immutable.BitSet
@@ -29,7 +31,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Failure
 
-class ReduceSpec extends FlatSpec with Matchers with AppendedClues with PersistentStoreTester {
+class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with PersistentStoreTester {
   implicit val rand: Blake2b512Random = Blake2b512Random(Array.empty[Byte])
   implicit val metrics: Metrics[Task] = new Metrics.MetricsNOP[Task]
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReplaySpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReplaySpec.scala
@@ -10,11 +10,12 @@ import coop.rchain.rspace.SoftCheckpoint
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class ReplaySpec extends FlatSpec with Matchers {
+class ReplaySpec extends AnyFlatSpec with Matchers {
 
   // TODO: these tests are temporary and specific to bugs found in replay.
   // Testing execution for many iteration doesn't make sense.

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/RuntimeSpec.scala
@@ -7,11 +7,12 @@ import coop.rchain.rholang.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class RuntimeSpec extends FlatSpec with Matchers {
+class RuntimeSpec extends AnyFlatSpec with Matchers {
   private val tmpPrefix                   = "rspace-store-"
   private val maxDuration                 = 5.seconds
   implicit val logF: Log[Task]            = Log.log[Task]

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SequentialConsumeSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SequentialConsumeSpec.scala
@@ -1,9 +1,10 @@
 package coop.rchain.rholang.interpreter
 
 import coop.rchain.rholang.interpreter.ParBuilderUtil.assertCompiledEqual
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SequentialConsumeSpec extends WordSpec with Matchers {
+class SequentialConsumeSpec extends AnyWordSpec with Matchers {
 
   "The normalizer" should {
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ShortCircuitBooleanSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ShortCircuitBooleanSpec.scala
@@ -6,7 +6,8 @@ import coop.rchain.models.Expr.ExprInstance.GString
 import coop.rchain.rholang.Resources.mkRuntime
 import coop.rchain.shared.Log
 import monix.eval.Task
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import coop.rchain.rholang.syntax._
 
 import scala.concurrent.duration._
@@ -14,7 +15,7 @@ import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.errors.{InterpreterError, ReduceError}
 import monix.execution.Scheduler.Implicits.global
 
-class ShortCircuitBooleanSpec extends WordSpec with Matchers {
+class ShortCircuitBooleanSpec extends AnyWordSpec with Matchers {
   implicit val logF: Log[Task]            = Log.log[Task]
   implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
   implicit val noopSpan: Span[Task]       = NoopSpan[Task]()

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SortSpec.scala
@@ -3,13 +3,14 @@ import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.rholang.sorter.Sortable
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import coop.rchain.models.rholang.sorter.ScoredTerm
 import monix.eval.Coeval
 
 import scala.collection.immutable.BitSet
 
-class SortSpec extends FlatSpec with Matchers {
+class SortSpec extends AnyFlatSpec with Matchers {
 
   "GroundSortMatcher" should "discern sets with and without remainder" in {
     assertOrder[Expr](

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
@@ -10,9 +10,9 @@ import coop.rchain.rholang.interpreter.errors.SubstituteError
 import coop.rchain.models.rholang.implicits._
 import monix.eval.Coeval
 import org.scalacheck.Gen
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.collection.immutable.BitSet
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
@@ -10,12 +10,12 @@ import coop.rchain.rholang.interpreter.errors.SubstituteError
 import coop.rchain.models.rholang.implicits._
 import monix.eval.Coeval
 import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.collection.immutable.BitSet
 
-class SubSpec extends FlatSpec with Matchers with PropertyChecks {
+class SubSpec extends FlatSpec with Matchers with ScalaCheckPropertyChecks {
 
   behavior of "Substitute"
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
@@ -11,11 +11,12 @@ import coop.rchain.models.rholang.implicits._
 import monix.eval.Coeval
 import org.scalacheck.Gen
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.BitSet
 
-class SubSpec extends FlatSpec with Matchers with ScalaCheckPropertyChecks {
+class SubSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 
   behavior of "Substitute"
 
@@ -46,7 +47,7 @@ class SubSpec extends FlatSpec with Matchers with ScalaCheckPropertyChecks {
   }
 }
 
-class VarSubSpec extends FlatSpec with Matchers {
+class VarSubSpec extends AnyFlatSpec with Matchers {
   implicit val depth: Int = 0
   "FreeVar" should "throw an error" in {
     val source: Par            = GPrivateBuilder()
@@ -76,7 +77,7 @@ class VarSubSpec extends FlatSpec with Matchers {
   }
 }
 
-class SendSubSpec extends FlatSpec with Matchers {
+class SendSubSpec extends AnyFlatSpec with Matchers {
   implicit val depth: Int = 0
   "Send" should "leave variables not in evironment alone." in {
 
@@ -163,7 +164,7 @@ class SendSubSpec extends FlatSpec with Matchers {
   }
 }
 
-class NewSubSpec extends FlatSpec with Matchers {
+class NewSubSpec extends AnyFlatSpec with Matchers {
   implicit val depth: Int = 0
   "New" should "only substitute body of expression" in {
     val source: Par  = GPrivateBuilder()
@@ -219,7 +220,7 @@ class NewSubSpec extends FlatSpec with Matchers {
   }
 }
 
-class EvalSubSpec extends FlatSpec with Matchers {
+class EvalSubSpec extends AnyFlatSpec with Matchers {
   implicit val depth: Int = 0
   "Eval" should "remove Eval/Quote pairs." in {
     implicit val env: Env[Par] = Env.makeEnv(GPrivateBuilder("one"), GPrivateBuilder("zero"))
@@ -231,7 +232,7 @@ class EvalSubSpec extends FlatSpec with Matchers {
   }
 }
 
-class BundleSubSpec extends FlatSpec with Matchers {
+class BundleSubSpec extends AnyFlatSpec with Matchers {
   implicit val depth: Int = 0
   "Bundle" should "substitute within the body of the bundle." in {
     val source: Par  = GPrivateBuilder()
@@ -279,7 +280,7 @@ class BundleSubSpec extends FlatSpec with Matchers {
   }
 }
 
-class VarRefSubSpec extends FlatSpec with Matchers {
+class VarRefSubSpec extends AnyFlatSpec with Matchers {
   implicit val depth: Int = 1
   "VarRef" should "be replaced at correct depth" in {
     val source: Par         = GPrivateBuilder()
@@ -326,7 +327,7 @@ class VarRefSubSpec extends FlatSpec with Matchers {
   }
 }
 
-class OpSubSpec extends FlatSpec with Matchers {
+class OpSubSpec extends AnyFlatSpec with Matchers {
   implicit val depth: Int = 0
   "EPlusPlus" should "be substituted correctly" in {
     val source: Par            = Send(EVar(BoundVar(0)), List(Par()), false, BitSet(0))

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SynchronousOutputSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SynchronousOutputSpec.scala
@@ -1,9 +1,10 @@
 package coop.rchain.rholang.interpreter
 
 import coop.rchain.rholang.interpreter.ParBuilderUtil.assertCompiledEqual
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SynchronousOutputSpec extends FlatSpec with Matchers {
+class SynchronousOutputSpec extends AnyFlatSpec with Matchers {
 
   "';'" should "have a higher precedence than '|' 2" in {
     val s = "@3!?(3). | @1!?(1) ; @2!?(2). "

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -19,11 +19,12 @@ import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class CostAccountingPropertyTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class CostAccountingPropertyTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
   import CostAccountingPropertyTest._
 
   implicit val params: Parameters = Parameters.defaultVerbose.withMinSuccessfulTests(1000)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -18,9 +18,9 @@ import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.duration._
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingPropertyTest.scala
@@ -18,12 +18,12 @@ import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Test.Parameters
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 
-class CostAccountingPropertyTest extends FlatSpec with PropertyChecks with Matchers {
+class CostAccountingPropertyTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
   import CostAccountingPropertyTest._
 
   implicit val params: Parameters = Parameters.defaultVerbose.withMinSuccessfulTests(1000)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -27,13 +27,15 @@ import org.scalacheck.Prop.forAllNoShrink
 import org.scalacheck._
 import org.scalatestplus.scalacheck.Checkers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import org.scalatest.{AppendedClues, Assertion, FlatSpec, Matchers}
+import org.scalatest.{AppendedClues, Assertion}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 
 class CostAccountingSpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with ScalaCheckPropertyChecks
     with Checkers

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -25,11 +25,11 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Prop.forAllNoShrink
 import org.scalacheck._
-import org.scalatestplus.scalacheck.Checkers
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{AppendedClues, Assertion}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.Checkers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/CostAccountingSpec.scala
@@ -25,14 +25,19 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Prop.forAllNoShrink
 import org.scalacheck._
-import org.scalatest.prop.Checkers.check
-import org.scalatest.prop.PropertyChecks
+import org.scalatestplus.scalacheck.Checkers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import org.scalatest.{AppendedClues, Assertion, FlatSpec, Matchers}
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 
-class CostAccountingSpec extends FlatSpec with Matchers with PropertyChecks with AppendedClues {
+class CostAccountingSpec
+    extends FlatSpec
+    with Matchers
+    with ScalaCheckPropertyChecks
+    with Checkers
+    with AppendedClues {
 
   private[this] def evaluateWithCostLog(
       initialPhlo: Long,

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -16,7 +16,7 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
-import org.scalatest.prop.PropertyChecks._
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
 import org.scalatest.{Assertion, BeforeAndAfterAll, Matchers, WordSpec}
 
 import java.nio.file.{Files, Path}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -16,10 +16,10 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
 import org.scalatest.{Assertion, BeforeAndAfterAll}
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
 
 import java.nio.file.{Files, Path}
 import scala.collection.immutable.BitSet

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -17,14 +17,16 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
-import org.scalatest.{Assertion, BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.{Assertion, BeforeAndAfterAll}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.{Files, Path}
 import scala.collection.immutable.BitSet
 import scala.concurrent.duration._
 
 class RholangMethodsCostsSpec
-    extends WordSpec
+    extends AnyWordSpec
     with TripleEqualsSupport
     with Matchers
     with BeforeAndAfterAll {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/BoolMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/BoolMatcherSpec.scala
@@ -2,11 +2,12 @@ package coop.rchain.rholang.interpreter.compiler.normalizer
 
 import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import coop.rchain.models.Expr.ExprInstance._
 
-class BoolMatcherSpec extends FlatSpec with Matchers {
+class BoolMatcherSpec extends AnyFlatSpec with Matchers {
   "BoolTrue" should "Compile as GBool(true)" in {
     val btrue = new BoolTrue()
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/CollectMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/CollectMatcherSpec.scala
@@ -3,6 +3,8 @@ package coop.rchain.rholang.interpreter.compiler.normalizer
 import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.BitSet
 import coop.rchain.models.Expr.ExprInstance._
@@ -23,7 +25,7 @@ import coop.rchain.rholang.interpreter.compiler.{
 }
 import monix.eval.Coeval
 
-class CollectMatcherSpec extends FlatSpec with Matchers {
+class CollectMatcherSpec extends AnyFlatSpec with Matchers {
   val inputs = ProcVisitInputs(
     Par(),
     BoundMapChain

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundMatcherSpec.scala
@@ -2,14 +2,15 @@ package coop.rchain.rholang.interpreter.compiler.normalizer
 
 import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import monix.eval.Coeval
 
-class GroundMatcherSpec extends FlatSpec with Matchers {
+class GroundMatcherSpec extends AnyFlatSpec with Matchers {
   "GroundInt" should "Compile as GInt" in {
     val gi                   = new GroundInt("7")
     val expectedResult: Expr = GInt(7)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/NameMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/NameMatcherSpec.scala
@@ -1,7 +1,8 @@
 package coop.rchain.rholang.interpreter.compiler.normalizer
 
 import coop.rchain.rholang.ast.rholang_mercury.Absyn._
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import coop.rchain.models.Expr.ExprInstance._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
@@ -18,7 +19,7 @@ import coop.rchain.rholang.interpreter.compiler.{
 }
 import monix.eval.Coeval
 
-class NameMatcherSpec extends FlatSpec with Matchers {
+class NameMatcherSpec extends AnyFlatSpec with Matchers {
   val inputs                                   = NameVisitInputs(BoundMapChain.empty[VarSort], FreeMap.empty[VarSort])
   implicit val normalizerEnv: Map[String, Par] = Map.empty
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/ProcMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/ProcMatcherSpec.scala
@@ -27,11 +27,13 @@ import coop.rchain.rholang.interpreter.compiler.{
 import coop.rchain.rholang.interpreter.errors._
 import monix.eval.Coeval
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.io.StringReader
 import scala.collection.immutable.BitSet
 
-class ProcMatcherSpec extends FlatSpec with Matchers {
+class ProcMatcherSpec extends AnyFlatSpec with Matchers {
   val inputs                                   = ProcVisitInputs(Par(), BoundMapChain.empty[VarSort], FreeMap.empty[VarSort])
   implicit val normalizerEnv: Map[String, Par] = Map.empty
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -16,12 +16,14 @@ import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.TimeLimits
 
 import scala.collection.immutable.BitSet
 import scala.concurrent.duration._
 
-class VarMatcherSpec extends FlatSpec with Matchers with TimeLimits with TripleEqualsSupport {
+class VarMatcherSpec extends AnyFlatSpec with Matchers with TimeLimits with TripleEqualsSupport {
   import SpatialMatcher._
   import coop.rchain.models.rholang.implicits._
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -12,11 +12,12 @@ import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.matcher.{run => runMatcher}
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 
-class MatcherMonadSpec extends FlatSpec with Matchers {
+class MatcherMonadSpec extends AnyFlatSpec with Matchers {
   implicit val metrics: Metrics[Task] = new Metrics.MetricsNOP[Task]
   implicit val ms: Metrics.Source     = Metrics.BaseSource
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MaximumBipartiteMatchSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MaximumBipartiteMatchSpec.scala
@@ -1,9 +1,11 @@
 package coop.rchain.rholang.interpreter.matcher
 import cats.data.Writer
 import cats.{Id, Monad}
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MaximumBipartiteMatchSpec extends FlatSpec with Matchers {
+class MaximumBipartiteMatchSpec extends AnyFlatSpec with Matchers {
 
   val edges = Map(
     //  A - 1

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/StreamTSpec.scala
@@ -12,11 +12,13 @@ import coop.rchain.rholang.StackSafetySpec
 import coop.rchain.rholang.interpreter.matcher.StreamT.{SCons, Step}
 import monix.eval.Coeval
 import org.scalacheck.{Arbitrary, Gen, Prop}
-import org.scalatest.{FlatSpec, FunSuite, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 import cats.instances.AllInstances
 import cats.syntax.AllSyntax
 
-class StreamTSpec extends FlatSpec with Matchers {
+class StreamTSpec extends AnyFlatSpec with Matchers {
 
   val maxDepth = StackSafetySpec.findMaxRecursionDepth()
 
@@ -107,7 +109,7 @@ class StreamTSpec extends FlatSpec with Matchers {
 }
 
 class StreamTLawsSpec
-    extends FunSuite
+    extends AnyFunSuite
     with LowPriorityDerivations
     with AllInstances
     with AllSyntax {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogicSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogicSpec.scala
@@ -5,9 +5,10 @@ import cats.syntax.all._
 import coop.rchain.shared.scalatestcontrib._
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RholangMergingLogicSpec extends FlatSpec with Matchers {
+class RholangMergingLogicSpec extends AnyFlatSpec with Matchers {
 
   it should "calculate number channels difference" in effectTest {
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/storage/ChargingRSpaceTest.scala
@@ -22,11 +22,13 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
-import org.scalatest.{fixture, Matchers, Outcome}
+import org.scalatest.Outcome
+import org.scalatest.flatspec.FixtureAnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 
-class ChargingRSpaceTest extends fixture.FlatSpec with TripleEqualsSupport with Matchers {
+class ChargingRSpaceTest extends FixtureAnyFlatSpec with TripleEqualsSupport with Matchers {
 
   behavior of "ChargingRSpace"
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/AddressToolsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/AddressToolsSpec.scala
@@ -2,12 +2,13 @@ package coop.rchain.rholang.interpreter.util
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256}
 import org.scalacheck._
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 import coop.rchain.crypto.PublicKey
 import coop.rchain.rholang.interpreter.util.codec.Base58
 import coop.rchain.shared.{Base16, EqualitySpecUtils}
 
-class AddressToolsSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class AddressToolsSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val propertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 10000, sizeRange = 200)
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/AddressToolsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/AddressToolsSpec.scala
@@ -1,13 +1,13 @@
 package coop.rchain.rholang.interpreter.util
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256}
 import org.scalacheck._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 import coop.rchain.crypto.PublicKey
 import coop.rchain.rholang.interpreter.util.codec.Base58
 import coop.rchain.shared.{Base16, EqualitySpecUtils}
 
-class AddressToolsSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class AddressToolsSpec extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val propertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 10000, sizeRange = 200)
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/AddressToolsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/AddressToolsSpec.scala
@@ -1,9 +1,9 @@
 package coop.rchain.rholang.interpreter.util
 import coop.rchain.crypto.hash.{Blake2b256, Keccak256}
 import org.scalacheck._
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import coop.rchain.crypto.PublicKey
 import coop.rchain.rholang.interpreter.util.codec.Base58
 import coop.rchain.shared.{Base16, EqualitySpecUtils}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/RevAddressSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/RevAddressSpec.scala
@@ -2,9 +2,10 @@ package coop.rchain.rholang.interpreter.util
 
 import coop.rchain.crypto.PublicKey
 import coop.rchain.shared.Base16
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RevAddressSpec extends FlatSpec with Matchers {
+class RevAddressSpec extends AnyFlatSpec with Matchers {
   "fromPublicKey" should "work correctly" in {
     val pk =
       PublicKey(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/codec/Base58Properties.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/codec/Base58Properties.scala
@@ -3,9 +3,9 @@ package coop.rchain.rholang.interpreter.util.codec
 import java.math.BigInteger
 
 import org.scalacheck.{Gen, Shrink}
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class Base58Properties extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val propertyCheckConfiguration =

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/codec/Base58Properties.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/codec/Base58Properties.scala
@@ -4,9 +4,10 @@ import java.math.BigInteger
 
 import org.scalacheck.{Gen, Shrink}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
 
-class Base58Properties extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+class Base58Properties extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val propertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 10000, sizeRange = 200)
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/codec/Base58Properties.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/codec/Base58Properties.scala
@@ -3,10 +3,10 @@ package coop.rchain.rholang.interpreter.util.codec
 import java.math.BigInteger
 
 import org.scalacheck.{Gen, Shrink}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{Matchers, PropSpec}
 
-class Base58Properties extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class Base58Properties extends PropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
   implicit val propertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 10000, sizeRange = 200)
   implicit def noShrink[T]: Shrink[T] = Shrink.shrinkAny

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/codec/Base58Spec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/util/codec/Base58Spec.scala
@@ -1,9 +1,10 @@
 package coop.rchain.rholang.interpreter.util.codec
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop._
 
-class Base58Spec extends FlatSpec with TableDrivenPropertyChecks with Matchers {
+class Base58Spec extends AnyFlatSpec with TableDrivenPropertyChecks with Matchers {
   "encode empty array" should "be empty" in {
     val input = Array[Byte]()
     Base58.encode(input) should equal("")

--- a/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
+++ b/rholang/src/test/scala/rholang/rosette/CompilerTests.scala
@@ -8,14 +8,15 @@ import coop.rchain.rholang.interpreter.{EvaluateResult, Interpreter, Interpreter
 import coop.rchain.shared.{Log, Resources}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.{Files, Path, Paths}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.io.Source
 
-class CompilerTests extends FunSuite with Matchers {
+class CompilerTests extends AnyFunSuite with Matchers {
   private val tmpPrefix                   = "rspace-store-"
   private val maxDuration                 = 5.seconds
   implicit val logF: Log[Task]            = new Log.NOPLog[Task]

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/KryoRoundTripTest.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/KryoRoundTripTest.scala
@@ -3,11 +3,11 @@ package coop.rchain.rspace
 import coop.rchain.models._
 import org.scalacheck._
 import org.scalatest._
-import org.scalatest.prop._
+import org.scalatestplus.scalacheck._
 
 import scala.reflect.ClassTag
 
-class KryoRoundTripTest extends FlatSpec with PropertyChecks with Matchers {
+class KryoRoundTripTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(minSuccessful = 50, sizeRange = 250)
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/KryoRoundTripTest.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/KryoRoundTripTest.scala
@@ -3,11 +3,13 @@ package coop.rchain.rspace
 import coop.rchain.models._
 import org.scalacheck._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck._
 
 import scala.reflect.ClassTag
 
-class KryoRoundTripTest extends FlatSpec with ScalaCheckPropertyChecks with Matchers {
+class KryoRoundTripTest extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers {
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(minSuccessful = 50, sizeRange = 250)
 

--- a/rspace/src/test/scala/coop/rchain/rspace/ExportImportTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ExportImportTests.scala
@@ -16,11 +16,12 @@ import coop.rchain.shared.{Log, Serialize}
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.atomic.AtomicAny
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.bits.ByteVector
 
 class ExportImportTests
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with InMemoryExportImportTestsBase[String, Pattern, String, String] {
 

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -14,6 +14,8 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck._
 import scodec.bits.ByteVector
 
@@ -21,7 +23,7 @@ import scala.collection.SortedSet
 import scala.concurrent.duration._
 import scala.util.Random
 
-trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+trait HotStoreSpec[F[_]] extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(minSize = 0, sizeRange = 10, minSuccessful = 20)

--- a/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/HotStoreSpec.scala
@@ -14,14 +14,14 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest._
-import org.scalatest.prop._
+import org.scalatestplus.scalacheck._
 import scodec.bits.ByteVector
 
 import scala.collection.SortedSet
 import scala.concurrent.duration._
 import scala.util.Random
 
-trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+trait HotStoreSpec[F[_]] extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   implicit override val generatorDrivenConfig =
     PropertyCheckConfiguration(minSize = 0, sizeRange = 10, minSuccessful = 20)

--- a/rspace/src/test/scala/coop/rchain/rspace/InternalTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/InternalTests.scala
@@ -1,10 +1,11 @@
 package coop.rchain.rspace
 
 import coop.rchain.rspace.serializers.ScodecSerialize.RichAttempt
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.{Attempt, Err}
 
-class InternalTests extends FlatSpec with Matchers {
+class InternalTests extends AnyFlatSpec with Matchers {
 
   "RichAttempt" should "tell user that data in RSpace was corrupted on faulty get" in {
     val a = Attempt.failure(Err("I failed miserably"))

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -22,6 +22,8 @@ import monix.execution.Scheduler
 import monix.execution.atomic.AtomicAny
 import org.scalacheck._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck._
 
 import scala.collection.SortedSet
@@ -1224,7 +1226,7 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
 }
 
 trait ReplayRSpaceTestsBase[C, P, A, K]
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with ScalaCheckPropertyChecks {

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -22,7 +22,7 @@ import monix.execution.Scheduler
 import monix.execution.atomic.AtomicAny
 import org.scalacheck._
 import org.scalatest._
-import org.scalatest.prop._
+import org.scalatestplus.scalacheck._
 
 import scala.collection.SortedSet
 import scala.util.Random
@@ -1227,7 +1227,7 @@ trait ReplayRSpaceTestsBase[C, P, A, K]
     extends FlatSpec
     with Matchers
     with OptionValues
-    with PropertyChecks {
+    with ScalaCheckPropertyChecks {
   val logger = Logger(this.getClass.getName.stripSuffix("$"))
 
   implicit override val generatorDrivenConfig =

--- a/rspace/src/test/scala/coop/rchain/rspace/SerializeTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/SerializeTests.scala
@@ -6,7 +6,8 @@ import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.test.roundTripCodec
 import org.scalacheck.Prop
 import org.scalactic.anyvals.PosInt
-import org.scalatest.prop.{Checkers, Configuration}
+import org.scalatest.prop.Configuration
+import org.scalatestplus.scalacheck.Checkers
 import org.scalatest.{FlatSpec, Matchers}
 import scodec.DecodeResult
 

--- a/rspace/src/test/scala/coop/rchain/rspace/SerializeTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/SerializeTests.scala
@@ -8,10 +8,11 @@ import org.scalacheck.Prop
 import org.scalactic.anyvals.PosInt
 import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.Checkers
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.DecodeResult
 
-class SerializeTests extends FlatSpec with Matchers with Checkers with Configuration {
+class SerializeTests extends AnyFlatSpec with Matchers with Checkers with Configuration {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = PosInt(1000))

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageActionsTests.scala
@@ -11,13 +11,13 @@ import coop.rchain.rspace.trace.Consume
 import coop.rchain.rspace.util.{getK, runK, unpackOption}
 import coop.rchain.shared.Serialize
 import monix.eval.Task
-import org.scalatest.prop.{Checkers, GeneratorDrivenPropertyChecks}
+import org.scalatestplus.scalacheck._
 
 import scala.collection.SortedSet
 
 trait StorageActionsTests[F[_]]
     extends StorageTestsBase[F, String, Pattern, String, StringsCaptor]
-    with GeneratorDrivenPropertyChecks
+    with ScalaCheckDrivenPropertyChecks
     with Checkers {
 
   implicit override val generatorDrivenConfig =

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -16,10 +16,12 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval._
 import monix.execution.atomic.AtomicAny
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-trait StorageTestsBase[F[_], C, P, A, K] extends FlatSpec with Matchers with OptionValues {
+trait StorageTestsBase[F[_], C, P, A, K] extends AnyFlatSpec with Matchers with OptionValues {
   type T    = ISpace[F, C, P, A, K]
   type ST   = HotStore[F, C, P, A, K]
   type HR   = HistoryRepository[F, C, P, A, K]

--- a/rspace/src/test/scala/coop/rchain/rspace/UtilTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/UtilTests.scala
@@ -1,10 +1,11 @@
 package coop.rchain.rspace
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.bits.ByteVector
 import coop.rchain.rspace.util.veccmp
 
-class UtilTests extends FlatSpec with Matchers {
+class UtilTests extends AnyFlatSpec with Matchers {
 
   "veccmp" should "work" in {
     val ve    = ByteVector.empty

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/MultiLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/MultiLockTest.scala
@@ -1,6 +1,7 @@
 package coop.rchain.rspace.concurrent
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import monix.eval.Task
 import scala.collection._
 import scala.collection.immutable.Seq
@@ -8,7 +9,7 @@ import scala.collection.immutable.Seq
 import coop.rchain.metrics
 import coop.rchain.metrics.Metrics
 
-class MultiLockTest extends FlatSpec with Matchers {
+class MultiLockTest extends AnyFlatSpec with Matchers {
 
   import monix.execution.Scheduler
   implicit val s       = Scheduler.fixedPool("test-scheduler", 8)

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
@@ -1,11 +1,12 @@
 package coop.rchain.rspace.concurrent
 
 import monix.eval.Task
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.metrics.Metrics
 
-class TwoStepLockTest extends FlatSpec with Matchers {
+class TwoStepLockTest extends AnyFlatSpec with Matchers {
 
   import monix.execution.Scheduler
   implicit val s       = Scheduler.fixedPool("test-scheduler", 8)

--- a/rspace/src/test/scala/coop/rchain/rspace/history/Blake2b256HashTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/Blake2b256HashTests.scala
@@ -7,7 +7,7 @@ import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.test.roundTripCodec
 import org.scalacheck.Prop
 import org.scalatest.FlatSpec
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import scodec.DecodeResult
 
 class Blake2b256HashTests extends FlatSpec with Checkers {

--- a/rspace/src/test/scala/coop/rchain/rspace/history/Blake2b256HashTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/Blake2b256HashTests.scala
@@ -6,11 +6,11 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.test.roundTripCodec
 import org.scalacheck.Prop
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatestplus.scalacheck.Checkers
 import scodec.DecodeResult
 
-class Blake2b256HashTests extends FlatSpec with Checkers {
+class Blake2b256HashTests extends AnyFlatSpec with Checkers {
 
   "The bytes of a Blake2b256 hash" should "be the same as if it was created directly" in {
 

--- a/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
@@ -7,9 +7,10 @@ import coop.rchain.rspace.internal.{Datum, _}
 import coop.rchain.rspace.serializers.ScodecSerialize._
 import coop.rchain.rspace.test.ArbitraryInstances._
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class EncodingSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class EncodingSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   type Continuation = WaitingContinuation[Pattern, StringsCaptor]
   type Join         = Seq[String]

--- a/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
@@ -6,9 +6,9 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.internal.{Datum, _}
 import coop.rchain.rspace.serializers.ScodecSerialize._
 import coop.rchain.rspace.test.ArbitraryInstances._
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class EncodingSpec extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 

--- a/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/EncodingSpec.scala
@@ -6,10 +6,10 @@ import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.internal.{Datum, _}
 import coop.rchain.rspace.serializers.ScodecSerialize._
 import coop.rchain.rspace.test.ArbitraryInstances._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
-class EncodingSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+class EncodingSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   type Continuation = WaitingContinuation[Pattern, StringsCaptor]
   type Join         = Seq[String]

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryActionTests.scala
@@ -8,7 +8,9 @@ import coop.rchain.shared.Base16
 import coop.rchain.store.InMemoryKeyValueStore
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.bits.ByteVector
 
 import java.nio.ByteBuffer
@@ -16,7 +18,7 @@ import scala.collection.concurrent.TrieMap
 import scala.concurrent.duration._
 import scala.util.Random
 
-class HistoryActionTests extends FlatSpec with Matchers with InMemoryHistoryTestBase {
+class HistoryActionTests extends AnyFlatSpec with Matchers with InMemoryHistoryTestBase {
 
   "creating and read one record" should "works" in withEmptyHistory { emptyHistoryF =>
     val data = insert(_zeros) :: Nil

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
@@ -17,7 +17,7 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatest._
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import java.nio.file.{Files, Path}
 import scala.concurrent.duration._
@@ -92,7 +92,7 @@ abstract class HistoryRepositoryGenerativeDefinition
     extends FlatSpec
     with Matchers
     with OptionValues
-    with GeneratorDrivenPropertyChecks {
+    with ScalaCheckDrivenPropertyChecks {
 
   val serializeString  = implicitly[Serialize[String]]
   val serializePattern = implicitly[Serialize[Pattern]]

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositoryGenerativeSpec.scala
@@ -17,6 +17,8 @@ import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import java.nio.file.{Files, Path}
@@ -89,7 +91,7 @@ class InMemHistoryRepositoryGenerativeSpec
 }
 
 abstract class HistoryRepositoryGenerativeDefinition
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with ScalaCheckDrivenPropertyChecks {

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
@@ -19,7 +19,9 @@ import coop.rchain.state.TrieNode
 import coop.rchain.store.InMemoryKeyValueStore
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
 import scodec.bits.ByteVector
 
 import java.nio.ByteBuffer
@@ -28,7 +30,7 @@ import scala.concurrent.duration._
 import scala.util.Random
 
 class HistoryRepositorySpec
-    extends FlatSpec
+    extends AnyFlatSpec
     with Matchers
     with OptionValues
     with InMemoryHistoryRepositoryTestBase {

--- a/rspace/src/test/scala/coop/rchain/rspace/history/RadixTreeSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/RadixTreeSpec.scala
@@ -10,13 +10,19 @@ import coop.rchain.shared.syntax.{sharedSyntaxKeyValueStore, sharedSyntaxKeyValu
 import coop.rchain.store.{InMemoryKeyValueStore, KeyValueTypedStore}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.OptionValues
 import scodec.bits.ByteVector
 
 import java.nio.ByteBuffer
 import scala.concurrent.duration._
 
-class RadixTreeSpec extends FlatSpec with Matchers with OptionValues with InMemoryHistoryTestBase {
+class RadixTreeSpec
+    extends AnyFlatSpec
+    with Matchers
+    with OptionValues
+    with InMemoryHistoryTestBase {
   "appending leaf in empty tree" should "create tree with one node" in withImplAndStore {
     (impl, _) =>
       val dataSet = radixKV("1122334455", "01")

--- a/rspace/src/test/scala/coop/rchain/rspace/merging/EventsMergingLogicSpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/merging/EventsMergingLogicSpec.scala
@@ -2,9 +2,10 @@ package coop.rchain.rspace.merging
 
 import coop.rchain.rspace.merger.EventLogMergingLogic._
 import coop.rchain.shared.Stopwatch
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class EventsMergingLogicSpec extends FlatSpec with Matchers {
+class EventsMergingLogicSpec extends AnyFlatSpec with Matchers {
   // some random conflict maps and rejection options, computed manually
   "rejection options" should "be computed correctly" in {
     computeRejectionOptions(

--- a/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
@@ -8,9 +8,9 @@ import coop.rchain.rspace.serializers.ScodecSerialize.{RichAttempt, _}
 import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.util
 import coop.rchain.shared.Serialize
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scodec.codecs.{ignore => cignore, _}
 
 class EventTests extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {

--- a/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
@@ -8,11 +8,11 @@ import coop.rchain.rspace.serializers.ScodecSerialize.{RichAttempt, _}
 import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.util
 import coop.rchain.shared.Serialize
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import scodec.codecs.{ignore => cignore, _}
 
-class EventTests extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+class EventTests extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   "A Produce" should "contain the expected hash" in {
     forAll { (channel: String, data: String, persist: Boolean) =>

--- a/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/trace/EventTests.scala
@@ -9,10 +9,11 @@ import coop.rchain.rspace.test.ArbitraryInstances._
 import coop.rchain.rspace.util
 import coop.rchain.shared.Serialize
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.codecs.{ignore => cignore, _}
 
-class EventTests extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class EventTests extends AnyFlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
 
   "A Produce" should "contain the expected hash" in {
     forAll { (channel: String, data: String, persist: Boolean) =>

--- a/sdk/src/test/scala/coop/rchain/sdk/SdkSpec.scala
+++ b/sdk/src/test/scala/coop/rchain/sdk/SdkSpec.scala
@@ -1,8 +1,9 @@
 package coop.rchain.sdk
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SdkSpec extends FlatSpec with Matchers {
+class SdkSpec extends AnyFlatSpec with Matchers {
 
   it should "trivially be true" in {
     1 shouldBe 1

--- a/shared/src/test/scala/coop/rchain/catscontrib/BooleanFSpec.scala
+++ b/shared/src/test/scala/coop/rchain/catscontrib/BooleanFSpec.scala
@@ -2,9 +2,10 @@ package coop.rchain.catscontrib
 
 import cats._
 import cats.syntax.all._
-import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class BooleanFSpec extends FunSpec with Matchers with ToBooleanF {
+class BooleanFSpec extends AnyFunSpec with Matchers with ToBooleanF {
 
   describe("boolean OR") {
     it("FALSE || FALSE = FALSE") {

--- a/shared/src/test/scala/coop/rchain/shared/CellSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/CellSpec.scala
@@ -1,6 +1,8 @@
 package coop.rchain.shared
 
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import cats._, cats.data._, cats.syntax.all._
 import coop.rchain.catscontrib._, Catscontrib._, TaskContrib._
@@ -9,7 +11,7 @@ import monix.execution.Scheduler
 import monix.execution.schedulers.SchedulerService
 import scala.collection.concurrent.TrieMap
 
-class CellSpec extends FunSpec with Matchers with BeforeAndAfterEach {
+class CellSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
 
   implicit val io: SchedulerService = Scheduler.io("test")
 

--- a/shared/src/test/scala/coop/rchain/shared/CompressionSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/CompressionSpec.scala
@@ -1,7 +1,7 @@
 package coop.rchain.shared
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalacheck.Gen
 
 import scala.util.Random

--- a/shared/src/test/scala/coop/rchain/shared/CompressionSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/CompressionSpec.scala
@@ -1,11 +1,12 @@
 package coop.rchain.shared
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalacheck.Gen
 
 import scala.util.Random
 
-class CompressionSpec extends FunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class CompressionSpec extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
   val byteArrays =
     for (n <- Gen.choose(10, 500000))
       yield Array.fill(n)((Random.nextInt(256) - 128).toByte)

--- a/shared/src/test/scala/coop/rchain/shared/CompressionSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/CompressionSpec.scala
@@ -1,11 +1,11 @@
 package coop.rchain.shared
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FunSpec, Matchers}
 import org.scalacheck.Gen
 
 import scala.util.Random
 
-class CompressionSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+class CompressionSpec extends FunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
   val byteArrays =
     for (n <- Gen.choose(10, 500000))
       yield Array.fill(n)((Random.nextInt(256) - 128).toByte)

--- a/shared/src/test/scala/coop/rchain/shared/ResourcesSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/ResourcesSpec.scala
@@ -1,8 +1,9 @@
 package coop.rchain.shared
 import coop.rchain.shared.Resources.withResource
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ResourcesSpec extends FlatSpec with Matchers {
+class ResourcesSpec extends AnyFlatSpec with Matchers {
 
   val resource = new AutoCloseable {
     override def close(): Unit = throw new Exception("close")

--- a/shared/src/test/scala/coop/rchain/shared/SeqOpsTest.scala
+++ b/shared/src/test/scala/coop/rchain/shared/SeqOpsTest.scala
@@ -1,10 +1,11 @@
 package coop.rchain.shared
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scala.collection.immutable.Seq
 import coop.rchain.shared.SeqOps._
 
-class SeqOpsTest extends FlatSpec with Matchers {
+class SeqOpsTest extends AnyFlatSpec with Matchers {
 
   "dropIndex" should "remove first element" in {
     dropIndex(Seq(1, 2, 3), 0) shouldBe Seq(2, 3)

--- a/shared/src/test/scala/coop/rchain/shared/StreamTSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/StreamTSpec.scala
@@ -3,12 +3,13 @@ package coop.rchain.shared
 import cats._
 import cats.syntax.all._
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.util.{Failure, Success, Try}
 
-class StreamTSpec extends FunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class StreamTSpec extends AnyFunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
   import StreamTSpec._
 
   describe("StreamT") {

--- a/shared/src/test/scala/coop/rchain/shared/StreamTSpec.scala
+++ b/shared/src/test/scala/coop/rchain/shared/StreamTSpec.scala
@@ -4,11 +4,11 @@ import cats._
 import cats.syntax.all._
 
 import org.scalatest.{FunSpec, Matchers}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.util.{Failure, Success, Try}
 
-class StreamTSpec extends FunSpec with Matchers with GeneratorDrivenPropertyChecks {
+class StreamTSpec extends FunSpec with Matchers with ScalaCheckDrivenPropertyChecks {
   import StreamTSpec._
 
   describe("StreamT") {

--- a/shared/src/test/scala/coop/rchain/shared/scalatestcontrib.scala
+++ b/shared/src/test/scala/coop/rchain/shared/scalatestcontrib.scala
@@ -5,7 +5,8 @@ import cats.syntax.functor._
 import coop.rchain.catscontrib.TaskContrib.TaskOps
 import monix.eval.Task
 import monix.execution.Scheduler
-import org.scalatest.{Assertion, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
 
 object scalatestcontrib extends Matchers {
 

--- a/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
+++ b/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
@@ -5,9 +5,9 @@ import cats.syntax.all._
 import coop.rchain.shared.syntax._
 import monix.eval.Task
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scodec.codecs.{int64, utf8}
 
 class KeyValueStoreSut[F[_]: Sync: KeyValueStoreManager] {

--- a/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
+++ b/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
@@ -6,7 +6,8 @@ import coop.rchain.shared.syntax._
 import monix.eval.Task
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import scodec.codecs.{int64, utf8}
 
 class KeyValueStoreSut[F[_]: Sync: KeyValueStoreManager] {
@@ -46,7 +47,10 @@ class KeyValueStoreSut[F[_]: Sync: KeyValueStoreManager] {
     } yield result.toMap
 }
 
-class InMemoryKeyValueStoreSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
+class InMemoryKeyValueStoreSpec
+    extends AnyFlatSpec
+    with Matchers
+    with ScalaCheckDrivenPropertyChecks {
   implicit val scheduler = monix.execution.Scheduler.global
 
   def genData: Gen[Map[Long, String]] = {

--- a/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
+++ b/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 import coop.rchain.shared.syntax._
 import monix.eval.Task
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 import scodec.codecs.{int64, utf8}
 
@@ -46,7 +46,7 @@ class KeyValueStoreSut[F[_]: Sync: KeyValueStoreManager] {
     } yield result.toMap
 }
 
-class InMemoryKeyValueStoreSpec extends FlatSpec with Matchers with GeneratorDrivenPropertyChecks {
+class InMemoryKeyValueStoreSpec extends FlatSpec with Matchers with ScalaCheckDrivenPropertyChecks {
   implicit val scheduler = monix.execution.Scheduler.global
 
   def genData: Gen[Map[Long, String]] = {


### PR DESCRIPTION
## Overview

Upgraded version of [scalatest, scalactic](https://www.scalatest.org/) and [scalacheck](https://scalacheck.org/) libraries to be able to use effectful unit testing.

The libraries have not been updated to the latest versions, but to
* 3.2.10 for scalatest/scalactic and
* 1.15 for scalacheck
to provide compatibility with [cats-effect-testing](https://github.com/typelevel/cats-effect-testing) (see [release 1.4.0 notes](https://github.com/typelevel/cats-effect-testing/releases/tag/v1.4.0) and [PR](https://github.com/typelevel/cats-effect-testing/pull/208)).

### Note

* Changing imports made according to [scalatest 3.1.0 release notes](https://www.scalatest.org/release_notes/3.1.0).
* Renaming of scalacheck entities made according to [scalatest autofix warnings](https://github.com/scalatest/autofix/blob/d1fad4842e65c9c54e710d8e9b9de39dfe4527ae/3.0.x/rules/src/main/scala/org/scalatest/autofix/v3_0_x/RenameDeprecatedPackage.scala).

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
