### PR TITLE
Removed parameter allowPrivateAddresses and host check when node starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Evaluating:
 A peer node can be started with the following command (note that `--bootstrap` takes the listening address of `rnode0`):
 
 ```bash
-$ docker run -it --rm --name rnode1 --network rnode-net rchain/rnode:latest run --bootstrap 'rnode://8c775b2143b731a225f039838998ef0fac34ba25@rnode0?protocol=40400&discovery=40404' --allow-private-addresses --host rnode1
+$ docker run -it --rm --name rnode1 --network rnode-net rchain/rnode:latest run --bootstrap 'rnode://8c775b2143b731a225f039838998ef0fac34ba25@rnode0?protocol=40400&discovery=40404' --host rnode1
 [...]
 15:41:41.818 [INFO ] [node-runner-39      ] [coop.rchain.node.NodeRuntime ] - Starting node that will bootstrap from rnode://8c775b2143b731a225f039838998ef0fac34ba25@rnode0?protocol=40400&discovery=40404
 15:57:37.021 [INFO ] [node-runner-32      ] [coop.rchain.comm.rp.Connect$ ] - Peers: 1

--- a/comm/src/main/scala/coop/rchain/comm/package.scala
+++ b/comm/src/main/scala/coop/rchain/comm/package.scala
@@ -1,11 +1,6 @@
 package coop.rchain
 
-import java.net.InetAddress
-
-import cats.effect.Sync
 import cats.mtl.ApplicativeAsk
-import cats.syntax.all._
-import coop.rchain.catscontrib.ski.kp
 import coop.rchain.comm.transport.TransportLayerSyntax
 import coop.rchain.metrics.Metrics
 
@@ -17,23 +12,6 @@ package object comm {
   }
 
   val CommMetricsSource: Metrics.Source = Metrics.Source(Metrics.BaseSource, "comm")
-
-  private def validateInetAddress[F[_]: Sync](host: String, p: InetAddress => Boolean): F[Boolean] =
-    Sync[F].delay(InetAddress.getByName(host)).attempt.map(_.fold(kp(false), p))
-
-  def isValidInetAddress[F[_]: Sync](host: String): F[Boolean] =
-    validateInetAddress(host, !_.isAnyLocalAddress)
-
-  def isValidPublicInetAddress[F[_]: Sync](host: String): F[Boolean] =
-    validateInetAddress(
-      host,
-      a =>
-        !(a.isAnyLocalAddress ||
-          a.isLinkLocalAddress ||
-          a.isLoopbackAddress ||
-          a.isMulticastAddress ||
-          a.isSiteLocalAddress)
-    )
 
   // Importing syntax object means using all extensions in the project
   object syntax extends AllSyntaxComm

--- a/comm/src/test/scala/coop/rchain/comm/discovery/GrpcKademliaRPCSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/GrpcKademliaRPCSpec.scala
@@ -37,7 +37,7 @@ class GrpcKademliaRPCSpec extends KademliaRPCSpec[Task, GrpcEnvironment] {
         def ask: Task[PeerNode]            = Task.pure(env.peer)
       }
     Task.delay {
-      new GrpcKademliaRPC(networkId, 500.millis, true)
+      new GrpcKademliaRPC(networkId, 500.millis)
     }
   }
 

--- a/comm/src/test/scala/coop/rchain/comm/discovery/KademliaRPCSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/discovery/KademliaRPCSpec.scala
@@ -127,33 +127,6 @@ abstract class KademliaRPCSpec[F[_]: Monad: cats.effect.Timer, E <: Environment]
           }
       }
 
-      "response contains an invalid address" should {
-        "filter out the invalid address" in
-          new TwoNodesRuntime[Seq[PeerNode]](
-            lookupHandler = Handler.lookupHandler(
-              Seq(
-                otherPeer,
-                PeerNode.from(NodeIdentifier(key), "0.0.0.0", 0, 0)
-              )
-            )
-          ) {
-            def execute(
-                kademliaRPC: KademliaRPC[F],
-                local: PeerNode,
-                remote: PeerNode
-            ): F[Seq[PeerNode]] = kademliaRPC.lookup(key, remote)
-
-            val result: TwoNodesResult = run()
-
-            result() shouldEqual Seq(otherPeer)
-            lookupHandler.received should have length 1
-            val (receiver, (sender, k)) = lookupHandler.received.head
-            receiver shouldEqual result.remoteNode
-            sender shouldEqual result.localNode
-            k should be(key)
-          }
-      }
-
       "response takes to long" should {
         "get an empty list result" in
           new TwoNodesRuntime[Seq[PeerNode]](

--- a/integration-tests/test/rnode.py
+++ b/integration-tests/test/rnode.py
@@ -525,8 +525,7 @@ def make_bootstrap_node(
         *rnode_default_launcher_args,
         "--standalone",
         "--prometheus",
-        "--no-upnp",
-        "--allow-private-addresses"
+        "--no-upnp"
     ])
 
     container_command_options = {
@@ -615,8 +614,7 @@ def make_peer(
 
     container_command_flags = set([
         "--prometheus",
-        "--no-upnp",
-        "--allow-private-addresses"
+        "--no-upnp"
     ])
 
     if cli_flags is not None:

--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -20,9 +20,6 @@ protocol-server {
   # Note: actual protocol server is binded to "0.0.0.0"
   # host = localhost
 
-  # Allow `host` to be non publicly accessible address. Required for private networks installations.
-  allow-private-addresses = false
-
   # Use random ports in case RChain Protocol port and/or Kademlia port are not free.
   use-random-ports = false
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -26,7 +26,6 @@ object ConfigMapper {
       add("protocol-server.host", run.host)
       add("protocol-server.port", run.protocolPort)
       add("protocol-server.use-random-ports", run.useRandomPorts)
-      add("protocol-server.allow-private-addresses", run.allowPrivateAddresses)
       add(
         "protocol-server.disable-state-exporter",
         run.disableStateExporter

--- a/node/src/main/scala/coop/rchain/node/configuration/model.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/model.scala
@@ -35,7 +35,6 @@ final case class NodeConf(
 final case class ProtocolServer(
     networkId: String,
     host: Option[String],
-    allowPrivateAddresses: Boolean,
     useRandomPorts: Boolean,
     dynamicIp: Boolean,
     noUpnp: Boolean,

--- a/node/src/main/scala/coop/rchain/node/effects/package.scala
+++ b/node/src/main/scala/coop/rchain/node/effects/package.scala
@@ -39,10 +39,8 @@ package object effects {
 
   def kademliaRPC[F[_]: Monixable: Sync: PeerNodeAsk: Metrics](
       networkId: String,
-      timeout: FiniteDuration,
-      allowPrivateAddresses: Boolean
-  )(implicit scheduler: Scheduler): KademliaRPC[F] =
-    new GrpcKademliaRPC(networkId, timeout, allowPrivateAddresses)
+      timeout: FiniteDuration
+  )(implicit scheduler: Scheduler): KademliaRPC[F] = new GrpcKademliaRPC(networkId, timeout)
 
   def transportClient[F[_]: Monixable: Concurrent: Parallel: Log: Metrics](
       networkId: String,

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
@@ -124,8 +124,7 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
         implicit val p = peerNodeAsk
         effects.kademliaRPC(
           nodeConf.protocolServer.networkId,
-          nodeConf.protocolClient.networkTimeout,
-          nodeConf.protocolServer.allowPrivateAddresses
+          nodeConf.protocolClient.networkTimeout
         )
       }
 

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -29,7 +29,6 @@ class ConfigMapperSpec extends AnyFunSuite with Matchers {
         "--dynamic-ip",
         "--autogen-shard-size 111111",
         "--use-random-ports",
-        "--allow-private-addresses",
         "--network-timeout 111111seconds",
         "--discovery-port 111111",
         "--discovery-lookup-interval 111111seconds",

--- a/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/commandline/ConfigMapperSpec.scala
@@ -131,7 +131,6 @@ class ConfigMapperSpec extends AnyFunSuite with Matchers {
       protocolServer = ProtocolServer(
         networkId = "testnet",
         host = Some("localhost"),
-        allowPrivateAddresses = true,
         useRandomPorts = true,
         dynamicIp = true,
         noUpnp = true,

--- a/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/configuration/hocon/HoconConfigurationSpec.scala
@@ -47,7 +47,6 @@ class HoconConfigurationSpec extends AnyFunSuite with Matchers {
       protocolServer = ProtocolServer(
         networkId = "testnet",
         host = None,
-        allowPrivateAddresses = false,
         useRandomPorts = false,
         dynamicIp = false,
         noUpnp = false,


### PR DESCRIPTION
## Overview

Also removed related code. A deprecation warning is printed to the output if the user has specified a parameter. This is for compatibility with current clients, such as the VSCode extension, and should be removed in a future releases.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
