### PR TITLE
Added unit - tests for BlockRandomSeed case class

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockRandomSeed.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockRandomSeed.scala
@@ -1,3 +1,5 @@
+package coop.rchain.casper
+
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.rspace.hashing.Blake2b256Hash
@@ -8,7 +10,6 @@ import scodec.{Codec, TransformSyntax}
 final case class BlockRandomSeed(
     shardId: String,
     blockNumber: Long,
-    sender: PublicKey,
     validatorPublicKey: PublicKey,
     preStateHash: Blake2b256Hash
 )
@@ -17,8 +18,9 @@ object BlockRandomSeed {
   private val codecPublicKey: Codec[PublicKey] = variableSizeBytes(uint8, bytes)
     .xmap[PublicKey](bv => PublicKey(bv.toArray), pk => ByteVector(pk.bytes))
 
-  private val codecBlockRandomSeed: Codec[BlockRandomSeed] = (utf8 :: ulong(bits = 64) ::
-    codecPublicKey :: codecPublicKey :: Blake2b256Hash.codecPureBlake2b256Hash).as[BlockRandomSeed]
+  val codecBlockRandomSeed: Codec[BlockRandomSeed] =
+    (variableSizeBytes(uint8, utf8) :: ulong(bits = 63) ::
+      codecPublicKey :: Blake2b256Hash.codecBlake2b256Hash).as[BlockRandomSeed]
 
   private def encode(blockRandomSeed: BlockRandomSeed): Array[Byte] =
     codecBlockRandomSeed.encode(blockRandomSeed).require.toByteArray

--- a/casper/src/main/scala/coop/rchain/casper/BlockRandomSeed.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockRandomSeed.scala
@@ -7,7 +7,7 @@ import scodec.bits.ByteVector
 import scodec.codecs.{bytes, uint8, ulong, utf8, variableSizeBytes}
 import scodec.{Codec, TransformSyntax}
 
-final case class BlockRandomSeed(
+final case class BlockRandomSeed private (
     shardId: String,
     blockNumber: Long,
     sender: PublicKey,
@@ -15,6 +15,13 @@ final case class BlockRandomSeed(
 )
 
 object BlockRandomSeed {
+  def apply(
+      shardId: String,
+      blockNumber: Long,
+      sender: PublicKey,
+      preStateHash: Blake2b256Hash
+  ): BlockRandomSeed = new BlockRandomSeed(shardId, blockNumber, sender, preStateHash)
+
   private val codecPublicKey: Codec[PublicKey] = variableSizeBytes(uint8, bytes)
     .xmap[PublicKey](bv => PublicKey(bv.toArray), pk => ByteVector(pk.bytes))
 

--- a/casper/src/main/scala/coop/rchain/casper/BlockRandomSeed.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockRandomSeed.scala
@@ -10,7 +10,7 @@ import scodec.{Codec, TransformSyntax}
 final case class BlockRandomSeed(
     shardId: String,
     blockNumber: Long,
-    validatorPublicKey: PublicKey,
+    sender: PublicKey,
     preStateHash: Blake2b256Hash
 )
 

--- a/casper/src/test/scala/coop/rchain/casper/BlockRandomSeedSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/BlockRandomSeedSpec.scala
@@ -1,0 +1,87 @@
+package coop.rchain.casper
+
+import cats.syntax.all._
+import coop.rchain.crypto.PublicKey
+import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.shared.Base16
+import coop.rchain.shared.scalatestcontrib.convertToAnyShouldWrapper
+import coop.rchain.store.InMemoryKeyValueStore
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
+import org.scalacheck.Prop.AnyOperators
+import org.scalacheck.{Arbitrary, Gen}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.Checkers
+import scodec.bits.ByteVector
+import scodec.bits.ByteVector.fromHex
+
+class BlockRandomSeedSpec extends AnyFlatSpec with Checkers {
+  "encoding coop.rchain.casper.BlockRandomSeed object and decoding it" should "give original object" in {
+    val blockRandomSeedGen = for {
+      shardId                <- Gen.stringOfN(6, Gen.alphaChar)
+      blockNumber            <- Gen.choose(0L, 1000000L)
+      validatorPublicKeyList <- Gen.listOfN(120, Gen.hexChar)
+      validatorPublicKey     = PublicKey(validatorPublicKeyList.map(_.toByte).toArray)
+      hash                   <- Gen.listOfN(Blake2b256Hash.length, Gen.hexChar)
+      preStateHash           = Blake2b256Hash.fromByteArray(hash.map(_.toByte).toArray)
+    } yield BlockRandomSeed(shardId, blockNumber, validatorPublicKey, preStateHash)
+
+    implicit lazy val blockRandomSeedArbitrary = Arbitrary(blockRandomSeedGen)
+
+    check { blockRandomSeed: BlockRandomSeed =>
+      val serialized    = BlockRandomSeed.codecBlockRandomSeed.encode(blockRandomSeed).require
+      val reconstructed = BlockRandomSeed.codecBlockRandomSeed.decode(serialized).require.value
+
+      reconstructed ?= blockRandomSeed
+    }
+  }
+
+  "encoding Blake2b256Hash object and decoding it" should "give original object" in {
+    val hashGen = for {
+      hashValue <- Gen.listOfN(Blake2b256Hash.length, Gen.hexChar)
+    } yield Blake2b256Hash.fromByteArray(hashValue.map(_.toByte).toArray)
+
+    implicit lazy val blockRandomSeedArbitrary = Arbitrary(hashGen)
+
+    check { hash: Blake2b256Hash =>
+      val serialized = Blake2b256Hash.codecBlake2b256Hash.encode(hash).require
+      val restored   = Blake2b256Hash.codecBlake2b256Hash.decode(serialized).require.value
+
+      restored ?= hash
+    }
+  }
+
+  "generate random seed from constant BlockRandomSeed object" should "give expected value" in {
+    val validatorPublicKey = PublicKey(
+      fromHex(
+        "0406A102343B05BDF86DF2552C125430CC319323792507328DCC9456713E1E7A24E715171E43ACA3288E41DD346E840901A5D1588C2170AD1D55C0885A3230343A"
+      ).get.toArray
+    )
+    val preStateHash =
+      Blake2b256Hash.fromHex("AD1356323FFEBE9083687265928AD3CAD1356323FDEBE9083687265928AD3918")
+
+    val constantBlockRandomSeed = BlockRandomSeed(
+      shardId = "AD4516",
+      blockNumber = 1,
+      validatorPublicKey = validatorPublicKey,
+      preStateHash = preStateHash
+    )
+
+    val serialized =
+      BlockRandomSeed.codecBlockRandomSeed.encode(constantBlockRandomSeed).require.toByteVector
+    val randomNumber =
+      ByteVector(BlockRandomSeed.generateRandomNumber(constantBlockRandomSeed).next())
+
+    val referenceRandomNumber =
+      ByteVector.fromHex("0C338721fa06CAf348C9E013922E8B6D27C6E31FDC2B18FC6A83F144CA22D375").get
+
+    val referenceSerialized = ByteVector
+      .fromHex(
+        "06414434353136000000000000000282080d420468760b7bf0dbe4aa5824a86198632646f24a0e651b9928ace27c3cf449ce2a2e3c875946511c83ba68dd0812034ba2b11842e15a3aab8110b4646068755a26ac647ffd7d2106d0e4cb2515a795a26ac647fbd7d2106d0e4cb2515a7230"
+      )
+      .get
+
+    serialized shouldBe referenceSerialized
+    randomNumber shouldBe referenceRandomNumber
+  }
+}

--- a/casper/src/test/scala/coop/rchain/casper/BlockRandomSeedSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/BlockRandomSeedSpec.scala
@@ -1,13 +1,8 @@
 package coop.rchain.casper
 
-import cats.syntax.all._
 import coop.rchain.crypto.PublicKey
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.shared.Base16
 import coop.rchain.shared.scalatestcontrib.convertToAnyShouldWrapper
-import coop.rchain.store.InMemoryKeyValueStore
-import monix.eval.Task
-import monix.execution.Scheduler.Implicits.global
 import org.scalacheck.Prop.AnyOperators
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.flatspec.AnyFlatSpec
@@ -16,33 +11,36 @@ import scodec.bits.ByteVector
 import scodec.bits.ByteVector.fromHex
 
 class BlockRandomSeedSpec extends AnyFlatSpec with Checkers {
-  "encoding coop.rchain.casper.BlockRandomSeed object and decoding it" should "give original object" in {
-    val blockRandomSeedGen = for {
-      shardId      <- Gen.stringOfN(6, Gen.alphaChar)
-      blockNumber  <- Gen.choose(0L, 1000000L)
-      senderList   <- Gen.listOfN(120, Gen.hexChar)
-      sender       = PublicKey(senderList.map(_.toByte).toArray)
-      hash         <- Gen.listOfN(Blake2b256Hash.length, Gen.hexChar)
-      preStateHash = Blake2b256Hash.fromByteArray(hash.map(_.toByte).toArray)
-    } yield BlockRandomSeed(shardId, blockNumber, sender, preStateHash)
 
-    implicit lazy val blockRandomSeedArbitrary = Arbitrary(blockRandomSeedGen)
+  // Arbitrary[BlockRandomSeed]
+  val blockRandomSeedGen = for {
+    shardId     <- Gen.stringOfN(6, Gen.alphaChar)
+    blockNumber <- Gen.choose(0L, 1000000L)
+    senderList  <- Gen.listOfN(120, Gen.hexChar)
+    hash        <- Gen.listOfN(Blake2b256Hash.length, Gen.hexChar)
+  } yield {
+    val sender       = PublicKey(senderList.map(_.toByte).toArray)
+    val preStateHash = Blake2b256Hash.fromByteArray(hash.map(_.toByte).toArray)
+    BlockRandomSeed(shardId, blockNumber, sender, preStateHash)
+  }
+  implicit lazy val blockRandomSeedArbitrary = Arbitrary(blockRandomSeedGen)
 
+  // Arbitrary[Blake2b256Hash]
+  val blake2b256HashGen = Gen.listOfN(Blake2b256Hash.length, Gen.hexChar).map { hashValue =>
+    Blake2b256Hash.fromByteArray(hashValue.map(_.toByte).toArray)
+  }
+  implicit lazy val blake2b256HashArbitrary = Arbitrary(blake2b256HashGen)
+
+  "encoding BlockRandomSeed object and decoding it" should "give original object" in {
     check { blockRandomSeed: BlockRandomSeed =>
-      val serialized    = BlockRandomSeed.codecBlockRandomSeed.encode(blockRandomSeed).require
-      val reconstructed = BlockRandomSeed.codecBlockRandomSeed.decode(serialized).require.value
+      val serialized = BlockRandomSeed.codecBlockRandomSeed.encode(blockRandomSeed).require
+      val restored   = BlockRandomSeed.codecBlockRandomSeed.decode(serialized).require.value
 
-      reconstructed ?= blockRandomSeed
+      restored ?= blockRandomSeed
     }
   }
 
   "encoding Blake2b256Hash object and decoding it" should "give original object" in {
-    val hashGen = for {
-      hashValue <- Gen.listOfN(Blake2b256Hash.length, Gen.hexChar)
-    } yield Blake2b256Hash.fromByteArray(hashValue.map(_.toByte).toArray)
-
-    implicit lazy val blockRandomSeedArbitrary = Arbitrary(hashGen)
-
     check { hash: Blake2b256Hash =>
       val serialized = Blake2b256Hash.codecBlake2b256Hash.encode(hash).require
       val restored   = Blake2b256Hash.codecBlake2b256Hash.decode(serialized).require.value
@@ -52,36 +50,40 @@ class BlockRandomSeedSpec extends AnyFlatSpec with Checkers {
   }
 
   "generate random seed from constant BlockRandomSeed object" should "give expected value" in {
-    val validatorPublicKey = PublicKey(
-      fromHex(
-        "0406A102343B05BDF86DF2552C125430CC319323792507328DCC9456713E1E7A24E715171E43ACA3288E41DD346E840901A5D1588C2170AD1D55C0885A3230343A"
-      ).get.toArray
-    )
-    val preStateHash =
-      Blake2b256Hash.fromHex("AD1356323FFEBE9083687265928AD3CAD1356323FDEBE9083687265928AD3918")
+    val pubKeyStr =
+      "0406A102343B05BDF86DF2552C125430CC319323792507328DCC9456713E1E7A24E715171E43ACA3288E41DD346E840901A5D1588C2170AD1D55C0885A3230343A"
+    val preStateStr = "AD1356323FFEBE9083687265928AD3CAD1356323FDEBE9083687265928AD3918"
 
-    val constantBlockRandomSeed = BlockRandomSeed(
-      shardId = "AD4516",
-      blockNumber = 1,
-      sender = validatorPublicKey,
-      preStateHash = preStateHash
-    )
+    // Seed input data
+    val shardId      = "AD4516"
+    val blockNumber  = 1L
+    val sender       = PublicKey(fromHex(pubKeyStr).get.toArray)
+    val preStateHash = Blake2b256Hash.fromHex(preStateStr)
 
-    val serialized =
-      BlockRandomSeed.codecBlockRandomSeed.encode(constantBlockRandomSeed).require.toByteVector
-    val randomNumber =
-      ByteVector(BlockRandomSeed.generateRandomNumber(constantBlockRandomSeed).next())
-
-    val referenceRandomNumber =
-      ByteVector.fromHex("0C338721fa06CAf348C9E013922E8B6D27C6E31FDC2B18FC6A83F144CA22D375").get
-
-    val referenceSerialized = ByteVector
-      .fromHex(
-        "06414434353136000000000000000282080d420468760b7bf0dbe4aa5824a86198632646f24a0e651b9928ace27c3cf449ce2a2e3c875946511c83ba68dd0812034ba2b11842e15a3aab8110b4646068755a26ac647ffd7d2106d0e4cb2515a795a26ac647fbd7d2106d0e4cb2515a7230"
+    // Generated values - seed and first random value
+    val (seed, rnd) = {
+      val constantBlockRandomSeed = BlockRandomSeed(
+        shardId = shardId,
+        blockNumber = blockNumber,
+        sender = sender,
+        preStateHash = preStateHash
       )
-      .get
+      val serialized =
+        BlockRandomSeed.codecBlockRandomSeed.encode(constantBlockRandomSeed).require.toByteVector
+      val randomNumber =
+        ByteVector(BlockRandomSeed.generateRandomNumber(constantBlockRandomSeed).next())
+      (serialized, randomNumber)
+    }
 
-    serialized shouldBe referenceSerialized
-    randomNumber shouldBe referenceRandomNumber
+    // Reference values as hex strings
+    val seedHexRef =
+      "06414434353136000000000000000282080d420468760b7bf0dbe4aa5824a86198632646f24a0e651b9928ace27c3cf449ce2a2e3c875946511c83ba68dd0812034ba2b11842e15a3aab8110b4646068755a26ac647ffd7d2106d0e4cb2515a795a26ac647fbd7d2106d0e4cb2515a7230"
+    val rndHexRef = "0C338721fa06CAf348C9E013922E8B6D27C6E31FDC2B18FC6A83F144CA22D375"
+
+    // Reference values - seed and first random value
+    val (seedRef, rndRef) = (ByteVector.fromHex(seedHexRef).get, ByteVector.fromHex(rndHexRef).get)
+
+    seed shouldBe seedRef
+    rnd shouldBe rndRef
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/BlockRandomSeedSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/BlockRandomSeedSpec.scala
@@ -18,13 +18,13 @@ import scodec.bits.ByteVector.fromHex
 class BlockRandomSeedSpec extends AnyFlatSpec with Checkers {
   "encoding coop.rchain.casper.BlockRandomSeed object and decoding it" should "give original object" in {
     val blockRandomSeedGen = for {
-      shardId                <- Gen.stringOfN(6, Gen.alphaChar)
-      blockNumber            <- Gen.choose(0L, 1000000L)
-      validatorPublicKeyList <- Gen.listOfN(120, Gen.hexChar)
-      validatorPublicKey     = PublicKey(validatorPublicKeyList.map(_.toByte).toArray)
-      hash                   <- Gen.listOfN(Blake2b256Hash.length, Gen.hexChar)
-      preStateHash           = Blake2b256Hash.fromByteArray(hash.map(_.toByte).toArray)
-    } yield BlockRandomSeed(shardId, blockNumber, validatorPublicKey, preStateHash)
+      shardId      <- Gen.stringOfN(6, Gen.alphaChar)
+      blockNumber  <- Gen.choose(0L, 1000000L)
+      senderList   <- Gen.listOfN(120, Gen.hexChar)
+      sender       = PublicKey(senderList.map(_.toByte).toArray)
+      hash         <- Gen.listOfN(Blake2b256Hash.length, Gen.hexChar)
+      preStateHash = Blake2b256Hash.fromByteArray(hash.map(_.toByte).toArray)
+    } yield BlockRandomSeed(shardId, blockNumber, sender, preStateHash)
 
     implicit lazy val blockRandomSeedArbitrary = Arbitrary(blockRandomSeedGen)
 
@@ -63,7 +63,7 @@ class BlockRandomSeedSpec extends AnyFlatSpec with Checkers {
     val constantBlockRandomSeed = BlockRandomSeed(
       shardId = "AD4516",
       blockNumber = 1,
-      validatorPublicKey = validatorPublicKey,
+      sender = validatorPublicKey,
       preStateHash = preStateHash
     )
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
@@ -9,6 +9,7 @@ import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.ListParWithRandom
 import coop.rchain.rholang.interpreter.RhoType.Number
 import coop.rchain.rholang.interpreter.storage
+import coop.rchain.rspace.hashing.Blake2b256Hash.codecBlake2b256Hash
 import coop.rchain.rspace.hashing.{Blake2b256Hash, StableHashProvider}
 import coop.rchain.rspace.internal.Datum
 import coop.rchain.rspace.merger.ChannelChange
@@ -188,12 +189,6 @@ object RholangMergingLogic {
   final case class DeployMergeableData(channels: Seq[NumberChannel])
 
   final case class NumberChannel(hash: Blake2b256Hash, diff: Long)
-
-  val codecBlake2b256Hash: Codec[Blake2b256Hash] =
-    scodec.codecs
-      .bytes(size = Blake2b256Hash.length)
-      .xmap[Blake2b256Hash](Blake2b256Hash.fromByteVector, _.bytes)
-      .as[Blake2b256Hash]
 
   val numberChannelCodec: Codec[NumberChannel] =
     (codecBlake2b256Hash :: int64).as[NumberChannel]

--- a/rspace/src/main/scala/coop/rchain/rspace/hashing/Blake2b256Hash.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/hashing/Blake2b256Hash.scala
@@ -79,27 +79,10 @@ object Blake2b256Hash {
   def fromByteString(byteString: ByteString): Blake2b256Hash =
     fromByteVector(ByteVector(byteString.toByteArray))
 
-  val codecPureBlake2b256Hash: Codec[Blake2b256Hash] = new Codec[Blake2b256Hash] {
-    val bitLength = (length * 8).toLong
-    override def decode(bits: BitVector): Attempt[DecodeResult[Blake2b256Hash]] =
-      if (bits.sizeGreaterThanOrEqual(bitLength)) {
-        Attempt.successful(
-          DecodeResult(Blake2b256Hash.create(bits.toByteVector), bits.drop(bitLength))
-        )
-      } else {
-        Attempt.failure(Err.insufficientBits(bitLength, bits.size))
-      }
-    override def encode(value: Blake2b256Hash): Attempt[BitVector] = {
-      val encoded = value.bytes.toBitVector
-      if (encoded.size != bitLength)
-        Attempt.failure(
-          Err(s"[$value] requires ${encoded.size} bits but field is fixed size of $bitLength bits")
-        )
-      else
-        Attempt.successful(encoded)
-    }
-    override def sizeBound: SizeBound = SizeBound.exact(bitLength)
-  }
+  val codecBlake2b256Hash: Codec[Blake2b256Hash] = scodec.codecs
+    .bytes(size = Blake2b256Hash.length)
+    .xmap[Blake2b256Hash](Blake2b256Hash.fromByteVector, _.bytes)
+    .as[Blake2b256Hash]
 
   implicit val codecWithBytesStringBlake2b256Hash: Codec[Blake2b256Hash] =
     fixedSizeBytes(length.toLong, bytes).as[Blake2b256Hash]

--- a/rspace/src/main/scala/coop/rchain/rspace/history/ColdStore.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/history/ColdStore.scala
@@ -1,7 +1,7 @@
 package coop.rchain.rspace.history
 
 import cats.effect.Sync
-import coop.rchain.rspace.hashing.Blake2b256Hash.codecPureBlake2b256Hash
+import coop.rchain.rspace.hashing.Blake2b256Hash.codecBlake2b256Hash
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.shared.Serialize._
 import coop.rchain.shared.syntax._
@@ -14,7 +14,7 @@ object ColdStoreInstances {
   type ColdKeyValueStore[F[_]] = KeyValueTypedStore[F, Blake2b256Hash, PersistedData]
 
   def coldStore[F[_]: Sync](store: KeyValueStore[F]): ColdKeyValueStore[F] =
-    store.toTypedStore(codecPureBlake2b256Hash, codecPersistedData)
+    store.toTypedStore(codecBlake2b256Hash, codecPersistedData)
 
   val codecPersistedData: Codec[PersistedData] =
     discriminated[PersistedData]

--- a/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/history/HistoryRepositorySpec.scala
@@ -5,7 +5,7 @@ import cats.syntax.all._
 import coop.rchain.metrics.{NoopSpan, Span}
 import coop.rchain.rspace._
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.hashing.Blake2b256Hash.codecPureBlake2b256Hash
+import coop.rchain.rspace.hashing.Blake2b256Hash.codecBlake2b256Hash
 import coop.rchain.rspace.history.ColdStoreInstances.{codecPersistedData, ColdKeyValueStore}
 import coop.rchain.rspace.history.TestData.{randomBlake, zerosBlake}
 import coop.rchain.rspace.internal.{Datum, WaitingContinuation}
@@ -238,7 +238,7 @@ trait InMemoryHistoryRepositoryTestBase {
 
   def inMemColdStore: ColdKeyValueStore[Task] = {
     val store = InMemoryKeyValueStore[Task]
-    store.toTypedStore(codecPureBlake2b256Hash, codecPersistedData)
+    store.toTypedStore(codecBlake2b256Hash, codecPersistedData)
   }
 
   def emptyExporter[F[_]: Sync]: RSpaceExporter[F] = new RSpaceExporter[F] {


### PR DESCRIPTION
## Overview
Added unit - tests for BlockRandomSeed case class 



### Notes
1. Added unit - tests for BlockRandomSeed class. 
2. Fixed some errors in BlockRandomSeed class
3. Removed  codecBlake2b256Hash codec from RholangMergingLogic object (now use same codec from Blake2b256Hash object)
4. Made default constructor in BlockRandomSeed class private


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
