### PR TITLE
Add BigInt support in Rholang

### DIFF
--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -17,6 +17,7 @@ option (scalapb.options) = {
   import: "coop.rchain.models.BitSetBytesMapper.bitSetBytesMapper"
   import: "coop.rchain.models.ParSetTypeMapper.parSetESetTypeMapper"
   import: "coop.rchain.models.ParMapTypeMapper.parMapEMapTypeMapper"
+  import: "coop.rchain.models.BigIntTypeMapper.bigIntBytesTypeMapper"
   preserve_unknown_fields: false
 };
 
@@ -177,6 +178,7 @@ message Expr {
     oneof expr_instance {
         bool g_bool = 1;
         sint64 g_int = 2;
+        bytes g_big_int = 34 [(scalapb.field).type = "scala.math.BigInt"];
         string g_string = 3;
         string g_uri = 4;
         bytes g_byte_array = 25;
@@ -385,6 +387,7 @@ message Connective {
     VarRef var_ref_body = 4;
     bool conn_bool = 5;
     bool conn_int = 6;
+    bool conn_big_int = 10;
     bool conn_string = 7;
     bool conn_uri = 8;
     bool conn_byte_array = 9;

--- a/models/src/main/scala/coop/rchain/models/BigIntTypeMapper.scala
+++ b/models/src/main/scala/coop/rchain/models/BigIntTypeMapper.scala
@@ -1,0 +1,15 @@
+package coop.rchain.models
+
+import com.google.protobuf.ByteString
+import scalapb.TypeMapper
+
+object BigIntTypeMapper {
+  implicit val bigIntBytesTypeMapper: TypeMapper[ByteString, BigInt] =
+    TypeMapper(byteStringToBigInt)(bigIntToByteString)
+
+  private[models] def byteStringToBigInt(byteString: ByteString): BigInt =
+    BigInt(byteString.toByteArray)
+
+  private[models] def bigIntToByteString(bigInt: BigInt): ByteString =
+    ByteString.copyFrom(bigInt.toByteArray)
+}

--- a/models/src/main/scala/coop/rchain/models/EqualsM.scala
+++ b/models/src/main/scala/coop/rchain/models/EqualsM.scala
@@ -57,6 +57,7 @@ object EqualM extends EqualMDerivation {
   }
 
   implicit val IntEqual: EqualM[Int]                           = opaqueEqual
+  implicit val BigIntEqual: EqualM[BigInt]                     = opaqueEqual
   implicit val FloatEqual: EqualM[Float]                       = opaqueEqual
   implicit val LongEqual: EqualM[Long]                         = opaqueEqual
   implicit val DoubleEqual: EqualM[Double]                     = opaqueEqual

--- a/models/src/main/scala/coop/rchain/models/HashM.scala
+++ b/models/src/main/scala/coop/rchain/models/HashM.scala
@@ -8,7 +8,7 @@ import coop.rchain.casper.protocol._
 import coop.rchain.casper.protocol.deploy.v1
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.crypto.signatures.Signed
-import coop.rchain.models.Expr.ExprInstance.GInt
+import coop.rchain.models.Expr.ExprInstance.{GBigInt, GInt}
 
 import java.util.Objects
 import scala.collection.immutable.BitSet
@@ -56,6 +56,7 @@ object HashM extends HashMDerivation {
 
   implicit val BooleanHash: HashM[Boolean]                   = opaqueHash
   implicit val IntHash: HashM[Int]                           = opaqueHash
+  implicit val BigIntHash: HashM[BigInt]                     = opaqueHash
   implicit val FloatHash: HashM[Float]                       = opaqueHash
   implicit val DoubleHash: HashM[Double]                     = opaqueHash
   implicit val StringHash: HashM[String]                     = opaqueHash
@@ -112,7 +113,8 @@ object HashM extends HashMDerivation {
         .map(dataHash => Objects.hash(value.sig, value.sigAlgorithm, Int.box(dataHash)))
   }
 
-  implicit val GIntHash = gen[GInt] //This is only possible to derive here, b/c LongHashM is private
+  implicit val GIntHash    = gen[GInt] //This is only possible to derive here, b/c LongHashM is private
+  implicit val GBigIntHash = gen[GBigInt]
 
   implicit val ConnectiveHash = gen[Connective]
 

--- a/models/src/main/scala/coop/rchain/models/Pretty.scala
+++ b/models/src/main/scala/coop/rchain/models/Pretty.scala
@@ -37,6 +37,7 @@ trait PrettyInstances extends PrettyDerivation {
   implicit val PrettyInt     = fromToString[Int]
   implicit val PrettyLong    = fromToString[Long]
   implicit val PrettyBitSet  = fromToString[BitSet]
+  implicit val PrettyBigInt  = fromToString[BigInt]
 
   // obviously won't print compiling code,
   // but seeing the stacktrace is more important in this case

--- a/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/implicits.scala
@@ -31,6 +31,7 @@ object implicits {
 
   implicit def fromGBool(g: GBool): Expr          = apply(g)
   implicit def fromGInt(g: GInt): Expr            = apply(g)
+  implicit def fromGBigInt(g: GBigInt): Expr      = apply(g)
   implicit def fromGString(g: GString): Expr      = apply(g)
   implicit def fromGUri(g: GUri): Expr            = apply(g)
   implicit def fromByteArray(g: GByteArray): Expr = apply(g)
@@ -232,6 +233,7 @@ object implicits {
       exprInstance match {
         case GBool(_)      => "Bool"
         case GInt(_)       => "Int"
+        case GBigInt(_)    => "BigInt"
         case GString(_)    => "String"
         case GUri(_)       => "Uri"
         case GByteArray(_) => "ByteArray"
@@ -388,6 +390,7 @@ object implicits {
       e.exprInstance match {
         case GBool(_)                                     => false
         case GInt(_)                                      => false
+        case GBigInt(_)                                   => false
         case GString(_)                                   => false
         case GUri(_)                                      => false
         case GByteArray(_)                                => false
@@ -425,6 +428,7 @@ object implicits {
       e.exprInstance match {
         case GBool(_)                                     => BitSet()
         case GInt(_)                                      => BitSet()
+        case GBigInt(_)                                   => BitSet()
         case GString(_)                                   => BitSet()
         case GUri(_)                                      => BitSet()
         case GByteArray(_)                                => BitSet()
@@ -529,6 +533,7 @@ object implicits {
           case VarRefBody(_)            => false
           case _: ConnBool              => true
           case _: ConnInt               => true
+          case _: ConnBigInt            => true
           case _: ConnString            => true
           case _: ConnUri               => true
           case _: ConnByteArray         => true

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ConnectiveSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ConnectiveSortMatcher.scala
@@ -37,6 +37,8 @@ private[sorter] object ConnectiveSortMatcher extends Sortable[Connective] {
         ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_BOOL, if (b) 1 else 0)).pure[F]
       case v @ ConnInt(b) =>
         ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_INT, if (b) 1 else 0)).pure[F]
+      case v @ ConnBigInt(b) =>
+        ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_BIG_INT, if (b) 1 else 0)).pure[F]
       case v @ ConnString(b) =>
         ScoredTerm(Connective(v), Leaves(Score.CONNECTIVE_STRING, if (b) 1 else 0)).pure[F]
       case v @ ConnUri(b) =>

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ExprSortMatcher.scala
@@ -272,9 +272,10 @@ private[sorter] object ExprSortMatcher extends Sortable[Expr] {
         Sortable.sortMatch(gb).map { sorted =>
           ScoredTerm(e, sorted.score)
         }
-      case gi: GInt    => ScoredTerm(e, Leaves(Score.INT, gi.value)).pure[F]
-      case gs: GString => ScoredTerm(e, Node(Score.STRING, Leaf(gs.value))).pure[F]
-      case gu: GUri    => ScoredTerm(e, Node(Score.URI, Leaf(gu.value))).pure[F]
+      case gi: GInt     => ScoredTerm(e, Leaves(Score.INT, gi.value)).pure[F]
+      case gbi: GBigInt => ScoredTerm(e, Node(Score.BIG_INT, Leaf(gbi.value))).pure[F]
+      case gs: GString  => ScoredTerm(e, Node(Score.STRING, Leaf(gs.value))).pure[F]
+      case gu: GUri     => ScoredTerm(e, Node(Score.URI, Leaf(gu.value))).pure[F]
       case GByteArray(ba) =>
         ScoredTerm(e, Node(Score.EBYTEARR, Leaf(ba))).pure[F]
       //TODO get rid of Empty nodes in Protobuf unless they represent sth indeed optional

--- a/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/sorter/ScoreTree.scala
@@ -27,6 +27,7 @@ trait ScoreTree {
 
   sealed trait TaggedAtom
   case class IntAtom(i: Long)         extends TaggedAtom
+  case class BigIntAtom(bi: BigInt)   extends TaggedAtom
   case class StringAtom(s: String)    extends TaggedAtom
   case class BytesAtom(b: ByteString) extends TaggedAtom
 
@@ -54,24 +55,29 @@ trait ScoreTree {
     }
     def compare(that: ScoreAtom): Int =
       (this.value, that.value) match {
-        case (IntAtom(i1), IntAtom(i2))       => i1.compare(i2)
-        case (IntAtom(_), _)                  => -1
-        case (_, IntAtom(_))                  => 1
-        case (StringAtom(s1), StringAtom(s2)) => s1.compare(s2)
-        case (StringAtom(_), _)               => -1
-        case (_, StringAtom(_))               => 1
-        case (BytesAtom(b1), BytesAtom(b2))   => bsCompare(b1, b2)
+        case (IntAtom(i1), IntAtom(i2))         => i1.compare(i2)
+        case (IntAtom(_), _)                    => -1
+        case (_, IntAtom(_))                    => 1
+        case (BigIntAtom(bi1), BigIntAtom(bi2)) => bi1.compare(bi2)
+        case (BigIntAtom(_), _)                 => -1
+        case (_, BigIntAtom(_))                 => 1
+        case (StringAtom(s1), StringAtom(s2))   => s1.compare(s2)
+        case (StringAtom(_), _)                 => -1
+        case (_, StringAtom(_))                 => 1
+        case (BytesAtom(b1), BytesAtom(b2))     => bsCompare(b1, b2)
       }
   }
 
   object ScoreAtom {
     def apply(value: Long): ScoreAtom       = new ScoreAtom(IntAtom(value))
+    def apply(value: BigInt): ScoreAtom     = new ScoreAtom(BigIntAtom(value))
     def apply(value: String): ScoreAtom     = new ScoreAtom(StringAtom(value))
     def apply(value: ByteString): ScoreAtom = new ScoreAtom(BytesAtom(value))
   }
 
   object Leaf {
     def apply(item: Long)       = new Leaf(ScoreAtom(item))
+    def apply(item: BigInt)     = new Leaf(ScoreAtom(item))
     def apply(item: String)     = new Leaf(ScoreAtom(item))
     def apply(item: ByteString) = new Leaf(ScoreAtom(item))
   }
@@ -140,6 +146,7 @@ trait ScoreTree {
     final val DEPLOYER_AUTH  = 10
     final val DEPLOY_ID      = 11
     final val SYS_AUTH_TOKEN = 12
+    final val BIG_INT        = 13
 
     // Vars
     final val BOUND_VAR = 50
@@ -196,6 +203,7 @@ trait ScoreTree {
     final val CONNECTIVE_STRING    = 406
     final val CONNECTIVE_URI       = 407
     final val CONNECTIVE_BYTEARRAY = 408
+    final val CONNECTIVE_BIG_INT   = 409
 
     final val PAR = 999
   }

--- a/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/EqualMSpec.scala
@@ -56,6 +56,7 @@ class EqualMSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers
   sameResultAsReference[ParMap]
 
   sameResultAsReference[Int]
+  sameResultAsReference[BigInt]
   sameResultAsReference[Long]
   sameResultAsReference[String]
   sameResultAsReference[ByteString]

--- a/models/src/test/scala/coop/rchain/models/HashMSpec.scala
+++ b/models/src/test/scala/coop/rchain/models/HashMSpec.scala
@@ -60,6 +60,7 @@ class HashMSpec extends AnyFlatSpec with ScalaCheckPropertyChecks with Matchers 
 
   assertTypeError("sameResultAsReference[Long]") //see the private instance in HashM
   sameResultAsReference[String]
+  sameResultAsReference[BigInt]
   sameResultAsReference[ByteString]
   sameResultAsReference[BitSet]
   sameResultAsReference[AlwaysEqual[BitSet]]

--- a/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
+++ b/models/src/test/scala/coop/rchain/models/rholang/SortTest.scala
@@ -238,11 +238,55 @@ class ParSortMatcherSpec extends AnyFlatSpec with Matchers {
     result.term should be(sortedParGround)
   }
 
-  it should "sort in order of boolean, int, string, uri" in {
+  it should "sort so that smaller BigInt values come first" in {
     val parGround =
-      Par(exprs = List(GUri("https://www.rchain.coop/"), GInt(47), GString("Hello"), GBool(true)))
+      Par(
+        exprs = List(
+          GBigInt(2),
+          GBigInt(BigInt("9999999999999999999999999999999999999999999999")),
+          GBigInt(BigInt("-9999999999999999999999999999999999999999999999")),
+          GBigInt(-2),
+          GBigInt(0)
+        )
+      )
+    val sortedParGround: Par =
+      Par(
+        exprs = List(
+          GBigInt(BigInt("-9999999999999999999999999999999999999999999999")),
+          GBigInt(-2),
+          GBigInt(0),
+          GBigInt(2),
+          GBigInt(BigInt("9999999999999999999999999999999999999999999999"))
+        )
+      )
+    val result = sort(parGround)
+    result.term should be(sortedParGround)
+  }
+
+  it should "sort in order of boolean, int, string, uri, ByteArray, BigInt" in {
+    val byteArray = GByteArray(ByteString.copyFrom(Base16.unsafeDecode("80")))
+    val parGround =
+      Par(
+        exprs = List(
+          byteArray,
+          GBigInt(0),
+          GUri("https://www.rchain.coop/"),
+          GInt(47),
+          GString("Hello"),
+          GBool(true)
+        )
+      )
     val sortedParGround =
-      Par(exprs = List(GBool(true), GInt(47), GString("Hello"), GUri("https://www.rchain.coop/")))
+      Par(
+        exprs = List(
+          GBool(true),
+          GInt(47),
+          GString("Hello"),
+          GUri("https://www.rchain.coop/"),
+          GBigInt(0),
+          byteArray
+        )
+      )
     val result = sort(parGround)
     result.term should be(sortedParGround)
   }
@@ -768,13 +812,14 @@ class ParSortMatcherSpec extends AnyFlatSpec with Matchers {
     result.term should be(sortedParExpr)
   }
 
-  it should "sort logical connectives in \"varref\", \"bool\", \"int\", \"string\", \"uri\", \"bytearray\" order" in {
+  it should "sort logical connectives in \"varref\", \"bool\", \"int\", \"string\", \"uri\", \"bytearray\", \"bigint\" order" in {
     val parExpr =
       Par(
         connectives = List(
           Connective(ConnByteArray(true)),
           Connective(ConnUri(true)),
           Connective(ConnString(true)),
+          Connective(ConnBigInt(true)),
           Connective(ConnInt(true)),
           Connective(ConnBool(true)),
           Connective(
@@ -793,7 +838,8 @@ class ParSortMatcherSpec extends AnyFlatSpec with Matchers {
           Connective(ConnInt(true)),
           Connective(ConnString(true)),
           Connective(ConnUri(true)),
-          Connective(ConnByteArray(true))
+          Connective(ConnByteArray(true)),
+          Connective(ConnBigInt(true))
         ),
         connectiveUsed = true
       )

--- a/rholang/src/main/bnfc/rholang_mercury.cf
+++ b/rholang/src/main/bnfc/rholang_mercury.cf
@@ -167,6 +167,9 @@ BoolFalse.  BoolLiteral ::= "false" ;
 -- Ground types:
 -- The "Literal" suffix avoids collisions with Simple Types
 GroundBool.    Ground ::= BoolLiteral ;
+-- We are forced to use `"BigInt("` instead `"BigInt" "("`. Because we have a conflict with SimpleTypeBigInt in two cases:
+-- 1 case (name quote in contract): `contract "@"BigInt ( )` 2 case (Tuple in match): `match "" {"" => BigInt (1,) "=>" ""}`
+GroundBigInt.  Ground ::= "BigInt(" LongLiteral ")" ;
 GroundInt.     Ground ::= LongLiteral ;
 GroundString.  Ground ::= StringLiteral ;
 GroundUri.     Ground ::= UriLiteral ;
@@ -196,6 +199,7 @@ VarRefKindName. VarRefKind ::= "=" "*" ;
 -- Simple Types:
 SimpleTypeBool. SimpleType ::= "Bool" ;
 SimpleTypeInt. SimpleType ::= "Int" ;
+SimpleTypeBigInt. SimpleType ::= "BigInt" ;
 SimpleTypeString. SimpleType ::= "String" ;
 SimpleTypeUri. SimpleType ::= "Uri" ;
 SimpleTypeByteArray. SimpleType ::= "ByteArray" ;

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -130,6 +130,7 @@ final case class PrettyPrinter(
       case EVarBody(EVar(v)) => buildStringM(v)
       case GBool(b)          => pure(b.toString)
       case GInt(i)           => pure(i.toString)
+      case GBigInt(bi)       => pure("BigInt(" + bi.toString + ")")
       case GString(s)        => pure("\"" + s + "\"")
       case GUri(u)           => pure(s"`$u`")
       // TODO: Figure out if we can prevent ScalaPB from generating
@@ -264,6 +265,7 @@ final case class PrettyPrinter(
           case VarRefBody(value)  => pure(s"=$freeId${freeShift - value.index - 1}")
           case _: ConnBool        => pure("Bool")
           case _: ConnInt         => pure("Int")
+          case _: ConnBigInt      => pure("BigInt")
           case _: ConnString      => pure("String")
           case _: ConnUri         => pure("Uri")
           case _: ConnByteArray   => pure("ByteArray")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/PrettyPrinter.scala
@@ -130,7 +130,7 @@ final case class PrettyPrinter(
       case EVarBody(EVar(v)) => buildStringM(v)
       case GBool(b)          => pure(b.toString)
       case GInt(i)           => pure(i.toString)
-      case GBigInt(bi)       => pure("BigInt(" + bi.toString + ")")
+      case GBigInt(bi)       => pure(s"BigInt($bi)")
       case GString(s)        => pure("\"" + s + "\"")
       case GUri(u)           => pure(s"`$u`")
       // TODO: Figure out if we can prevent ScalaPB from generating

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Substitute.scala
@@ -135,6 +135,7 @@ object Substitute {
                 .map(par.prepend(_, depth))
             case c: ConnBool      => par.prepend(Connective(c), depth).pure[M]
             case c: ConnInt       => par.prepend(Connective(c), depth).pure[M]
+            case c: ConnBigInt    => par.prepend(Connective(c), depth).pure[M]
             case c: ConnString    => par.prepend(Connective(c), depth).pure[M]
             case c: ConnUri       => par.prepend(Connective(c), depth).pure[M]
             case c: ConnByteArray => par.prepend(Connective(c), depth).pure[M]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -93,6 +93,48 @@ trait Costs {
   // + then it copies all elements of the Par
   def toByteArrayCost[T <: StacksafeMessage[_]](a: T): Cost =
     Cost(ProtoM.serializedSize(a).value, "to byte array")
+
+  // Converting rholang BigInt, String or ByteArray into a GInt.
+  // The cost is estimated as the number of bytes in converted data.
+  def toIntCost(bi: BigInt): Cost  = Cost(bigIntSize(bi), "bigint to int")
+  def toIntCost(str: String): Cost = Cost(str.length, "string to int")
+
+  // TODO: Adjust the BigInt operation cost
+  // Converting rholang Int, String or ByteArray into a GBigInt.
+  // The cost is estimated as the number of bytes in converted data.
+  final val INT_TO_BIGINT_COST: Cost  = Cost(8, "int to bigint")
+  def toBigIntCost(str: String): Cost = Cost(str.length, "string to bigint")
+
+  // The number of bytes in the new array is used
+  def bigIntNegation(bi: BigInt): Cost = Cost(bigIntSize(bi), "bigint negation")
+
+  // Сompared byte by byte
+  def bigIntComparison(left: BigInt, right: BigInt): Cost =
+    Cost(scala.math.min(bigIntSize(left), bigIntSize(right)), "bigint comparison")
+
+  // For storing result need to copy N+1 bytes
+  def bigIntSum(left: BigInt, right: BigInt): Cost =
+    Cost(scala.math.max(bigIntSize(left), bigIntSize(right)) + 1, "bigint sum")
+
+  // For storing result need to copy N+1 bytes
+  def bigIntSubtraction(left: BigInt, right: BigInt): Cost =
+    Cost(scala.math.max(bigIntSize(left), bigIntSize(right)) + 1, "bigint subtraction")
+
+  // Assumed to be used long multiplication
+  def bigIntMultiplication(left: BigInt, right: BigInt): Cost =
+    Cost(bigIntSize(left) * bigIntSize(right), "bigint multiplication")
+
+  // Assumed to be used long division
+  def bigIntDivision(left: BigInt, right: BigInt): Cost =
+    Cost(bigIntSize(left) * bigIntSize(right), "bigint division")
+
+  // Assumed to be used long division
+  def bigIntModulo(left: BigInt, right: BigInt): Cost =
+    Cost(bigIntSize(left) * bigIntSize(right), "bigint modulo")
+
+  // Calculate number of bytes needed to storyng BigInt value
+  def bigIntSize(bi: BigInt): Int = bi.bitLength / 8 + 1
+
   //TODO: adjust the cost of size method
   def sizeMethodCost(size: Int): Cost = Cost(size, "size")
   // slice(from, to) needs to drop `from` elements and then append `to - from` elements

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -94,12 +94,11 @@ trait Costs {
   def toByteArrayCost[T <: StacksafeMessage[_]](a: T): Cost =
     Cost(ProtoM.serializedSize(a).value, "to byte array")
 
-  // Converting rholang BigInt, String or ByteArray into a GInt.
+  // Converting rholang BigInt, String into a GInt.
   // The cost is estimated as the number of bytes in converted data.
   def toIntCost(bi: BigInt): Cost  = Cost(bigIntSize(bi), "bigint to int")
   def toIntCost(str: String): Cost = Cost(str.length, "string to int")
 
-  // TODO: Adjust the BigInt operation cost
   // Converting rholang Int, String or ByteArray into a GBigInt.
   // The cost is estimated as the number of bytes in converted data.
   final val INT_TO_BIGINT_COST: Cost  = Cost(8, "int to bigint")

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundNormalizeMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundNormalizeMatcher.scala
@@ -1,43 +1,26 @@
 package coop.rchain.rholang.interpreter.compiler.normalizer
 
-import cats.MonadError
+import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.models.Expr
 import coop.rchain.models.Expr.ExprInstance.{GBigInt, GInt, GString, GUri}
-import coop.rchain.rholang.ast.rholang_mercury.Absyn.{
-  Ground,
-  GroundBigInt,
-  GroundBool,
-  GroundInt,
-  GroundString,
-  GroundUri
-}
+import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 import coop.rchain.rholang.interpreter.errors.NormalizerError
 
-import scala.util.Try
-
 object GroundNormalizeMatcher {
-  def normalizeMatch[F[_]](g: Ground)(implicit M: MonadError[F, Throwable]): F[Expr] =
+  def normalizeMatch[F[_]: Sync](g: Ground): F[Expr] =
     g match {
       case gb: GroundBool => Expr(BoolNormalizeMatcher.normalizeMatch(gb.boolliteral_)).pure[F]
       case gi: GroundInt =>
-        M.fromTry(
-            Try(gi.longliteral_.toLong).adaptError {
-              case e: NumberFormatException => NormalizerError(e.getMessage)
-            }
-          )
-          .map { long =>
-            Expr(GInt(long))
-          }
+        Sync[F]
+          .delay(gi.longliteral_.toLong)
+          .adaptError { case e: NumberFormatException => NormalizerError(e.getMessage) }
+          .map(long => Expr(GInt(long)))
       case gbi: GroundBigInt =>
-        M.fromTry(
-            Try(BigInt(gbi.longliteral_)).adaptError {
-              case e: NumberFormatException => NormalizerError(e.getMessage)
-            }
-          )
-          .map { bigInt =>
-            Expr(GBigInt(bigInt))
-          }
+        Sync[F]
+          .delay(BigInt(gbi.longliteral_))
+          .adaptError { case e: NumberFormatException => NormalizerError(e.getMessage) }
+          .map(bigInt => Expr(GBigInt(bigInt)))
       case gs: GroundString => Expr(GString(stripString(gs.stringliteral_))).pure[F]
       case gu: GroundUri    => Expr(GUri(stripUri(gu.uriliteral_))).pure[F]
     }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PSimpleTypeNormalizer.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/compiler/normalizer/processes/PSimpleTypeNormalizer.scala
@@ -1,25 +1,12 @@
 package coop.rchain.rholang.interpreter.compiler.normalizer.processes
 
-import cats.syntax.all._
 import cats.effect.Sync
-import coop.rchain.models.Connective.ConnectiveInstance.{
-  ConnBool,
-  ConnByteArray,
-  ConnInt,
-  ConnString,
-  ConnUri
-}
-import coop.rchain.models.{Connective, Par}
+import cats.syntax.all._
+import coop.rchain.models.Connective
+import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.rholang.implicits._
+import coop.rchain.rholang.ast.rholang_mercury.Absyn._
 import coop.rchain.rholang.interpreter.compiler.{ProcVisitInputs, ProcVisitOutputs}
-import coop.rchain.rholang.ast.rholang_mercury.Absyn.{
-  PSimpleType,
-  SimpleTypeBool,
-  SimpleTypeByteArray,
-  SimpleTypeInt,
-  SimpleTypeString,
-  SimpleTypeUri
-}
 
 object PSimpleTypeNormalizer {
   def normalize[F[_]: Sync](p: PSimpleType, input: ProcVisitInputs): F[ProcVisitOutputs] =
@@ -35,6 +22,13 @@ object PSimpleTypeNormalizer {
         ProcVisitOutputs(
           input.par
             .prepend(Connective(ConnInt(true)), input.boundMapChain.depth)
+            .withConnectiveUsed(true),
+          input.freeMap
+        ).pure[F]
+      case _: SimpleTypeBigInt =>
+        ProcVisitOutputs(
+          input.par
+            .prepend(Connective(ConnBigInt(true)), input.boundMapChain.depth)
             .withConnectiveUsed(true),
           input.freeMap
         ).pure[F]

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/ParCount.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/ParCount.scala
@@ -107,6 +107,7 @@ private[matcher] object ParCount {
         (ParCount(), ParCount())
       case _: ConnBool      => (ParCount(exprs = 1), ParCount(exprs = 1))
       case _: ConnInt       => (ParCount(exprs = 1), ParCount(exprs = 1))
+      case _: ConnBigInt    => (ParCount(exprs = 1), ParCount(exprs = 1))
       case _: ConnString    => (ParCount(exprs = 1), ParCount(exprs = 1))
       case _: ConnUri       => (ParCount(exprs = 1), ParCount(exprs = 1))
       case _: ConnByteArray => (ParCount(exprs = 1), ParCount(exprs = 1))

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/matcher/SpatialMatcher.scala
@@ -317,6 +317,13 @@ trait SpatialMatcherInstances {
             case _ => MonoidK[F].empty[Unit]
           }
 
+        case _: ConnBigInt =>
+          target.singleExpr match {
+            case Some(Expr(GBigInt(_))) =>
+              ().pure[F]
+            case _ => MonoidK[F].empty[Unit]
+          }
+
         case _: ConnString =>
           target.singleExpr match {
             case Some(Expr(GString(_))) =>

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/BigIntNormalizerSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/BigIntNormalizerSpec.scala
@@ -111,7 +111,7 @@ class BigIntNormalizerSpec extends AsyncFlatSpec with MonixTaskTest with Matcher
     }
   }
 
-  it should "return throw error if input data isn't number string" in {
+  it should "return throw error if input data isn't number string or it is negative number" in {
     val term1 =
       s"""
          # @"$outcomeCh"!(BigInt(NOTNUMBER))
@@ -124,14 +124,20 @@ class BigIntNormalizerSpec extends AsyncFlatSpec with MonixTaskTest with Matcher
       s"""
          # @"$outcomeCh"!(BigInt(9999999999999999999999999999999999999999999999 NOTNUMBER))
          # """.stripMargin('#')
+    val term4 =
+      s"""
+         # @"$outcomeCh"!(BigInt(-9999999999999999999999999999999999999999999999))
+         # """.stripMargin('#')
     for {
       r1 <- execute[Task](term1)
       r2 <- execute[Task](term2)
       r3 <- execute[Task](term3)
+      r4 <- execute[Task](term4)
     } yield {
       r1 should equal(Left(SyntaxError("syntax error(): NOTNUMBER at 2:17-2:26")))
       r2 should equal(Left(SyntaxError("syntax error(): NOTNUMBER at 2:63-2:72")))
       r3 should equal(Left(SyntaxError("syntax error(): NOTNUMBER at 2:64-2:73")))
+      r4 should equal(Left(SyntaxError("syntax error(): - at 2:17-2:18")))
     }
   }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/BigIntNormalizerSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/BigIntNormalizerSpec.scala
@@ -1,5 +1,8 @@
 package coop.rchain.rholang.interpreter
 
+import cats.Parallel
+import cats.effect.{Concurrent, ContextShift}
+import cats.syntax.all._
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.Expr.ExprInstance.GString
@@ -9,22 +12,21 @@ import coop.rchain.rholang.interpreter.errors.{InterpreterError, SyntaxError}
 import coop.rchain.rholang.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
-import monix.execution.Scheduler.Implicits.global
+import monix.testing.scalatest.MonixTaskTest
+import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
-import scala.concurrent.duration._
-
-class BigIntNormalizerSpec extends AnyWordSpec with Matchers {
+class BigIntNormalizerSpec extends AsyncFlatSpec with MonixTaskTest with Matchers {
   implicit val logF: Log[Task]            = Log.log[Task]
   implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
   implicit val noopSpan: Span[Task]       = NoopSpan[Task]()
-  private val maxDuration                 = 5.seconds
 
   val outcomeCh = "ret"
 
-  private def execute(source: String): Task[Either[InterpreterError, BigInt]] =
-    mkRuntime[Task]("rholang-bigint")
+  private def execute[F[_]: Concurrent: Parallel: ContextShift: Metrics: Span: Log](
+      source: String
+  ): F[Either[InterpreterError, BigInt]] =
+    mkRuntime[F]("rholang-bigint")
       .use { runtime =>
         for {
           evalResult <- runtime.evaluate(source)
@@ -33,120 +35,103 @@ class BigIntNormalizerSpec extends AnyWordSpec with Matchers {
                        data         <- runtime.getData(GString(outcomeCh)).map(_.head)
                        bigIntResult = data.a.pars.head.exprs.head.getGBigInt
                      } yield Right(bigIntResult)
-                   else Task.pure(Left(evalResult.errors.head))
+                   else Left(evalResult.errors.head).pure[F]
         } yield result
       }
 
-  "method toBigInt()" should {
-    "convert Rholang Int value to BigInt" in {
-      val termWithNull =
-        s"""
+  "method toBigInt()" should "convert Rholang Int value to BigInt" in {
+    val termWithNull =
+      s"""
            # @"$outcomeCh"!(0.toBigInt())
            # """.stripMargin('#')
-      execute(termWithNull).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt(0))
-      )
-      val termWithMaxLong =
-        s"""
+    val termWithMaxLong =
+      s"""
            # @"$outcomeCh"!(9223372036854775807.toBigInt())
            # """.stripMargin('#')
-      execute(termWithMaxLong).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt(9223372036854775807L))
-      )
-      val termWithMinLong =
-        s"""
+    val termWithMinLong =
+      s"""
            # @"$outcomeCh"!((-9223372036854775807).toBigInt())
            # """.stripMargin('#')
-      execute(termWithMinLong).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt(-9223372036854775807L))
-      )
-    }
-
-    "convert Rholang String to BigInt" in {
-      val termWithNull =
-        s"""
-           # @"$outcomeCh"!("0".toBigInt())
-           # """.stripMargin('#')
-      execute(termWithNull).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt("0"))
-      )
-      val termWithPositiveBigValue =
-        s"""
-           # @"$outcomeCh"!("9999999999999999999999999999999999999999999999".toBigInt())
-           # """.stripMargin('#')
-      execute(termWithPositiveBigValue).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt("9999999999999999999999999999999999999999999999"))
-      )
-      val termWithNegativeBigValue =
-        s"""
-           # @"$outcomeCh"!("-9999999999999999999999999999999999999999999999".toBigInt())
-           # """.stripMargin('#')
-      execute(termWithNegativeBigValue).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt("-9999999999999999999999999999999999999999999999"))
-      )
+    for {
+      r1 <- execute[Task](termWithNull)
+      r2 <- execute[Task](termWithMaxLong)
+      r3 <- execute[Task](termWithMinLong)
+    } yield {
+      r1 should equal(Right(BigInt(0)))
+      r2 should equal(Right(BigInt(9223372036854775807L)))
+      r3 should equal(Right(BigInt(-9223372036854775807L)))
     }
   }
 
-  "BigInt() constructor" should {
-    "create BigInt value" in {
-      val termWithNull =
-        s"""
+  it should "convert Rholang String to BigInt" in {
+    val termWithNull =
+      s"""
+         # @"$outcomeCh"!("0".toBigInt())
+         # """.stripMargin('#')
+    val termWithPositiveBigValue =
+      s"""
+         # @"$outcomeCh"!("9999999999999999999999999999999999999999999999".toBigInt())
+         # """.stripMargin('#')
+    val termWithNegativeBigValue =
+      s"""
+         # @"$outcomeCh"!("-9999999999999999999999999999999999999999999999".toBigInt())
+         # """.stripMargin('#')
+    for {
+      r1 <- execute[Task](termWithNull)
+      r2 <- execute[Task](termWithPositiveBigValue)
+      r3 <- execute[Task](termWithNegativeBigValue)
+    } yield {
+      r1 should equal(Right(BigInt("0")))
+      r2 should equal(Right(BigInt("9999999999999999999999999999999999999999999999")))
+      r3 should equal(Right(BigInt("-9999999999999999999999999999999999999999999999")))
+    }
+  }
+
+  "BigInt() constructor" should "create BigInt value" in {
+    val termWithNull =
+      s"""
            # @"$outcomeCh"!( BigInt(0) )
            # """.stripMargin('#')
-      execute(termWithNull).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt("0"))
-      )
-      val termWithPositiveBigValue =
-        s"""
+    val termWithPositiveBigValue =
+      s"""
            # @"$outcomeCh"!( BigInt( 9999999999999999999999999999999999999999999999 ) )
            # """.stripMargin('#')
-      execute(termWithPositiveBigValue).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt("9999999999999999999999999999999999999999999999"))
-      )
-      val termWithNegativeBigValue =
-        s"""
+    val termWithNegativeBigValue =
+      s"""
            # @"$outcomeCh"!( -BigInt(9999999999999999999999999999999999999999999999) )
            # """.stripMargin('#')
-      execute(termWithNegativeBigValue).runSyncUnsafe(maxDuration) should equal(
-        Right(BigInt("-9999999999999999999999999999999999999999999999"))
-      )
-    }
-
-    "return throw error if input data isn't number string" in {
-      val term1 =
-        s"""
-         # @"$outcomeCh"!(BigInt(NOTNUMBER))
-         # """.stripMargin('#')
-      execute(term1).runSyncUnsafe(maxDuration) should equal(
-        Left(
-          SyntaxError(
-            "syntax error(): NOTNUMBER at 2:17-2:26"
-          )
-        )
-      )
-      val term2 =
-        s"""
-         # @"$outcomeCh"!(BigInt(9999999999999999999999999999999999999999999999NOTNUMBER))
-         # """.stripMargin('#')
-      execute(term2).runSyncUnsafe(maxDuration) should equal(
-        Left(
-          SyntaxError(
-            "syntax error(): NOTNUMBER at 2:63-2:72"
-          )
-        )
-      )
-      val term3 =
-        s"""
-         # @"$outcomeCh"!(BigInt(9999999999999999999999999999999999999999999999 NOTNUMBER))
-         # """.stripMargin('#')
-      execute(term3).runSyncUnsafe(maxDuration) should equal(
-        Left(
-          SyntaxError(
-            "syntax error(): NOTNUMBER at 2:64-2:73"
-          )
-        )
-      )
+    for {
+      r1 <- execute[Task](termWithNull)
+      r2 <- execute[Task](termWithPositiveBigValue)
+      r3 <- execute[Task](termWithNegativeBigValue)
+    } yield {
+      r1 should equal(Right(BigInt("0")))
+      r2 should equal(Right(BigInt("9999999999999999999999999999999999999999999999")))
+      r3 should equal(Right(BigInt("-9999999999999999999999999999999999999999999999")))
     }
   }
 
+  it should "return throw error if input data isn't number string" in {
+    val term1 =
+      s"""
+         # @"$outcomeCh"!(BigInt(NOTNUMBER))
+         # """.stripMargin('#')
+    val term2 =
+      s"""
+         # @"$outcomeCh"!(BigInt(9999999999999999999999999999999999999999999999NOTNUMBER))
+         # """.stripMargin('#')
+    val term3 =
+      s"""
+         # @"$outcomeCh"!(BigInt(9999999999999999999999999999999999999999999999 NOTNUMBER))
+         # """.stripMargin('#')
+    for {
+      r1 <- execute[Task](term1)
+      r2 <- execute[Task](term2)
+      r3 <- execute[Task](term3)
+    } yield {
+      r1 should equal(Left(SyntaxError("syntax error(): NOTNUMBER at 2:17-2:26")))
+      r2 should equal(Left(SyntaxError("syntax error(): NOTNUMBER at 2:63-2:72")))
+      r3 should equal(Left(SyntaxError("syntax error(): NOTNUMBER at 2:64-2:73")))
+    }
+  }
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/BigIntNormalizerSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/BigIntNormalizerSpec.scala
@@ -1,0 +1,152 @@
+package coop.rchain.rholang.interpreter
+
+import coop.rchain.metrics
+import coop.rchain.metrics.{Metrics, NoopSpan, Span}
+import coop.rchain.models.Expr.ExprInstance.GString
+import coop.rchain.models.rholang.implicits._
+import coop.rchain.rholang.Resources.mkRuntime
+import coop.rchain.rholang.interpreter.errors.{InterpreterError, SyntaxError}
+import coop.rchain.rholang.syntax._
+import coop.rchain.shared.Log
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration._
+
+class BigIntNormalizerSpec extends AnyWordSpec with Matchers {
+  implicit val logF: Log[Task]            = Log.log[Task]
+  implicit val noopMetrics: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
+  implicit val noopSpan: Span[Task]       = NoopSpan[Task]()
+  private val maxDuration                 = 5.seconds
+
+  val outcomeCh = "ret"
+
+  private def execute(source: String): Task[Either[InterpreterError, BigInt]] =
+    mkRuntime[Task]("rholang-bigint")
+      .use { runtime =>
+        for {
+          evalResult <- runtime.evaluate(source)
+          result <- if (evalResult.errors.isEmpty)
+                     for {
+                       data         <- runtime.getData(GString(outcomeCh)).map(_.head)
+                       bigIntResult = data.a.pars.head.exprs.head.getGBigInt
+                     } yield Right(bigIntResult)
+                   else Task.pure(Left(evalResult.errors.head))
+        } yield result
+      }
+
+  "method toBigInt()" should {
+    "convert Rholang Int value to BigInt" in {
+      val termWithNull =
+        s"""
+           # @"$outcomeCh"!(0.toBigInt())
+           # """.stripMargin('#')
+      execute(termWithNull).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt(0))
+      )
+      val termWithMaxLong =
+        s"""
+           # @"$outcomeCh"!(9223372036854775807.toBigInt())
+           # """.stripMargin('#')
+      execute(termWithMaxLong).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt(9223372036854775807L))
+      )
+      val termWithMinLong =
+        s"""
+           # @"$outcomeCh"!((-9223372036854775807).toBigInt())
+           # """.stripMargin('#')
+      execute(termWithMinLong).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt(-9223372036854775807L))
+      )
+    }
+
+    "convert Rholang String to BigInt" in {
+      val termWithNull =
+        s"""
+           # @"$outcomeCh"!("0".toBigInt())
+           # """.stripMargin('#')
+      execute(termWithNull).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt("0"))
+      )
+      val termWithPositiveBigValue =
+        s"""
+           # @"$outcomeCh"!("9999999999999999999999999999999999999999999999".toBigInt())
+           # """.stripMargin('#')
+      execute(termWithPositiveBigValue).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt("9999999999999999999999999999999999999999999999"))
+      )
+      val termWithNegativeBigValue =
+        s"""
+           # @"$outcomeCh"!("-9999999999999999999999999999999999999999999999".toBigInt())
+           # """.stripMargin('#')
+      execute(termWithNegativeBigValue).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt("-9999999999999999999999999999999999999999999999"))
+      )
+    }
+  }
+
+  "BigInt() constructor" should {
+    "create BigInt value" in {
+      val termWithNull =
+        s"""
+           # @"$outcomeCh"!( BigInt(0) )
+           # """.stripMargin('#')
+      execute(termWithNull).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt("0"))
+      )
+      val termWithPositiveBigValue =
+        s"""
+           # @"$outcomeCh"!( BigInt( 9999999999999999999999999999999999999999999999 ) )
+           # """.stripMargin('#')
+      execute(termWithPositiveBigValue).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt("9999999999999999999999999999999999999999999999"))
+      )
+      val termWithNegativeBigValue =
+        s"""
+           # @"$outcomeCh"!( -BigInt(9999999999999999999999999999999999999999999999) )
+           # """.stripMargin('#')
+      execute(termWithNegativeBigValue).runSyncUnsafe(maxDuration) should equal(
+        Right(BigInt("-9999999999999999999999999999999999999999999999"))
+      )
+    }
+
+    "return throw error if input data isn't number string" in {
+      val term1 =
+        s"""
+         # @"$outcomeCh"!(BigInt(NOTNUMBER))
+         # """.stripMargin('#')
+      execute(term1).runSyncUnsafe(maxDuration) should equal(
+        Left(
+          SyntaxError(
+            "syntax error(): NOTNUMBER at 2:17-2:26"
+          )
+        )
+      )
+      val term2 =
+        s"""
+         # @"$outcomeCh"!(BigInt(9999999999999999999999999999999999999999999999NOTNUMBER))
+         # """.stripMargin('#')
+      execute(term2).runSyncUnsafe(maxDuration) should equal(
+        Left(
+          SyntaxError(
+            "syntax error(): NOTNUMBER at 2:63-2:72"
+          )
+        )
+      )
+      val term3 =
+        s"""
+         # @"$outcomeCh"!(BigInt(9999999999999999999999999999999999999999999999 NOTNUMBER))
+         # """.stripMargin('#')
+      execute(term3).runSyncUnsafe(maxDuration) should equal(
+        Left(
+          SyntaxError(
+            "syntax error(): NOTNUMBER at 2:64-2:73"
+          )
+        )
+      )
+    }
+  }
+
+}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PrettyPrinterTest.scala
@@ -51,6 +51,12 @@ class GroundPrinterSpec extends AnyFlatSpec with Matchers {
     PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Coeval](gi).value) shouldBe target
   }
 
+  "GroundBigInt" should "Print as \" 9999999999999999999999999999999999999999 \"" in {
+    val gbi            = new GroundBigInt("9999999999999999999999999999999999999999")
+    val target: String = "BigInt(9999999999999999999999999999999999999999)"
+    PrettyPrinter().buildString(GroundNormalizeMatcher.normalizeMatch[Coeval](gbi).value) shouldBe target
+  }
+
   "GroundString" should "Print as \"" + "String" + "\"" in {
     val gs             = new GroundString("\"String\"")
     val target: String = "\"" + "String" + "\""

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2343,4 +2343,332 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       ReduceError("The number of terms in the Par is 32768, which exceeds the limit of 32767.")
     )
   }
+
+  "BigInt" should "work correctly with arithmetic operations" in {
+    val table = Table(
+      ("clue", "input", "output"),
+      (
+        """-BigInt(9999999999999999999999999999999999999999) => 
+          |BigInt(-9999999999999999999999999999999999999999999999)""".stripMargin,
+        ENegBody(ENeg(GBigInt(BigInt("9999999999999999999999999999999999999999")))),
+        GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+      ),
+      (
+        """BigInt(9999999999999999999999999999999999999999) * 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |BigInt(-99999999999999999999999999999999999999980000000000000000000000000000000000000001)""".stripMargin,
+        EMultBody(
+          EMult(
+            GBigInt(BigInt("9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBigInt(
+          BigInt(
+            "-99999999999999999999999999999999999999980000000000000000000000000000000000000001"
+          )
+        )
+      ),
+      (
+        """BigInt(-99999999999999999999999999999999999999980000000000000000000000000000000000000001) / 
+          |BigInt(9999999999999999999999999999999999999999) => 
+          |BigInt(-9999999999999999999999999999999999999999)""".stripMargin,
+        EDivBody(
+          EDiv(
+            GBigInt(
+              BigInt(
+                "-99999999999999999999999999999999999999980000000000000000000000000000000000000001"
+              )
+            ),
+            GBigInt(BigInt("9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBigInt(
+          BigInt("-9999999999999999999999999999999999999999")
+        )
+      ),
+      (
+        """BigInt(99999999999999999999999999999999999999980000000000000000000000000000000000000002) % 
+          |BigInt(9999999999999999999999999999999999999999) => 
+          |BigInt(1)""".stripMargin,
+        EModBody(
+          EMod(
+            GBigInt(
+              BigInt(
+                "99999999999999999999999999999999999999980000000000000000000000000000000000000002"
+              )
+            ),
+            GBigInt(BigInt("9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBigInt(
+          BigInt("1")
+        )
+      ),
+      (
+        """BigInt(-9999999999999999999999999999999999999999) + 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |BigInt(-19999999999999999999999999999999999999998)""".stripMargin,
+        EPlusBody(
+          EPlus(
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBigInt(
+          BigInt("-19999999999999999999999999999999999999998")
+        )
+      ),
+      (
+        """BigInt(-9999999999999999999999999999999999999999) - 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |BigInt(0)""".stripMargin,
+        EMinusBody(
+          EMinus(
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBigInt(
+          BigInt("0")
+        )
+      )
+    )
+    forAll(table) { (clue, input, output) =>
+      val result = runReducer(input).map(_.exprs)
+      result should be(Right(Seq(Expr(output)))) withClue clue
+    }
+  }
+
+  "BigInt" should "work correctly with сomparison operations" in {
+    val table = Table(
+      ("clue", "input", "output"),
+      (
+        """BigInt(-9999999999999999999999999999999999999999) < 
+          |BigInt(9999999999999999999999999999999999999999) => 
+          |true""".stripMargin,
+        ELtBody(
+          ELt(
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBool(true)
+      ),
+      (
+        """BigInt(-9999999999999999999999999999999999999999) < 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |false""".stripMargin,
+        ELtBody(
+          ELt(
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBool(false)
+      ),
+      (
+        """BigInt(-9999999999999999999999999999999999999999) <= 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |true""".stripMargin,
+        ELteBody(
+          ELte(
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBool(true)
+      ),
+      (
+        """BigInt(-9999999999999999999999999999999999999998) <= 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |false""".stripMargin,
+        ELteBody(
+          ELte(
+            GBigInt(BigInt("-9999999999999999999999999999999999999998")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBool(false)
+      ),
+      (
+        """BigInt(9999999999999999999999999999999999999999) > 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |true""".stripMargin,
+        EGtBody(
+          EGt(
+            GBigInt(BigInt("9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBool(true)
+      ),
+      (
+        """BigInt(-9999999999999999999999999999999999999999) > 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |false""".stripMargin,
+        EGtBody(
+          EGt(
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBool(false)
+      ),
+      (
+        """BigInt(-9999999999999999999999999999999999999999) >= 
+          |BigInt(-9999999999999999999999999999999999999999) => 
+          |true""".stripMargin,
+        EGteBody(
+          EGte(
+            GBigInt(BigInt("-9999999999999999999999999999999999999999")),
+            GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBool(true)
+      ),
+      (
+        """BigInt(9999999999999999999999999999999999999998) >= 
+          |BigInt(9999999999999999999999999999999999999999) => 
+          |false""".stripMargin,
+        EGteBody(
+          EGte(
+            GBigInt(BigInt("9999999999999999999999999999999999999998")),
+            GBigInt(BigInt("9999999999999999999999999999999999999999"))
+          )
+        ),
+        GBool(false)
+      )
+    )
+
+    forAll(table) { (clue, input, output) =>
+      val result = runReducer(input).map(_.exprs)
+      result should be(Right(Seq(Expr(output)))) withClue clue
+    }
+  }
+
+  "Reducer" should "return report errors with failure BigInt operations" in {
+    val table = Table(
+      ("clue", "input", "output"),
+      (
+        """BigInt(1) * 1 => OperatorExpectedError""",
+        EMultBody(EMult(GBigInt(BigInt("1")), GInt(1))),
+        OperatorExpectedError("*", "BigInt", GInt(1).typ)
+      ),
+      (
+        """BigInt(1) >= 1 => ReduceError""",
+        EGteBody(EGte(GBigInt(BigInt("1")), GInt(1))),
+        ReduceError(
+          "Unexpected compare: " + GBigInt(BigInt("1")).exprs.head + " vs. " + GInt(1).exprs.head
+        )
+      )
+    )
+
+    forAll(table) { (clue, input, error) =>
+      runReducer(input) should be(Left(error)) withClue clue
+    }
+  }
+
+  "Reducer" should "work correctly with toInt() method" in {
+    val table = Table(
+      ("clue", "input", "output"),
+      (
+        """(-1).toInt() => -1""",
+        EMethod("toInt", GInt(-1)),
+        GInt(-1)
+      ),
+      (
+        """BigInt(9223372036854775807).toInt() => 9223372036854775807""",
+        EMethod("toInt", GBigInt(BigInt("9223372036854775807"))),
+        GInt(9223372036854775807L)
+      ),
+      (
+        """"-9223372036854775808".toInt() => -9223372036854775808""",
+        EMethod("toInt", GString("-9223372036854775808")),
+        GInt(-9223372036854775808L)
+      )
+    )
+
+    forAll(table) { (clue, input, output) =>
+      val result = runReducer(input).map(_.exprs)
+      result should be(Right(Seq(Expr(output)))) withClue clue
+    }
+  }
+
+  "Reducer" should "work correctly with toBigInt() method" in {
+    val table = Table(
+      ("clue", "input", "output"),
+      (
+        """BigInt(-1).toBigInt() => BigInt(-1)""",
+        EMethod("toBigInt", GBigInt(BigInt("-1"))),
+        GBigInt(BigInt("-1"))
+      ),
+      (
+        """(-1).toBigInt() => BigInt(-1)""",
+        EMethod("toBigInt", GInt(-1)),
+        GBigInt(BigInt("-1"))
+      ),
+      (
+        """"-9999999999999999999999999999999999999999".toBigInt() => 
+          |BigInt(-9999999999999999999999999999999999999999)""".stripMargin,
+        EMethod("toBigInt", GString("-9999999999999999999999999999999999999999")),
+        GBigInt(BigInt("-9999999999999999999999999999999999999999"))
+      )
+    )
+
+    forAll(table) { (clue, input, output) =>
+      val result = runReducer(input).map(_.exprs)
+      result should be(Right(Seq(Expr(output)))) withClue clue
+    }
+  }
+
+  "Reducer" should "return report errors in failure cases with toInt() method" in {
+    val table = Table(
+      ("clue", "input", "output"),
+      (
+        """BigInt(9999999999999999999999999999999999999999).toInt() => ReduceError""",
+        EMethod("toInt", GBigInt(BigInt("9999999999999999999999999999999999999999"))),
+        ReduceError("Error: input value out of range")
+      ),
+      (
+        """"WRONG".toInt() => ReduceError""",
+        EMethod("toInt", GString("WRONG")),
+        ReduceError(
+          """Error: exception was thrown when decoding input String to Int: For input string: "WRONG""""
+        )
+      ),
+      (
+        """Set().toInt() => ReduceError""",
+        EMethod("toInt", ESetBody(ParSet(List()))),
+        MethodNotDefined("toInt", "Set")
+      )
+    )
+
+    forAll(table) { (clue, input, error) =>
+      runReducer(input) should be(Left(error)) withClue clue
+    }
+  }
+
+  "Reducer" should "return report errors in failure cases with toBigInt() method" in {
+    val table = Table(
+      ("clue", "input", "output"),
+      (
+        """"WRONG".toBigInt() => ReduceError""",
+        EMethod("toBigInt", GString("WRONG")),
+        ReduceError(
+          """Error: exception was thrown when decoding input String to BigInt: For input string: "WRONG""""
+        )
+      ),
+      (
+        """Set().toBigInt() => ReduceError""",
+        EMethod("toBigInt", ESetBody(ParSet(List()))),
+        MethodNotDefined("toBigInt", "Set")
+      )
+    )
+
+    forAll(table) { (clue, input, error) =>
+      runReducer(input) should be(Left(error)) withClue clue
+    }
+  }
+
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2344,19 +2344,19 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     )
   }
 
-  "Reducer" should "perform arithmetic operations with BigInt" in {
+  "reducer" should "perform arithmetic operations with BigInt" in {
     val table = Table(
       ("clue", "input", "output"),
       (
-        """-BigInt(9999999999999999999999999999999999999999) => 
-          |BigInt(-9999999999999999999999999999999999999999999999)""".stripMargin,
+        """-(BigInt(9999999999999999999999999999999999999999)) =>
+         | -BigInt(9999999999999999999999999999999999999999999999)""".stripMargin,
         ENegBody(ENeg(GBigInt(BigInt("9999999999999999999999999999999999999999")))),
         GBigInt(BigInt("-9999999999999999999999999999999999999999"))
       ),
       (
-        """BigInt(9999999999999999999999999999999999999999) * 
-          |BigInt(-9999999999999999999999999999999999999999) => 
-          |BigInt(-99999999999999999999999999999999999999980000000000000000000000000000000000000001)""".stripMargin,
+        """BigInt(9999999999999999999999999999999999999999) *
+          | (-BigInt(9999999999999999999999999999999999999999)) =>
+          | -BigInt(99999999999999999999999999999999999999980000000000000000000000000000000000000001)""".stripMargin,
         EMultBody(
           EMult(
             GBigInt(BigInt("9999999999999999999999999999999999999999")),
@@ -2370,9 +2370,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         )
       ),
       (
-        """BigInt(-99999999999999999999999999999999999999980000000000000000000000000000000000000001) / 
-          |BigInt(9999999999999999999999999999999999999999) => 
-          |BigInt(-9999999999999999999999999999999999999999)""".stripMargin,
+        """(-BigInt(99999999999999999999999999999999999999980000000000000000000000000000000000000001)) /
+          | BigInt(9999999999999999999999999999999999999999) =>
+          | -BigInt(9999999999999999999999999999999999999999)""".stripMargin,
         EDivBody(
           EDiv(
             GBigInt(
@@ -2388,9 +2388,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         )
       ),
       (
-        """BigInt(99999999999999999999999999999999999999980000000000000000000000000000000000000002) % 
-          |BigInt(9999999999999999999999999999999999999999) => 
-          |BigInt(1)""".stripMargin,
+        """BigInt(99999999999999999999999999999999999999980000000000000000000000000000000000000002) %
+          | BigInt(9999999999999999999999999999999999999999) =>
+          | BigInt(1)""".stripMargin,
         EModBody(
           EMod(
             GBigInt(
@@ -2406,9 +2406,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         )
       ),
       (
-        """BigInt(-9999999999999999999999999999999999999999) + 
-          |BigInt(-9999999999999999999999999999999999999999) => 
-          |BigInt(-19999999999999999999999999999999999999998)""".stripMargin,
+        """(-BigInt(9999999999999999999999999999999999999999)) +
+          | (-BigInt(9999999999999999999999999999999999999999)) =>
+          | -BigInt(19999999999999999999999999999999999999998)""".stripMargin,
         EPlusBody(
           EPlus(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
@@ -2420,8 +2420,8 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         )
       ),
       (
-        """BigInt(-9999999999999999999999999999999999999999) - 
-          |BigInt(-9999999999999999999999999999999999999999) => 
+        """(-BigInt(9999999999999999999999999999999999999999)) -
+          | (-BigInt(-9999999999999999999999999999999999999999)) =>
           |BigInt(0)""".stripMargin,
         EMinusBody(
           EMinus(
@@ -2444,9 +2444,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     val table = Table(
       ("clue", "input", "output"),
       (
-        """BigInt(-9999999999999999999999999999999999999999) < 
-          |BigInt(9999999999999999999999999999999999999999) => 
-          |true""".stripMargin,
+        """-BigInt(9999999999999999999999999999999999999999) <
+          | BigInt(9999999999999999999999999999999999999999) =>
+          | true""".stripMargin,
         ELtBody(
           ELt(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
@@ -2456,9 +2456,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         GBool(true)
       ),
       (
-        """BigInt(-9999999999999999999999999999999999999999) < 
-          |BigInt(-9999999999999999999999999999999999999999) => 
-          |false""".stripMargin,
+        """ -BigInt(9999999999999999999999999999999999999999) <
+          | -BigInt(9999999999999999999999999999999999999999) =>
+          | false""".stripMargin,
         ELtBody(
           ELt(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
@@ -2468,8 +2468,8 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         GBool(false)
       ),
       (
-        """BigInt(-9999999999999999999999999999999999999999) <= 
-          |BigInt(-9999999999999999999999999999999999999999) => 
+        """-BigInt(9999999999999999999999999999999999999999) <=
+          | -BigInt(9999999999999999999999999999999999999999) =>
           |true""".stripMargin,
         ELteBody(
           ELte(
@@ -2480,8 +2480,8 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         GBool(true)
       ),
       (
-        """BigInt(-9999999999999999999999999999999999999998) <= 
-          |BigInt(-9999999999999999999999999999999999999999) => 
+        """-BigInt(9999999999999999999999999999999999999998) <=
+          | -BigInt(9999999999999999999999999999999999999999) =>
           |false""".stripMargin,
         ELteBody(
           ELte(
@@ -2492,9 +2492,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         GBool(false)
       ),
       (
-        """BigInt(9999999999999999999999999999999999999999) > 
-          |BigInt(-9999999999999999999999999999999999999999) => 
-          |true""".stripMargin,
+        """BigInt(9999999999999999999999999999999999999999) >
+          | -BigInt(9999999999999999999999999999999999999999) =>
+          | true""".stripMargin,
         EGtBody(
           EGt(
             GBigInt(BigInt("9999999999999999999999999999999999999999")),
@@ -2504,8 +2504,8 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         GBool(true)
       ),
       (
-        """BigInt(-9999999999999999999999999999999999999999) > 
-          |BigInt(-9999999999999999999999999999999999999999) => 
+        """-BigInt(9999999999999999999999999999999999999999) >
+          | -BigInt(9999999999999999999999999999999999999999) =>
           |false""".stripMargin,
         EGtBody(
           EGt(
@@ -2516,9 +2516,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         GBool(false)
       ),
       (
-        """BigInt(-9999999999999999999999999999999999999999) >= 
-          |BigInt(-9999999999999999999999999999999999999999) => 
-          |true""".stripMargin,
+        """-BigInt(9999999999999999999999999999999999999999) >=
+          | -BigInt(9999999999999999999999999999999999999999) =>
+          | true""".stripMargin,
         EGteBody(
           EGte(
             GBigInt(BigInt("-9999999999999999999999999999999999999999")),
@@ -2528,9 +2528,9 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         GBool(true)
       ),
       (
-        """BigInt(9999999999999999999999999999999999999998) >= 
-          |BigInt(9999999999999999999999999999999999999999) => 
-          |false""".stripMargin,
+        """BigInt(9999999999999999999999999999999999999998) >=
+          | BigInt(9999999999999999999999999999999999999999) =>
+          | false""".stripMargin,
         EGteBody(
           EGte(
             GBigInt(BigInt("9999999999999999999999999999999999999998")),
@@ -2609,8 +2609,8 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         GBigInt(BigInt("-1"))
       ),
       (
-        """"-9999999999999999999999999999999999999999".toBigInt() => 
-          |BigInt(-9999999999999999999999999999999999999999)""".stripMargin,
+        """"-9999999999999999999999999999999999999999".toBigInt() =>
+          | -BigInt(9999999999999999999999999999999999999999)""".stripMargin,
         EMethod("toBigInt", GString("-9999999999999999999999999999999999999999")),
         GBigInt(BigInt("-9999999999999999999999999999999999999999"))
       )
@@ -2669,5 +2669,4 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       runReducer(input) should be(Left(error)) withClue clue
     }
   }
-
 }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2635,7 +2635,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
       (
         """"WRONG".toInt() => ReduceError""",
         EMethod("toInt", GString("WRONG")),
-        ReduceError(s"""Method toInt(): input string "WRONG" cannot be converted to Integer""")
+        ReduceError(s"""Method toInt(): input string "WRONG" cannot be converted to Int""")
       ),
       (
         """Set().toInt() => ReduceError""",

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2344,7 +2344,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     )
   }
 
-  "BigInt" should "work correctly with arithmetic operations" in {
+  "Reducer" should "perform arithmetic operations with BigInt" in {
     val table = Table(
       ("clue", "input", "output"),
       (
@@ -2440,7 +2440,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     }
   }
 
-  "BigInt" should "work correctly with сomparison operations" in {
+  it should "perform comparison operations with BigInt" in {
     val table = Table(
       ("clue", "input", "output"),
       (
@@ -2547,7 +2547,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     }
   }
 
-  "Reducer" should "return report errors with failure BigInt operations" in {
+  it should "return report errors with failure BigInt operations" in {
     val table = Table(
       ("clue", "input", "output"),
       (
@@ -2569,7 +2569,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     }
   }
 
-  "Reducer" should "work correctly with toInt() method" in {
+  it should "perform toInt() method" in {
     val table = Table(
       ("clue", "input", "output"),
       (
@@ -2595,7 +2595,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     }
   }
 
-  "Reducer" should "work correctly with toBigInt() method" in {
+  it should "perform toBigInt() method" in {
     val table = Table(
       ("clue", "input", "output"),
       (
@@ -2622,20 +2622,20 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     }
   }
 
-  "Reducer" should "return report errors in failure cases with toInt() method" in {
+  it should "return report errors in failure cases with toInt() method" in {
     val table = Table(
       ("clue", "input", "output"),
       (
         """BigInt(9999999999999999999999999999999999999999).toInt() => ReduceError""",
         EMethod("toInt", GBigInt(BigInt("9999999999999999999999999999999999999999"))),
-        ReduceError("Error: input value out of range")
+        ReduceError(
+          s"Method toInt(): input BigInt value 9999999999999999999999999999999999999999 out of range"
+        )
       ),
       (
         """"WRONG".toInt() => ReduceError""",
         EMethod("toInt", GString("WRONG")),
-        ReduceError(
-          """Error: exception was thrown when decoding input String to Int: For input string: "WRONG""""
-        )
+        ReduceError(s"""Method toInt(): input string "WRONG" cannot be converted to Integer""")
       ),
       (
         """Set().toInt() => ReduceError""",
@@ -2649,14 +2649,14 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
     }
   }
 
-  "Reducer" should "return report errors in failure cases with toBigInt() method" in {
+  it should "return report errors in failure cases with toBigInt() method" in {
     val table = Table(
       ("clue", "input", "output"),
       (
         """"WRONG".toBigInt() => ReduceError""",
         EMethod("toBigInt", GString("WRONG")),
         ReduceError(
-          """Error: exception was thrown when decoding input String to BigInt: For input string: "WRONG""""
+          """Method toBigInt(): input string "WRONG" cannot be converted to BigInt"""
         )
       ),
       (
@@ -2665,7 +2665,6 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
         MethodNotDefined("toBigInt", "Set")
       )
     )
-
     forAll(table) { (clue, input, error) =>
       runReducer(input) should be(Left(error)) withClue clue
     }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/SubstituteTest.scala
@@ -31,6 +31,7 @@ class SubSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
       ConnNotBody(Par()),
       ConnBool(false),
       ConnInt(false),
+      ConnBigInt(false),
       ConnString(true),
       ConnUri(true),
       ConnByteArray(true),

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -766,7 +766,7 @@ class RholangMethodsCostsSpec
     }
   }
 
-  "Reducer" when {
+  "reducer" when {
     "it works with BigInt" should {
       val table = Table(
         ("left", "right"),
@@ -868,7 +868,7 @@ class RholangMethodsCostsSpec
     }
   }
 
-  "The toInt() method" when {
+  "toInt() method" when {
     "working with Int value" should {
       "not require additional costs" in {
         val table = Table(
@@ -916,7 +916,7 @@ class RholangMethodsCostsSpec
     }
   }
 
-  "The toBigInt method" when {
+  "toBigInt method" when {
     "working with BigInt value" should {
       "doesn't have additional cost" in {
         val table = Table(

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -766,109 +766,111 @@ class RholangMethodsCostsSpec
     }
   }
 
-  "Reducer when it works with BigInt" should {
-    val table = Table(
-      ("left", "right"),
-      (gBigInt("225"), gBigInt("25")),
-      (
-        gBigInt("9999999999999999999999999999999999999999"),
-        gBigInt("-9999999999999999999999999999999999999999")
-      ),
-      (
-        gBigInt("0"),
-        gBigInt("9999999999999999999999999999999999999999")
-      ),
-      (
-        gBigInt("123"),
-        gBigInt("-9999999999999999999999999999999999999999")
+  "Reducer" when {
+    "it works with BigInt" should {
+      val table = Table(
+        ("left", "right"),
+        (gBigInt("225"), gBigInt("25")),
+        (
+          gBigInt("9999999999999999999999999999999999999999"),
+          gBigInt("-9999999999999999999999999999999999999999")
+        ),
+        (
+          gBigInt("0"),
+          gBigInt("9999999999999999999999999999999999999999")
+        ),
+        (
+          gBigInt("123"),
+          gBigInt("-9999999999999999999999999999999999999999")
+        )
       )
-    )
 
-    "charge expression `-x` as `size(x)`" in {
-      forAll(table) {
-        case (left, _) =>
-          val expr           = ENegBody(ENeg(left))
-          val expected: Long = size(left)
-          testExpr(expr, Cost(expected))
+      "charge expression `-x` as `size(x)`" in {
+        forAll(table) {
+          case (left, _) =>
+            val expr           = ENegBody(ENeg(left))
+            val expected: Long = size(left)
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 + x2` as `max(size(x1), size(x2)) + 1`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = EPlusBody(EPlus(left, right))
-          val expected: Long = scala.math.max(size(left), size(right)) + 1L
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 + x2` as `max(size(x1), size(x2)) + 1`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = EPlusBody(EPlus(left, right))
+            val expected: Long = scala.math.max(size(left), size(right)) + 1L
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 - x2` as `max(size(x1), size(x2)) + 1`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = EMinusBody(EMinus(left, right))
-          val expected: Long = scala.math.max(size(left), size(right)) + 1L
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 - x2` as `max(size(x1), size(x2)) + 1`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = EMinusBody(EMinus(left, right))
+            val expected: Long = scala.math.max(size(left), size(right)) + 1L
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 * x2` as `size(x1) * size(x2)`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = EMultBody(EMult(left, right))
-          val expected: Long = size(left) * size(right)
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 * x2` as `size(x1) * size(x2)`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = EMultBody(EMult(left, right))
+            val expected: Long = size(left) * size(right)
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 / x2` as `size(x1) * size(x2)`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = EDivBody(EDiv(left, right))
-          val expected: Long = size(left) * size(right)
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 / x2` as `size(x1) * size(x2)`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = EDivBody(EDiv(left, right))
+            val expected: Long = size(left) * size(right)
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 % x2` as `size(x1) * size(x2)`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = EModBody(EMod(left, right))
-          val expected: Long = size(left) * size(right)
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 % x2` as `size(x1) * size(x2)`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = EModBody(EMod(left, right))
+            val expected: Long = size(left) * size(right)
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 < x2` as `min(size(x1), size(x2))`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = ELtBody(ELt(left, right))
-          val expected: Long = scala.math.min(size(left), size(right))
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 < x2` as `min(size(x1), size(x2))`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = ELtBody(ELt(left, right))
+            val expected: Long = scala.math.min(size(left), size(right))
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 <= x2` as `min(size(x1), size(x2))`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = ELteBody(ELte(left, right))
-          val expected: Long = scala.math.min(size(left), size(right))
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 <= x2` as `min(size(x1), size(x2))`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = ELteBody(ELte(left, right))
+            val expected: Long = scala.math.min(size(left), size(right))
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 > x2` as `min(size(x1), size(x2))`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = EGtBody(EGt(left, right))
-          val expected: Long = scala.math.min(size(left), size(right))
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 > x2` as `min(size(x1), size(x2))`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = EGtBody(EGt(left, right))
+            val expected: Long = scala.math.min(size(left), size(right))
+            test(expr, Cost(expected))
+        }
       }
-    }
-    "charge expression `x1 >= x2` as `min(size(x1), size(x2))`" in {
-      forAll(table) {
-        case (left, right) =>
-          val expr           = EGteBody(EGte(left, right))
-          val expected: Long = scala.math.min(size(left), size(right))
-          testExpr(expr, Cost(expected))
+      "charge expression `x1 >= x2` as `min(size(x1), size(x2))`" in {
+        forAll(table) {
+          case (left, right) =>
+            val expr           = EGteBody(EGte(left, right))
+            val expected: Long = scala.math.min(size(left), size(right))
+            test(expr, Cost(expected))
+        }
       }
     }
   }
 
-  "toInt" when {
-    "called on Int" should {
-      "doesn't have additional cost" in {
+  "The toInt() method" when {
+    "working with Int value" should {
+      "not require additional costs" in {
         val table = Table(
           "par",
           GInt(123),
@@ -882,7 +884,7 @@ class RholangMethodsCostsSpec
         }
       }
     }
-    "called on BigInt" should {
+    "working with BigInt value" should {
       "charge `x.toInt()` as `size(x)`" in {
         val table = Table(
           "par",
@@ -897,7 +899,7 @@ class RholangMethodsCostsSpec
         }
       }
     }
-    "called on String" should {
+    "working with BigInt value" should {
       "charge `x.toInt()` as `length(x)`" in {
         val table = Table(
           "par",
@@ -914,8 +916,8 @@ class RholangMethodsCostsSpec
     }
   }
 
-  "toBigInt" when {
-    "called on BigInt" should {
+  "The toBigInt method" when {
+    "working with BigInt value" should {
       "doesn't have additional cost" in {
         val table = Table(
           "par",
@@ -930,7 +932,7 @@ class RholangMethodsCostsSpec
         }
       }
     }
-    "called on Int" should {
+    "working with Int value" should {
       "charge `x.toInt()` as `8`" in {
         val table = Table(
           "par",
@@ -945,7 +947,7 @@ class RholangMethodsCostsSpec
         }
       }
     }
-    "called on String" should {
+    "working with String value" should {
       "charge `x.toInt()` as `length(x)`" in {
         val table = Table(
           "par",
@@ -1005,24 +1007,17 @@ class RholangMethodsCostsSpec
 
   def emptyString: String = ""
 
-  def test(method: Expr, expectedCost: Cost): Assertion = {
+  def test(expr: Expr, expectedCost: Cost): Assertion = {
     implicit val cost = CostAccounting.emptyCost[Task].runSyncUnsafe(1.second)
     implicit val env  = Env[Par]()
     withReducer[Assertion] { reducer =>
       for {
-        _    <- reducer.evalExprToPar(method)
-        cost <- methodCallCost(reducer)
-      } yield assert(cost.value === expectedCost.value)
-    }
-  }
+        _ <- reducer.evalExprToPar(expr)
+        cost <- expr.exprInstance match {
+                 case EMethodBody(_) => methodCallCost(reducer)
+                 case _              => exprCallCost(reducer)
+               }
 
-  def testExpr(expr: Expr, expectedCost: Cost): Assertion = {
-    implicit val cost = CostAccounting.emptyCost[Task].runSyncUnsafe(1.second)
-    implicit val env  = Env[Par]()
-    withReducer[Assertion] { reducer =>
-      for {
-        _    <- reducer.evalExprToPar(expr)
-        cost <- exprCallCost(reducer)
       } yield assert(cost.value === expectedCost.value)
     }
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -133,7 +133,8 @@ class RholangMethodsCostsSpec
             Par()
           ),
           EMapBody(ParMap(List[(Par, Par)]((GString("name"), GString("Alice"))))),
-          GString("Hello")
+          GString("Hello"),
+          gBigInt("-9999999999999999999999999999999999999999")
         )
         val baseTerm = Par(exprs = Seq(GInt(1)))
         val baseCost = Cost(baseTerm)
@@ -765,12 +766,212 @@ class RholangMethodsCostsSpec
     }
   }
 
+  "Reducer when it works with BigInt" should {
+    val table = Table(
+      ("left", "right"),
+      (gBigInt("225"), gBigInt("25")),
+      (
+        gBigInt("9999999999999999999999999999999999999999"),
+        gBigInt("-9999999999999999999999999999999999999999")
+      ),
+      (
+        gBigInt("0"),
+        gBigInt("9999999999999999999999999999999999999999")
+      ),
+      (
+        gBigInt("123"),
+        gBigInt("-9999999999999999999999999999999999999999")
+      )
+    )
+
+    "charge expression `-x` as `size(x)`" in {
+      forAll(table) {
+        case (left, _) =>
+          val expr           = ENegBody(ENeg(left))
+          val expected: Long = size(left)
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 + x2` as `max(size(x1), size(x2)) + 1`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = EPlusBody(EPlus(left, right))
+          val expected: Long = scala.math.max(size(left), size(right)) + 1L
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 - x2` as `max(size(x1), size(x2)) + 1`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = EMinusBody(EMinus(left, right))
+          val expected: Long = scala.math.max(size(left), size(right)) + 1L
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 * x2` as `size(x1) * size(x2)`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = EMultBody(EMult(left, right))
+          val expected: Long = size(left) * size(right)
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 / x2` as `size(x1) * size(x2)`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = EDivBody(EDiv(left, right))
+          val expected: Long = size(left) * size(right)
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 % x2` as `size(x1) * size(x2)`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = EModBody(EMod(left, right))
+          val expected: Long = size(left) * size(right)
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 < x2` as `min(size(x1), size(x2))`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = ELtBody(ELt(left, right))
+          val expected: Long = scala.math.min(size(left), size(right))
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 <= x2` as `min(size(x1), size(x2))`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = ELteBody(ELte(left, right))
+          val expected: Long = scala.math.min(size(left), size(right))
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 > x2` as `min(size(x1), size(x2))`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = EGtBody(EGt(left, right))
+          val expected: Long = scala.math.min(size(left), size(right))
+          testExpr(expr, Cost(expected))
+      }
+    }
+    "charge expression `x1 >= x2` as `min(size(x1), size(x2))`" in {
+      forAll(table) {
+        case (left, right) =>
+          val expr           = EGteBody(EGte(left, right))
+          val expected: Long = scala.math.min(size(left), size(right))
+          testExpr(expr, Cost(expected))
+      }
+    }
+  }
+
+  "toInt" when {
+    "called on Int" should {
+      "doesn't have additional cost" in {
+        val table = Table(
+          "par",
+          GInt(123),
+          GInt(0),
+          GInt(-99999)
+        )
+        forAll(table) { i =>
+          val method         = methodCall("toInt", i, List())
+          val expected: Long = 0
+          test(method, Cost(expected))
+        }
+      }
+    }
+    "called on BigInt" should {
+      "charge `x.toInt()` as `size(x)`" in {
+        val table = Table(
+          "par",
+          gBigInt("123"),
+          gBigInt("0"),
+          gBigInt("-99999")
+        )
+        forAll(table) { bi =>
+          val method         = methodCall("toInt", bi, List())
+          val expected: Long = size(bi)
+          test(method, Cost(expected))
+        }
+      }
+    }
+    "called on String" should {
+      "charge `x.toInt()` as `length(x)`" in {
+        val table = Table(
+          "par",
+          GString("123"),
+          GString("0"),
+          GString("-99999")
+        )
+        forAll(table) { str =>
+          val method         = methodCall("toInt", str, List())
+          val expected: Long = str.value.length.toLong
+          test(method, Cost(expected))
+        }
+      }
+    }
+  }
+
+  "toBigInt" when {
+    "called on BigInt" should {
+      "doesn't have additional cost" in {
+        val table = Table(
+          "par",
+          gBigInt("123"),
+          gBigInt("0"),
+          gBigInt("-9999999999999999999999999999999999999999")
+        )
+        forAll(table) { bi =>
+          val method         = methodCall("toBigInt", bi, List())
+          val expected: Long = 0
+          test(method, Cost(expected))
+        }
+      }
+    }
+    "called on Int" should {
+      "charge `x.toInt()` as `8`" in {
+        val table = Table(
+          "par",
+          GInt(123),
+          GInt(0),
+          GInt(-99999)
+        )
+        forAll(table) { i =>
+          val method         = methodCall("toBigInt", i, List())
+          val expected: Long = 8L
+          test(method, Cost(expected))
+        }
+      }
+    }
+    "called on String" should {
+      "charge `x.toInt()` as `length(x)`" in {
+        val table = Table(
+          "par",
+          GString("123"),
+          GString("0"),
+          GString("-9999999999999999999999999999999999999999")
+        )
+        forAll(table) { bi =>
+          val method         = methodCall("toBigInt", bi, List())
+          val expected: Long = bi.value.length.toLong
+          test(method, Cost(expected))
+        }
+      }
+    }
+  }
+
   def methodCall(method: String, target: Par, arguments: List[Par]): Expr =
     EMethod(method, target, arguments)
 
   def methodCallCost(reducer: Reduce[Task])(implicit cost: _cost[Task]): Task[Cost] =
     cost.get
       .map(balance => Cost.UNSAFE_MAX - balance - METHOD_CALL_COST)
+
+  def exprCallCost(reducer: Reduce[Task])(implicit cost: _cost[Task]): Task[Cost] =
+    cost.get
+      .map(balance => Cost.UNSAFE_MAX - balance)
 
   def map(pairs: Seq[(Par, Par)]): Map[Par, Par] = Map(pairs: _*)
   def emptyMap: Map[Par, Par]                    = map(Seq.empty[(Par, Par)])
@@ -795,6 +996,10 @@ class RholangMethodsCostsSpec
   def gbyteArray(n: Int): GByteArray =
     GByteArray(ByteString.copyFrom(new Array[Byte](n)))
 
+  def gBigInt(data: String): GBigInt = GBigInt(BigInt(data))
+
+  def size(bi: GBigInt): Long = bi.value.toByteArray.length.toLong
+
   def stringN(n: Int): String =
     Seq.fill(n)("a").mkString
 
@@ -810,6 +1015,18 @@ class RholangMethodsCostsSpec
       } yield assert(cost.value === expectedCost.value)
     }
   }
+
+  def testExpr(expr: Expr, expectedCost: Cost): Assertion = {
+    implicit val cost = CostAccounting.emptyCost[Task].runSyncUnsafe(1.second)
+    implicit val env  = Env[Par]()
+    withReducer[Assertion] { reducer =>
+      for {
+        _    <- reducer.evalExprToPar(expr)
+        cost <- exprCallCost(reducer)
+      } yield assert(cost.value === expectedCost.value)
+    }
+  }
+
   def withReducer[R](
       f: DebruijnInterpreter[Task] => Task[R]
   )(implicit cost: _cost[Task]): R = {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/GroundMatcherSpec.scala
@@ -16,6 +16,11 @@ class GroundMatcherSpec extends AnyFlatSpec with Matchers {
     val expectedResult: Expr = GInt(7)
     GroundNormalizeMatcher.normalizeMatch[Coeval](gi).value should be(expectedResult)
   }
+  "Positive groundBigInt" should "Compile GBigInt" in {
+    val gbi                  = new GroundBigInt("9999999999999999999999999999999999999999")
+    val expectedResult: Expr = GBigInt(BigInt("9999999999999999999999999999999999999999"))
+    GroundNormalizeMatcher.normalizeMatch[Coeval](gbi).value should be(expectedResult)
+  }
   "GroundString" should "Compile as GString" in {
     val gs                   = new GroundString("\"String\"")
     val expectedResult: Expr = GString("String")

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/ProcMatcherSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/compiler/normalizer/ProcMatcherSpec.scala
@@ -2,35 +2,24 @@ package coop.rchain.rholang.interpreter.compiler.normalizer
 
 import coop.rchain.models.Connective.ConnectiveInstance._
 import coop.rchain.models.Expr.ExprInstance._
+import coop.rchain.models._
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models.Var.WildcardMsg
-import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.ast.rholang_mercury.Absyn.{
-  Bundle => AbsynBundle,
-  Ground => AbsynGround,
-  KeyValuePair => AbsynKeyValuePair,
-  Send => AbsynSend,
+  Bundle => _,
+  Ground => _,
+  KeyValuePair => _,
+  Send => _,
   _
 }
-import coop.rchain.rholang.interpreter.compiler.{
-  BoundMapChain,
-  Compiler,
-  FreeMap,
-  NameSort,
-  ProcNormalizeMatcher,
-  ProcSort,
-  ProcVisitInputs,
-  SourcePosition,
-  VarSort
-}
+import coop.rchain.rholang.interpreter.compiler._
 import coop.rchain.rholang.interpreter.errors._
 import monix.eval.Coeval
 import org.scalatest._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.io.StringReader
 import scala.collection.immutable.BitSet
 
 class ProcMatcherSpec extends AnyFlatSpec with Matchers {
@@ -1345,12 +1334,14 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
   "PSimpleType" should "result in a connective of the correct type" in {
     val procBool      = new PSimpleType(new SimpleTypeBool())
     val procInt       = new PSimpleType(new SimpleTypeInt())
+    val procBigInt    = new PSimpleType(new SimpleTypeBigInt())
     val procString    = new PSimpleType(new SimpleTypeString())
     val procUri       = new PSimpleType(new SimpleTypeUri())
     val procByteArray = new PSimpleType(new SimpleTypeByteArray())
 
     val resultBool      = ProcNormalizeMatcher.normalizeMatch[Coeval](procBool, inputs).value
     val resultInt       = ProcNormalizeMatcher.normalizeMatch[Coeval](procInt, inputs).value
+    val resultBigInt    = ProcNormalizeMatcher.normalizeMatch[Coeval](procBigInt, inputs).value
     val resultString    = ProcNormalizeMatcher.normalizeMatch[Coeval](procString, inputs).value
     val resultUri       = ProcNormalizeMatcher.normalizeMatch[Coeval](procUri, inputs).value
     val resultByteArray = ProcNormalizeMatcher.normalizeMatch[Coeval](procByteArray, inputs).value
@@ -1360,6 +1351,9 @@ class ProcMatcherSpec extends AnyFlatSpec with Matchers {
     )
     resultInt.par should be(
       Par(connectives = Seq(Connective(ConnInt(true))), connectiveUsed = true)
+    )
+    resultBigInt.par should be(
+      Par(connectives = Seq(Connective(ConnBigInt(true))), connectiveUsed = true)
     )
     resultString.par should be(
       Par(connectives = Seq(Connective(ConnString(true))), connectiveUsed = true)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatchTest.scala
@@ -890,6 +890,15 @@ class VarMatcherSpec extends AnyFlatSpec with Matchers with TimeLimits with Trip
     assertSpatialMatch(failTarget, pattern, None)
   }
 
+  "Matching BigInt" should "work" in {
+    val successTarget: Par  = GBigInt(BigInt("-9999999999999999999999999999999999999999999999"))
+    val failTarget: Par     = GInt(12)
+    val pattern: Connective = Connective(ConnBigInt(true))
+
+    assertSpatialMatch(successTarget, pattern, Some(Map.empty))
+    assertSpatialMatch(failTarget, pattern, None)
+  }
+
   "Matching String" should "work" in {
     val successTarget: Par  = GString("Match me!")
     val failTarget: Par     = GInt(42)


### PR DESCRIPTION
## Overview
Work within #3699.

### Notes
Implementation features of BigInt:
* based on [scala BigInt](https://www.scala-lang.org/api/2.12.1/scala/math/BigInt.html) which based on [java BigInteger](https://docs.oracle.com/javase/8/docs/api/java/math/BigInteger.html). 
* will never overflow assuming you have enough memory to handle it.
* support 
    * basic arithmetic operations: addition (`+`), subtraction (negation) (`-`), multiplication (`*`), integer division (`/`), modulo (`%`);
    * common binary operators for comparison which evaluate Boolean primitives (`<`, `<=`, `==`, `!=`, `>=`, `>`).
* created by:
    * calling the BigInt() constructor:
        * from any integer string: `BigInt(9999999999999999999999999999999999999999999999)`
* have methods:
    * `toBigInt()` which converts Rholang String or Integer to Rholang BigInt value. If the input value сontains invalid characterse throw exception returned.
    * `toInt()` which converts BigInt value to Rholang integer. If the BigInt value is outside the Rholang integer range throw exception returned.
    * `toByteArray()` which serializes process from BigInt value.
* have simple type `BigInt` which can be used for pattern matching with Connective.

### Changing Program Behavior for Int
The error message for arithmetic operations (addition (`+`), subtraction (negation) (`-`), multiplication (`*`), integer division (`/`), modulo (`%`)) with int has been changed. 
It was: "Error: expression didn't evaluate to integer."
It became: "Error: Operator is not defined on Int."

### Time performance
To determine the speed of work, the speed was compared with Int.
https://github.com/hilltracer/rchain/commit/be03eadc3ac290133d8b8a5350b57f6ec9da7efb
#### Sum test
Code for Int:
```scala=
new return, loop in {
   contract loop(@n, @acc, ret) = {
     if (n == 0) ret!(acc)
     else loop!(n - 1, acc + n, *ret)
   } |
   loop!($numberElements, 0, *return)
}
```
Code for BigInt:
```scala=
new return, loop in {
   contract loop(@n, @acc, ret) = {
     if (n == BigInt(0)) ret!(acc)
     else loop!(n - BigInt(1), acc + n, *ret)
   } |
   loop!(BigInt($numberElements), BigInt(0), *return)
}
```
![image](https://user-images.githubusercontent.com/81892279/173830333-152e1a77-ab78-481f-a196-8ab6647babe0.png)


#### Map construct test
Code for Int:
```scala
new return, loop in {
    contract loop(@n, @acc, ret) = {
      if (n == 0) ret!(acc)
      else loop!(n - 1, acc.set(n, n), *ret)
    } |
loop!($numberElements, {}, *return)
}
```
Code for BigInt:
```scala
new return, loop in {
    contract loop(@n, @acc, ret) = {
      if (n == BigInt(0)) ret!(acc)
      else loop!(n - BigInt(1), acc.set(n, n), *ret)
    } |
    loop!(BigInt($numberElements), {}, *return)
}
```
![image](https://user-images.githubusercontent.com/81892279/173830084-1d545428-7d11-4927-b45b-6520d50b464a.png)

### Please make sure that this PR:
- [ ] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:
- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.