### PR TITLE
Property-based effectful unit-testing with ScalaCheck Effect

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
@@ -1,20 +1,20 @@
 package coop.rchain.casper.batch2
 
-import java.nio.file.Files
 import cats.effect.Concurrent
 import cats.syntax.all._
 import coop.rchain.shared.Log
+import coop.rchain.shared.ScalaCheckOps.forAllF
 import coop.rchain.store.{KeyValueStoreSut, LmdbStoreManager}
 import monix.eval.Task
 import monix.execution.Scheduler
 import monix.testing.scalatest.MonixTaskTest
-import org.scalacheck.effect.PropF
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
+import java.nio.file.Files
 import scala.reflect.io.{Directory, Path}
 import scala.util.Random
 
@@ -52,55 +52,40 @@ class LmdbKeyValueStoreSpec
   implicit val log: Log[Task] = new Log.NOPLog[Task]()
 
   it should "put and get data from the store" in {
-    PropF
-      .forAllF(genData) { expected =>
-        val test = withSut[Task] { sut =>
-          for {
-            result <- sut.testPutGet(expected)
-          } yield result shouldBe expected
-        }
-
-        test.void
+    forAllF(genData) { expected =>
+      withSut[Task] { sut =>
+        for {
+          result <- sut.testPutGet(expected)
+        } yield result shouldBe expected
       }
-      .check()
-      .map(r => assert(r.passed, r.status.toString))
+    }
   }
 
   it should "put and get all data from the store" in {
-    PropF
-      .forAllF(genData) { expected =>
-        val test = withSut[Task] { sut =>
-          for {
-            result <- sut.testPutIterate(expected)
-          } yield result shouldBe expected
-        }
-
-        test.void
+    forAllF(genData) { expected =>
+      withSut[Task] { sut =>
+        for {
+          result <- sut.testPutIterate(expected)
+        } yield result shouldBe expected
       }
-      .check()
-      .map(r => assert(r.passed, r.status.toString))
+    }
   }
 
   it should "not have deleted keys in the store" in {
-    PropF
-      .forAllF(genData) { input =>
-        val test = withSut[Task] { sut =>
-          val allKeys = input.keysIterator.toVector
-          // Take some keys for deletion
-          val (getKeys, deleteKeys) = allKeys.splitAt(allKeys.size / 2)
-          val values                = getKeys.map(input.get)
-          // Expected input without deleted keys
-          val expected =
-            getKeys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
-          for {
-            result <- sut.testPutDeleteGet(input, deleteKeys)
-          } yield result shouldBe expected
-        }
-
-        test.void
+    forAllF(genData) { input =>
+      withSut[Task] { sut =>
+        val allKeys = input.keysIterator.toVector
+        // Take some keys for deletion
+        val (getKeys, deleteKeys) = allKeys.splitAt(allKeys.size / 2)
+        val values                = getKeys.map(input.get)
+        // Expected input without deleted keys
+        val expected =
+          getKeys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
+        for {
+          result <- sut.testPutDeleteGet(input, deleteKeys)
+        } yield result shouldBe expected
       }
-      .check()
-      .map(r => assert(r.passed, r.status.toString))
+    }
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/LmdbKeyValueStoreSpec.scala
@@ -1,15 +1,17 @@
 package coop.rchain.casper.batch2
 
 import java.nio.file.Files
-
 import cats.effect.Concurrent
 import cats.syntax.all._
 import coop.rchain.shared.Log
 import coop.rchain.store.{KeyValueStoreSut, LmdbStoreManager}
 import monix.eval.Task
+import monix.execution.Scheduler
+import monix.testing.scalatest.MonixTaskTest
+import org.scalacheck.effect.PropF
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
@@ -17,11 +19,12 @@ import scala.reflect.io.{Directory, Path}
 import scala.util.Random
 
 class LmdbKeyValueStoreSpec
-    extends AnyFlatSpec
+    extends AsyncFlatSpec
+    with MonixTaskTest
     with Matchers
     with ScalaCheckDrivenPropertyChecks
     with BeforeAndAfterAll {
-  implicit val scheduler = monix.execution.Scheduler.global
+  implicit override def scheduler: Scheduler = Scheduler.io("monix-task-support-spec")
 
   val tempPath = Files.createTempDirectory(s"lmdb-test-")
   val tempDir  = Directory(Path(tempPath.toFile))
@@ -49,46 +52,55 @@ class LmdbKeyValueStoreSpec
   implicit val log: Log[Task] = new Log.NOPLog[Task]()
 
   it should "put and get data from the store" in {
-    forAll(genData) { expected =>
-      val test = withSut[Task] { sut =>
-        for {
-          result <- sut.testPutGet(expected)
-        } yield result shouldBe expected
-      }
+    PropF
+      .forAllF(genData) { expected =>
+        val test = withSut[Task] { sut =>
+          for {
+            result <- sut.testPutGet(expected)
+          } yield result shouldBe expected
+        }
 
-      test.runSyncUnsafe()
-    }
+        test.void
+      }
+      .check()
+      .map(r => assert(r.passed, r.status.toString))
   }
 
   it should "put and get all data from the store" in {
-    forAll(genData) { expected =>
-      val test = withSut[Task] { sut =>
-        for {
-          result <- sut.testPutIterate(expected)
-        } yield result shouldBe expected
-      }
+    PropF
+      .forAllF(genData) { expected =>
+        val test = withSut[Task] { sut =>
+          for {
+            result <- sut.testPutIterate(expected)
+          } yield result shouldBe expected
+        }
 
-      test.runSyncUnsafe()
-    }
+        test.void
+      }
+      .check()
+      .map(r => assert(r.passed, r.status.toString))
   }
 
   it should "not have deleted keys in the store" in {
-    forAll(genData) { input =>
-      val test = withSut[Task] { sut =>
-        val allKeys = input.keysIterator.toVector
-        // Take some keys for deletion
-        val (getKeys, deleteKeys) = allKeys.splitAt(allKeys.size / 2)
-        val values                = getKeys.map(input.get)
-        // Expected input without deleted keys
-        val expected =
-          getKeys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
-        for {
-          result <- sut.testPutDeleteGet(input, deleteKeys)
-        } yield result shouldBe expected
-      }
+    PropF
+      .forAllF(genData) { input =>
+        val test = withSut[Task] { sut =>
+          val allKeys = input.keysIterator.toVector
+          // Take some keys for deletion
+          val (getKeys, deleteKeys) = allKeys.splitAt(allKeys.size / 2)
+          val values                = getKeys.map(input.get)
+          // Expected input without deleted keys
+          val expected =
+            getKeys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
+          for {
+            result <- sut.testPutDeleteGet(input, deleteKeys)
+          } yield result shouldBe expected
+        }
 
-      test.runSyncUnsafe()
-    }
+        test.void
+      }
+      .check()
+      .map(r => assert(r.passed, r.status.toString))
   }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
@@ -9,16 +9,17 @@ import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.shared.Log
-import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
-import org.scalatest.flatspec.AnyFlatSpec
+import monix.execution.Scheduler
+import monix.testing.scalatest.MonixTaskTest
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class RuntimeSpec extends AnyFlatSpec with Matchers {
-  import monix.execution.Scheduler.Implicits.global
+class RuntimeSpec extends AsyncFlatSpec with MonixTaskTest with Matchers {
+  implicit override def scheduler: Scheduler = Scheduler.io("monix-task-support-spec")
 
-  "emptyStateHash" should "be the same as hard-coded cached value" in effectTest {
+  "emptyStateHash" should "be the same as hard-coded cached value" in {
     implicit val log: Log[Task]         = new Log.NOPLog[Task]
     implicit val span: Span[Task]       = new NoopSpan[Task]
     implicit val metrics: Metrics[Task] = new MetricsNOP[Task]
@@ -49,7 +50,7 @@ class RuntimeSpec extends AnyFlatSpec with Matchers {
     } yield emptyHashHardCoded shouldEqual emptyHash
   }
 
-  "stateHash after fixed rholang term execution " should "be hash fixed without hard fork" in effectTest {
+  "stateHash after fixed rholang term execution " should "be hash fixed without hard fork" in {
     implicit val metricsEff: Metrics[Task] = new Metrics.MetricsNOP[Task]
     implicit val noopSpan: Span[Task]      = NoopSpan[Task]()
     implicit val logger: Log[Task]         = Log.log[Task]

--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
@@ -11,13 +11,11 @@ import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.shared.Log
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
-import monix.execution.Scheduler
 import monix.testing.scalatest.MonixTaskTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class RuntimeSpec extends AsyncFlatSpec with MonixTaskTest with Matchers {
-  implicit override def scheduler: Scheduler = Scheduler.io("monix-task-support-spec")
 
   "emptyStateHash" should "be the same as hard-coded cached value" in {
     implicit val log: Log[Task]         = new Log.NOPLog[Task]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,6 +74,7 @@ object Dependencies {
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.4"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.0"
+  val scalacheckEffect    = "org.typelevel"              %% "scalacheck-effect"         % "1.0.4"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0"  % "test"
   val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.9" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
@@ -140,7 +141,8 @@ object Dependencies {
     "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
   )
 
-  private val testing = Seq(scalactic, scalatest, scalacheck, scalatestPlus, monixTesting)
+  private val testing =
+    Seq(monixTesting, scalacheck, scalacheckEffect, scalactic, scalatest, scalatestPlus)
 
   private val logging = Seq(slf4j, julToSlf4j, scalaLogging, logbackClassic, logstashLogback)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,12 +69,13 @@ object Dependencies {
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
   val magnolia            = "com.propensive"             %% "magnolia"                  % "0.17.0"
   val monix               = "io.monix"                   %% "monix"                     % monixVersion
+  val monixTesting        = "io.monix"                   %% "monix-testing-scalatest"   % "0.3.0"
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.4"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.0"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0"  % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.10" % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.9" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -86,8 +87,8 @@ object Dependencies {
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
   val scalaCompat         = "org.scala-lang.modules"     %% "scala-collection-compat"   % "2.6.0"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.10"   % "test"
-  val scalatestPlus       = "org.scalatestplus"          %% "scalacheck-1-15"           % "3.2.10.0" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.9"   % "test"
+  val scalatestPlus       = "org.scalatestplus"          %% "scalacheck-1-15"           % "3.2.9.0" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"
@@ -139,7 +140,7 @@ object Dependencies {
     "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
   )
 
-  private val testing = Seq(scalactic, scalatest, scalacheck, scalatestPlus)
+  private val testing = Seq(scalactic, scalatest, scalacheck, scalatestPlus, monixTesting)
 
   private val logging = Seq(slf4j, julToSlf4j, scalaLogging, logbackClassic, logstashLogback)
 

--- a/shared/src/main/scala/coop/rchain/shared/ScalaCheckOps.scala
+++ b/shared/src/main/scala/coop/rchain/shared/ScalaCheckOps.scala
@@ -1,0 +1,22 @@
+package coop.rchain.shared
+
+import cats.syntax.all._
+import monix.eval.Task
+import org.scalacheck.effect.PropF
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.{Assertion, Assertions}
+
+/**
+  * Wrappers for writing property-based tests using the ScalaCheck Effect library.
+  */
+object ScalaCheckOps {
+
+  def forAllF[T: Arbitrary, P](f: T => Task[P]): Task[Assertion] =
+    PropF.forAllF(f.map(_.void)).check().map(r => Assertions.assert(r.passed, r.status.toString))
+
+  def forAllF[T: Arbitrary, P](data: Gen[T])(f: T => Task[P]): Task[Assertion] =
+    PropF
+      .forAllF(data)(f.map(_.void))
+      .check()
+      .map(r => Assertions.assert(r.passed, r.status.toString))
+}

--- a/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
+++ b/shared/src/test/scala/coop/rchain/store/InMemoryKeyValueStoreSpec.scala
@@ -4,8 +4,11 @@ import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.shared.syntax._
 import monix.eval.Task
+import monix.execution.Scheduler
+import monix.testing.scalatest.MonixTaskTest
+import org.scalacheck.effect.PropF
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import scodec.codecs.{int64, utf8}
@@ -48,10 +51,11 @@ class KeyValueStoreSut[F[_]: Sync: KeyValueStoreManager] {
 }
 
 class InMemoryKeyValueStoreSpec
-    extends AnyFlatSpec
+    extends AsyncFlatSpec
+    with MonixTaskTest
     with Matchers
     with ScalaCheckDrivenPropertyChecks {
-  implicit val scheduler = monix.execution.Scheduler.global
+  implicit override def scheduler: Scheduler = Scheduler.io("monix-task-support-spec")
 
   def genData: Gen[Map[Long, String]] = {
     val arbKV = Arbitrary.arbitrary[(Long, String)]
@@ -59,71 +63,83 @@ class InMemoryKeyValueStoreSpec
   }
 
   it should "put and get data from the store" in {
-    forAll(genData) { expected =>
-      implicit val kvm = InMemoryStoreManager[Task]
-      val sut          = new KeyValueStoreSut[Task]
-      val test = for {
-        result <- sut.testPutGet(expected)
-      } yield result shouldBe expected
+    PropF
+      .forAllF(genData) { expected =>
+        implicit val kvm = InMemoryStoreManager[Task]
+        val sut          = new KeyValueStoreSut[Task]
+        val test = for {
+          result <- sut.testPutGet(expected)
+        } yield result shouldBe expected
 
-      test.runSyncUnsafe()
-    }
+        test.void
+      }
+      .check()
+      .map(r => assert(r.passed, r.status.toString))
   }
 
   it should "put and get all data from the store" in {
-    forAll(genData) { expected =>
-      implicit val kvm = InMemoryStoreManager[Task]
-      val sut          = new KeyValueStoreSut[Task]
-      val test = for {
-        result <- sut.testPutIterate(expected)
-      } yield result shouldBe expected
+    PropF
+      .forAllF(genData) { expected =>
+        implicit val kvm = InMemoryStoreManager[Task]
+        val sut          = new KeyValueStoreSut[Task]
+        val test = for {
+          result <- sut.testPutIterate(expected)
+        } yield result shouldBe expected
 
-      test.runSyncUnsafe()
-    }
+        test.void
+      }
+      .check()
+      .map(r => assert(r.passed, r.status.toString))
   }
 
   it should "put and collect partial data from the store" in {
-    forAll(genData) { expected =>
-      implicit val kvm = InMemoryStoreManager[Task]
-      val sut          = new KeyValueStoreSut[Task]
+    PropF
+      .forAllF(genData) { expected =>
+        implicit val kvm = InMemoryStoreManager[Task]
+        val sut          = new KeyValueStoreSut[Task]
 
-      val keys = expected.toList.map(_._1)
-      val kMin = keys.min
-      val kMax = keys.min
-      val kAvg = kMax - kMin / 2
-      // Filter expected values
-      val expectedFiltered = expected.filter {
-        case (k, _) => k >= kAvg
+        val keys = expected.toList.map(_._1)
+        val kMin = keys.min
+        val kMax = keys.min
+        val kAvg = kMax - kMin / 2
+        // Filter expected values
+        val expectedFiltered = expected.filter {
+          case (k, _) => k >= kAvg
+        }
+
+        val test = for {
+          // Filter using partial function
+          result <- sut.testPutCollect(expected) {
+                     case (k, fv) if k >= kAvg => (k, fv())
+                   }
+        } yield result shouldBe expectedFiltered
+
+        test.void
       }
-
-      val test = for {
-        // Filter using partial function
-        result <- sut.testPutCollect(expected) {
-                   case (k, fv) if k >= kAvg => (k, fv())
-                 }
-      } yield result shouldBe expectedFiltered
-
-      test.runSyncUnsafe()
-    }
+      .check()
+      .map(r => assert(r.passed, r.status.toString))
   }
 
   it should "not have deleted keys in the store" in {
-    forAll(genData) { input =>
-      implicit val kvm = InMemoryStoreManager[Task]
-      val sut          = new KeyValueStoreSut[Task]
-      val allKeys      = input.keysIterator.toVector
-      // Take some keys for deletion
-      val (getKeys, deleteKeys) = allKeys.splitAt(allKeys.size / 2)
-      val values                = getKeys.map(input.get)
-      // Expected input without deleted keys
-      val expected =
-        getKeys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
-      val test = for {
-        result <- sut.testPutDeleteGet(input, deleteKeys)
-      } yield result shouldBe expected
+    PropF
+      .forAllF(genData) { input =>
+        implicit val kvm = InMemoryStoreManager[Task]
+        val sut          = new KeyValueStoreSut[Task]
+        val allKeys      = input.keysIterator.toVector
+        // Take some keys for deletion
+        val (getKeys, deleteKeys) = allKeys.splitAt(allKeys.size / 2)
+        val values                = getKeys.map(input.get)
+        // Expected input without deleted keys
+        val expected =
+          getKeys.zip(values).filter(_._2.nonEmpty).map { case (k, v) => (k, v.get) }.toMap
+        val test = for {
+          result <- sut.testPutDeleteGet(input, deleteKeys)
+        } yield result shouldBe expected
 
-      test.runSyncUnsafe()
-    }
+        test.void
+      }
+      .check()
+      .map(r => assert(r.passed, r.status.toString))
   }
 
 }


### PR DESCRIPTION
## Overview

Added library [ScalaCheck Effect](https://github.com/typelevel/scalacheck-effect) for writing property-based unit tests in F-context. It is used in conjunction with [Monix Testing](https://index.scala-lang.org/monix/monix-testing) library.

### Example of usage

```scala
import coop.rchain.shared.ScalaCheckOps.forAllF
import monix.eval.Task
import monix.execution.Scheduler
import monix.testing.scalatest.MonixTaskTest
import org.scalatest.flatspec.AsyncFlatSpec
import org.scalatest.matchers.should.Matchers

class PropertyBasedTestsSpec extends AsyncFlatSpec with MonixTaskTest with Matchers {
  implicit override def scheduler: Scheduler = Scheduler.io("monix-task-support-spec")

  it should "work with monix" in {
    forAllF { (x: Int) =>
        Task(x).map(res => assert(res == x))
      }
  }
}
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
