### PR TITLE
Effectful unit-testing with Monix Testing and ScalaTest

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
@@ -9,16 +9,17 @@ import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.shared.Log
-import coop.rchain.shared.scalatestcontrib.effectTest
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
-import org.scalatest.flatspec.AnyFlatSpec
+import monix.execution.Scheduler
+import monix.testing.scalatest.MonixTaskTest
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class RuntimeSpec extends AnyFlatSpec with Matchers {
-  import monix.execution.Scheduler.Implicits.global
+class RuntimeSpec extends AsyncFlatSpec with MonixTaskTest with Matchers {
+  implicit override def scheduler: Scheduler = Scheduler.io("monix-task-support-spec")
 
-  "emptyStateHash" should "be the same as hard-coded cached value" in effectTest {
+  "emptyStateHash" should "be the same as hard-coded cached value" in {
     implicit val log: Log[Task]         = new Log.NOPLog[Task]
     implicit val span: Span[Task]       = new NoopSpan[Task]
     implicit val metrics: Metrics[Task] = new MetricsNOP[Task]
@@ -49,7 +50,7 @@ class RuntimeSpec extends AnyFlatSpec with Matchers {
     } yield emptyHashHardCoded shouldEqual emptyHash
   }
 
-  "stateHash after fixed rholang term execution " should "be hash fixed without hard fork" in effectTest {
+  "stateHash after fixed rholang term execution " should "be hash fixed without hard fork" in {
     implicit val metricsEff: Metrics[Task] = new Metrics.MetricsNOP[Task]
     implicit val noopSpan: Span[Task]      = NoopSpan[Task]()
     implicit val logger: Log[Task]         = Log.log[Task]

--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
@@ -11,13 +11,11 @@ import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.shared.Log
 import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
-import monix.execution.Scheduler
 import monix.testing.scalatest.MonixTaskTest
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class RuntimeSpec extends AsyncFlatSpec with MonixTaskTest with Matchers {
-  implicit override def scheduler: Scheduler = Scheduler.io("monix-task-support-spec")
 
   "emptyStateHash" should "be the same as hard-coded cached value" in {
     implicit val log: Log[Task]         = new Log.NOPLog[Task]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -69,12 +69,13 @@ object Dependencies {
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
   val magnolia            = "com.propensive"             %% "magnolia"                  % "0.17.0"
   val monix               = "io.monix"                   %% "monix"                     % monixVersion
+  val monixTesting        = "io.monix"                   %% "monix-testing-scalatest"   % "0.3.0"
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
   val scalaLogging        = "com.typesafe.scala-logging" %% "scala-logging"             % "3.9.4"
   val scalaUri            = "io.lemonlabs"               %% "scala-uri"                 % "3.0.0"
   val scalacheck          = "org.scalacheck"             %% "scalacheck"                % "1.15.0"
   val scalacheckShapeless = "com.github.alexarchambault" %% "scalacheck-shapeless_1.15" % "1.3.0"  % "test"
-  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.10" % "test"
+  val scalactic           = "org.scalactic"              %% "scalactic"                 % "3.2.9" % "test"
   val scalapbCompiler     = "com.thesamet.scalapb"       %% "compilerplugin"            % scalapb.compiler.Version.scalapbVersion
   val scalapbRuntime      = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion % "protobuf"
   val scalapbRuntimeLib   = "com.thesamet.scalapb"       %% "scalapb-runtime"           % scalapb.compiler.Version.scalapbVersion
@@ -86,8 +87,8 @@ object Dependencies {
   val nettyTcnativeLinux  = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64"
   val nettyTcnativeFedora = "io.netty"                    % "netty-tcnative"            % "2.0.36.Final" classifier "linux-x86_64-fedora"
   val scalaCompat         = "org.scala-lang.modules"     %% "scala-collection-compat"   % "2.6.0"
-  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.10"   % "test"
-  val scalatestPlus       = "org.scalatestplus"          %% "scalacheck-1-15"           % "3.2.10.0" % "test"
+  val scalatest           = "org.scalatest"              %% "scalatest"                 % "3.2.9"   % "test"
+  val scalatestPlus       = "org.scalatestplus"          %% "scalacheck-1-15"           % "3.2.9.0" % "test"
   val scallop             = "org.rogach"                 %% "scallop"                   % "3.1.4"
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"
@@ -139,7 +140,7 @@ object Dependencies {
     "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
   )
 
-  private val testing = Seq(scalactic, scalatest, scalacheck, scalatestPlus)
+  private val testing = Seq(scalactic, scalatest, scalacheck, scalatestPlus, monixTesting)
 
   private val logging = Seq(slf4j, julToSlf4j, scalaLogging, logbackClassic, logstashLogback)
 


### PR DESCRIPTION
## Overview

Added new [Monix Testing](https://index.scala-lang.org/monix/monix-testing) library to run unit tests in F-context. The library supports various test frameworks, including our adopted [ScalaTest](https://www.scalatest.org/).

### Example of usage

```scala
import monix.testing.scalatest.MonixTaskTest
import org.scalatest.flatspec.AsyncFlatSpec
import org.scalatest.matchers.should.Matchers

class EffectfulTestsSpec extends AsyncFlatSpec with MonixTaskTest with Matchers {

  it should "work with monix" in {
    Task { 1 shouldBe 1 }
  }

  it should "produce expected result in for-comprehension" in {
    for {
      r1 <- Task(2)
      r2 <- Task(r1 * 3)
    } yield {
      r1 shouldBe 2
      r2 shouldBe 6
    }
  }

  it should "produce expected result in desugared code" in {
    Task(2).flatMap(r1 => Task(r1 * 3)).asserting(_ shouldBe 6)
  }
}
```

Example of usage also can be found in [RuntimeSpec.scala](https://github.com/rchain/rchain/blob/abf2f9290e80e7398cfb8276060fee5bf519b8d7/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala).

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
