### PR TITLE
Unit tests for BlockReceiver effects

### DIFF
--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -227,11 +227,10 @@ class BlockReceiverEffectsSpec
     ValidatorIdentity(privateKey).signBlock(block)
   }
 
-  private def addBlock[F[_]: Sync](bs: BlockStore[F]): F[BlockMessage] =
-    for {
-      block <- Sync[F].delay(makeBlock())
-      _     <- bs.put(Seq((block.blockHash, block)))
-    } yield block
+  private def addBlock[F[_]: Sync](bs: BlockStore[F]): F[BlockMessage] = {
+    val block = makeBlock()
+    bs.put(Seq((block.blockHash, block))).as(block)
+  }
 
   private def dagStorageWasNotModified[F[_]](bds: BlockDagStorage[F]) = {
     bds.insert(*, *, *) wasNever called

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -153,15 +153,15 @@ class BlockReceiverEffectsSpec
       }
   }
 
-  private def blockDagStorageMock[F[_]: Applicative](): BlockDagStorage[F] = {
+  private def blockDagStorageMock[F[_]: Applicative]: BlockDagStorage[F] = {
     val emptyDag = DagRepresentation(Set(), Map(), SortedMap(), DagMessageState(), Map())
     mock[BlockDagStorage[F]].getRepresentation returnsF emptyDag
   }
 
-  private def blockRetrieverMock[F[_]: Applicative](): BlockRetriever[F] =
+  private def blockRetrieverMock[F[_]: Applicative]: BlockRetriever[F] =
     mock[BlockRetriever[F]].ackReceived(*) returns ().pure[F]
 
-  private def blockStoreMock[F[_]: Sync: Applicative](): BlockStore[F] = {
+  private def blockStoreMock[F[_]: Sync]: BlockStore[F] = {
     val state  = Ref.unsafe[F, Map[BlockHash, BlockMessage]](Map())
     val bsMock = mock[BlockStore[F]]
     bsMock.contains(*) answers { keys: Seq[BlockHash] =>
@@ -193,9 +193,9 @@ class BlockReceiverEffectsSpec
       validatedBlocksStream = validatedBlocksQueue.dequeue
 
       // Create mock separately for each test
-      bs  = blockStoreMock[F]()
-      br  = blockRetrieverMock[F]()
-      bds = blockDagStorageMock[F]()
+      bs  = blockStoreMock[F]
+      br  = blockRetrieverMock[F]
+      bds = blockDagStorageMock[F]
 
       blockReceiver <- {
         implicit val (bsImp, brImp, bdsImp) = (bs, br, bds)

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -133,17 +133,15 @@ class BlockReceiverEffectsSpec
         // All dependencies of child A2 are resolved, so it also goes to the output queue
         a2InOutQueue <- outStream.take(1).compile.lastOrError
       } yield {
-        val bsPutCaptor = ArgCaptor[Seq[(BlockHash, BlockMessage)]]
-        bs.put(bsPutCaptor) wasCalled twice
-        bsPutCaptor.values should contain allOf (Seq((a1.blockHash, a1)), Seq((a2.blockHash, a2)))
+        bs.put(Seq((a1.blockHash, a1))) wasCalled once
+        bs.put(Seq((a2.blockHash, a2))) wasCalled once
 
         val bsContainsCaptor = ArgCaptor[Seq[BlockHash]]
         bs.contains(bsContainsCaptor) wasCalled 3.times
         bsContainsCaptor.values should contain allOf (Seq(a1.blockHash), Seq(a2.blockHash))
 
-        val brAckReceivedCaptor = ArgCaptor[BlockHash]
-        br.ackReceived(brAckReceivedCaptor) wasCalled twice
-        brAckReceivedCaptor.values should contain allOf (a1.blockHash, a2.blockHash)
+        br.ackReceived(a1.blockHash) wasCalled once
+        br.ackReceived(a2.blockHash) wasCalled once
 
         dagStorageWasNotModified(bds)
         a1InOutQueue shouldBe a1.blockHash

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -37,8 +37,7 @@ class BlockReceiverEffectsSpec
     with IdiomaticMockito
     with IdiomaticMockitoCats
     with ArgumentMatchersSugar {
-  implicit val logEff: Log[Task]            = Log.log[Task]
-  implicit val timeEff: LogicalTime[Effect] = new LogicalTime[Effect]
+  implicit val logEff: Log[Task] = Log.log[Task]
 
   it should "pass correct block to output stream with calling effectful components" in
     withEnv[Task]("root") {

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -126,13 +126,13 @@ class BlockReceiverEffectsSpec
 
         // Dependencies of the child (its parent) have not yet been resolved,
         // so only the parent goes to the output queue, since it has no dependencies
-        a1InOutQueue <- outStream.take(1).compile.toList.map(_.head)
+        a1InOutQueue <- outStream.take(1).compile.lastOrError
 
         // A1 is now validated (e.g. in BlockProcessor)
         _ <- validatedQueue.enqueue1(a1)
 
         // All dependencies of child A2 are resolved, so it also goes to the output queue
-        a2InOutQueue <- outStream.take(1).compile.toList.map(_.head)
+        a2InOutQueue <- outStream.take(1).compile.lastOrError
       } yield {
         val bsPutCaptor = ArgCaptor[Seq[(BlockHash, BlockMessage)]]
         bs.put(bsPutCaptor) wasCalled twice

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -100,7 +100,7 @@ class BlockReceiverEffectsSpec
       }
   }
 
-  it should "discard known block" in withEnv("root") {
+  /*it should "discard known block" in withEnv[Task]("root") {
     case (incomingQueue, _, outStream, bs, br, bds) =>
       for {
         block <- addBlock(bs)
@@ -112,9 +112,9 @@ class BlockReceiverEffectsSpec
         dagStorageWasNotModified(bds)
         outStream should notEmit
       }
-  }
+  }*/
 
-  it should "pass to output blocks with resolved dependencies" in withEnv("root") {
+  it should "pass to output blocks with resolved dependencies" in withEnv[Task]("root") {
     case (incomingQueue, validatedQueue, outStream, bs, br, bds) =>
       for {
         // Received a parent with an empty list of justifications and its child
@@ -229,11 +229,11 @@ class BlockReceiverEffectsSpec
     } yield signedBlock
   }
 
-  private def addBlock(bs: BlockStore[Task]): Task[BlockMessage] =
+  /*private def addBlock(bs: BlockStore[Task]): Task[BlockMessage] =
     for {
       block <- makeBlock()
       _     <- bs.put(Seq((block.blockHash, block)))
-    } yield block
+    } yield block*/
 
   private def dagStorageWasNotModified[F[_]](bds: BlockDagStorage[F]) = {
     bds.insert(*, *, *) wasNever called

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -49,7 +49,7 @@ class BlockReceiverEffectsSpec
         bs.put(*) wasCalled once
         bs.contains(*) wasCalled once
         br.ackReceived(*) wasCalled once
-        bds.getRepresentation wasCalled twice
+        dagStorageWasNotModified(bds)
         outList.length shouldBe 1
       }
   }
@@ -65,7 +65,7 @@ class BlockReceiverEffectsSpec
         bs.put(*) wasNever called
         bs.contains(*) wasNever called
         br.ackReceived(*) wasNever called
-        bds.getRepresentation wasNever called
+        dagStorageWasNotModified(bds)
         outStream should notEmit
       }
   }
@@ -79,7 +79,7 @@ class BlockReceiverEffectsSpec
         bs.put(*) wasNever called
         bs.contains(*) wasNever called
         br.ackReceived(*) wasNever called
-        bds.getRepresentation wasNever called
+        dagStorageWasNotModified(bds)
         outStream should notEmit
       }
   }
@@ -93,7 +93,7 @@ class BlockReceiverEffectsSpec
         bs.put(*) wasNever called
         bs.contains(*) wasNever called
         br.ackReceived(*) wasNever called
-        bds.getRepresentation wasNever called
+        dagStorageWasNotModified(bds)
         outStream should notEmit
       }
   }
@@ -107,7 +107,7 @@ class BlockReceiverEffectsSpec
         bs.put(*) wasCalled once
         bs.contains(*) wasNever called
         br.ackReceived(*) wasNever called
-        bds.getRepresentation wasNever called
+        dagStorageWasNotModified(bds)
         outStream should notEmit
       }
   }
@@ -136,7 +136,7 @@ class BlockReceiverEffectsSpec
         bs.put(*) wasCalled twice
         bs.contains(*) wasCalled 3.times
         br.ackReceived(*) wasCalled twice
-        bds.getRepresentation wasCalled 4.times
+        dagStorageWasNotModified(bds)
         a1InOutQueue shouldBe a1.blockHash
         a2InOutQueue shouldBe a2.blockHash
       }
@@ -223,4 +223,10 @@ class BlockReceiverEffectsSpec
       block <- makeBlock()
       _     <- bs.put(Seq((block.blockHash, block)))
     } yield block
+
+  private def dagStorageWasNotModified[F[_]](bds: BlockDagStorage[F]) = {
+    bds.insert(*, *, *) wasNever called
+    bds.insertNew(*, *) wasNever called
+    bds.addDeploy(*) wasNever called
+  }
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.SortedMap
 
-class BlockReceiverSpec
+class BlockReceiverEffectsSpec
     extends AsyncFlatSpec
     with MonixTaskTest
     with Matchers

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -1,21 +1,19 @@
 package coop.rchain.casper.batch2
 
 import cats.Applicative
-import cats.effect.{Concurrent, Sync}
 import cats.effect.concurrent.Ref
+import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.{BlockDagStorage, DagMessageState, DagRepresentation}
 import coop.rchain.casper.ValidatorIdentity
 import coop.rchain.casper.blocks.{BlockReceiver, BlockReceiverState}
 import coop.rchain.casper.engine.BlockRetriever
-import coop.rchain.casper.helper.TestNode.Effect
 import coop.rchain.casper.protocol.{BlockMessage, BlockMessageProto}
 import coop.rchain.casper.util.scalatest.Fs2StreamMatchers
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.syntax._
-import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.shared.Log
 import fs2.concurrent.Queue
 import monix.eval.Task
@@ -99,10 +97,10 @@ class BlockReceiverEffectsSpec
       }
   }
 
-  /*it should "discard known block" in withEnv[Task]("root") {
+  it should "discard known block" in withEnv[Task]("root") {
     case (incomingQueue, _, outStream, bs, br, bds) =>
       for {
-        block <- addBlock(bs)
+        block <- addBlock[Task](bs)
         _     <- incomingQueue.enqueue1(block)
       } yield {
         bs.put(Seq((block.blockHash, block))) wasCalled once
@@ -111,7 +109,7 @@ class BlockReceiverEffectsSpec
         dagStorageWasNotModified(bds)
         outStream should notEmit
       }
-  }*/
+  }
 
   it should "pass to output blocks with resolved dependencies" in withEnv[Task]("root") {
     case (incomingQueue, validatedQueue, outStream, bs, br, bds) =>
@@ -222,11 +220,11 @@ class BlockReceiverEffectsSpec
     ValidatorIdentity(privateKey).signBlock(block)
   }
 
-  /*private def addBlock(bs: BlockStore[Task]): Task[BlockMessage] =
+  private def addBlock[F[_]: Sync](bs: BlockStore[F]): F[BlockMessage] =
     for {
-      block <- makeBlock()
+      block <- Sync[F].delay(makeBlock())
       _     <- bs.put(Seq((block.blockHash, block)))
-    } yield block*/
+    } yield block
 
   private def dagStorageWasNotModified[F[_]](bds: BlockDagStorage[F]) = {
     bds.insert(*, *, *) wasNever called

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -172,7 +172,7 @@ class BlockReceiverEffectsSpec
 
   import fs2._
 
-  private def withEnv[F[_]: Concurrent: Sync: Log](shardId: String)(
+  private def withEnv[F[_]: Concurrent: Log](shardId: String)(
       f: (
           Queue[F, BlockMessage],
           Queue[F, BlockMessage],

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverSpec.scala
@@ -2,13 +2,16 @@ package coop.rchain.casper.blocks.proposer
 
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
+import com.google.protobuf.ByteString
+import coop.rchain.casper.ValidatorIdentity
 import coop.rchain.casper.blocks.{BlockReceiver, BlockReceiverState}
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode.Effect
-import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.protocol.{BlockMessage, Justification}
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.GenesisBuilder.buildGenesis
 import coop.rchain.casper.util.scalatest.Fs2StreamMatchers
+import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.syntax._
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
@@ -32,7 +35,12 @@ class BlockReceiverSpec
   import fs2._
 
   private def withBlockReceiverEnv(shardId: String)(
-      f: (Queue[Task, BlockMessage], Stream[Task, BlockHash], TestNode[Task]) => Task[Assertion]
+      f: (
+          Queue[Task, BlockMessage],
+          Queue[Task, BlockMessage],
+          Stream[Task, BlockHash],
+          TestNode[Task]
+      ) => Task[Assertion]
   ): Task[Assertion] = TestNode.standaloneEff(genesis).use { node =>
     implicit val (bds, br, bs) =
       (node.blockDagStorage, node.blockRetrieverEffect, node.blockStore)
@@ -41,23 +49,38 @@ class BlockReceiverSpec
       state                 <- Ref[Task].of(BlockReceiverState[BlockHash])
       incomingBlockQueue    <- Queue.unbounded[Task, BlockMessage]
       incomingBlockStream   = incomingBlockQueue.dequeue
-      validatedBlocksStream = Stream[Task, BlockMessage]()
+      validatedBlocksQueue  <- Queue.unbounded[Task, BlockMessage]
+      validatedBlocksStream = validatedBlocksQueue.dequeue
       br                    <- BlockReceiver(state, incomingBlockStream, validatedBlocksStream, shardId)
-      res                   <- f(incomingBlockQueue, br, node)
+      res                   <- f(incomingBlockQueue, validatedBlocksQueue, br, node)
     } yield res
   }
 
   private def makeDeploy =
     ConstructDeploy.sourceDeployNowF("new x in { x!(0) }", shardId = genesis.genesisBlock.shardId)
 
-  private def makeBlock(node: TestNode[Task]): Task[BlockMessage] =
-    makeDeploy >>= (node.createBlockUnsafe(_))
+  private def makeBlock(
+      node: TestNode[Task],
+      justifications: Seq[BlockHash] = Seq()
+  ): Task[BlockMessage] =
+    for {
+      deploy <- makeDeploy
+      block <- node
+                .createBlockUnsafe(deploy)
+                .map(
+                  _.copy(
+                    justifications = justifications.map(Justification(ByteString.EMPTY, _)).toList
+                  )
+                )
+      (sk, _)     = Secp256k1.newKeyPair
+      validatorId = ValidatorIdentity(sk)
+    } yield validatorId.signBlock(block)
 
   private def addBlock(node: TestNode[Task]): Task[BlockMessage] = makeDeploy >>= (node.addBlock(_))
 
   it should "pass correct block to output stream" in {
     withBlockReceiverEnv("root") {
-      case (incomingQueue, outStream, node) =>
+      case (incomingQueue, _, outStream, node) =>
         for {
           block   <- makeBlock(node)
           _       <- incomingQueue.enqueue1(block)
@@ -70,7 +93,7 @@ class BlockReceiverSpec
     // Provided to BlockReceiver shard name ("test") is differ from block's shard name ("root" by default)
     // So block should be rejected and output stream should never take block
     withBlockReceiverEnv("test") {
-      case (incomingQueue, outStream, node) =>
+      case (incomingQueue, _, outStream, node) =>
         for {
           block <- makeBlock(node)
           _     <- incomingQueue.enqueue1(block)
@@ -80,7 +103,7 @@ class BlockReceiverSpec
 
   it should "discard block with invalid block hash" in {
     withBlockReceiverEnv("root") {
-      case (incomingQueue, outStream, node) =>
+      case (incomingQueue, _, outStream, node) =>
         for {
           block <- makeBlock(node).map(_.copy(blockHash = "abc".unsafeHexToByteString))
           _     <- incomingQueue.enqueue1(block)
@@ -90,7 +113,7 @@ class BlockReceiverSpec
 
   it should "discard block with invalid signature" in {
     withBlockReceiverEnv("root") {
-      case (incomingQueue, outStream, node) =>
+      case (incomingQueue, _, outStream, node) =>
         for {
           block <- makeBlock(node).map(_.copy(sig = "abc".unsafeHexToByteString))
           _     <- incomingQueue.enqueue1(block)
@@ -100,11 +123,39 @@ class BlockReceiverSpec
 
   it should "discard known block" in {
     withBlockReceiverEnv("root") {
-      case (incomingQueue, outStream, node) =>
+      case (incomingQueue, _, outStream, node) =>
         for {
           block <- addBlock(node)
           _     <- incomingQueue.enqueue1(block)
         } yield outStream should notEmit
+    }
+  }
+
+  "BlockReceiver" should "pass to output blocks with resolved dependencies" in {
+    withBlockReceiverEnv("root") {
+      case (incomingQueue, validatedQueue, outStream, node) =>
+        for {
+          // Received a parent with an empty list of justifications and its child
+          a1 <- makeBlock(node)
+          a2 <- makeBlock(node, Seq(a1.blockHash))
+
+          // Put the parent and child in the input queue
+          _ <- incomingQueue.enqueue1(a2)
+          _ <- incomingQueue.enqueue1(a1)
+
+          // Dependencies of the child (its parent) have not yet been resolved,
+          // so only the parent goes to the output queue, since it has no dependencies
+          a1InOutQueue <- outStream.take(1).compile.toList.map(_.head)
+
+          // A1 is now validated (e.g. in BlockProcessor)
+          _ <- validatedQueue.enqueue1(a1)
+
+          // All dependencies of child A2 are resolved, so it also goes to the output queue
+          a2InOutQueue <- outStream.take(1).compile.toList.map(_.head)
+        } yield {
+          a1InOutQueue shouldBe a1.blockHash
+          a2InOutQueue shouldBe a2.blockHash
+        }
     }
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverSpec.scala
@@ -1,0 +1,69 @@
+package coop.rchain.casper.blocks.proposer
+
+import cats.effect.concurrent.Ref
+import cats.syntax.all._
+import coop.rchain.casper.blocks.{BlockReceiver, BlockReceiverState}
+import coop.rchain.casper.helper.TestNode
+import coop.rchain.casper.helper.TestNode.Effect
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.util.ConstructDeploy
+import coop.rchain.casper.util.GenesisBuilder.buildGenesis
+import coop.rchain.models.BlockHash.BlockHash
+import coop.rchain.models.syntax._
+import coop.rchain.p2p.EffectsTestInstances.LogicalTime
+import coop.rchain.shared.Log
+import monix.eval.Task
+import monix.testing.scalatest.MonixTaskTest
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.DurationInt
+
+class BlockReceiverSpec extends AsyncFlatSpec with MonixTaskTest with Matchers {
+  implicit val logEff: Log[Task]            = Log.log[Task]
+  implicit val timeEff: LogicalTime[Effect] = new LogicalTime[Effect]
+  private val genesis                       = buildGenesis()
+
+  import fs2._
+
+  private def withBlockReceiverEnv(shardId: String)(
+      f: Stream[Task, BlockHash] => Task[Assertion]
+  ): Task[Assertion] = TestNode.standaloneEff(genesis).use { node =>
+    implicit val (bds, br, bs) =
+      (node.blockDagStorage, node.blockRetrieverEffect, node.blockStore)
+
+    for {
+      state                 <- Ref[Task].of(BlockReceiverState[BlockHash])
+      block                 <- makeBlock(node)
+      incomingBlockStream   = Stream[Task, BlockMessage](block)
+      validatedBlocksStream = Stream[Task, BlockMessage]()
+      br                    <- BlockReceiver(state, incomingBlockStream, validatedBlocksStream, shardId)
+      res                   <- f(br)
+    } yield res
+  }
+
+  private def makeBlock(node: TestNode[Task]): Task[BlockMessage] =
+    ConstructDeploy
+      .sourceDeployNowF("new x in { x!(0) }", shardId = genesis.genesisBlock.shardId) >>= (node
+      .createBlockUnsafe(_))
+
+  it should "pass correct block to output stream" in {
+    withBlockReceiverEnv("root") { outStream =>
+      outStream.take(1).compile.toList.map(outList => outList.length shouldBe 1)
+    }
+  }
+
+  it should "discard block with invalid shard name" in {
+    // Provided to BlockReceiver shard name ("test") is differ from block's shard name ("root" by default)
+    // So block should be rejected and output stream should never take block
+    withBlockReceiverEnv("test") { outStream =>
+      outStream
+        .take(1)
+        .interruptAfter(1.second)
+        .compile
+        .toList
+        .map(outList => outList shouldBe empty)
+    }
+  }
+}

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverSpec.scala
@@ -7,7 +7,7 @@ import coop.rchain.casper.ValidatorIdentity
 import coop.rchain.casper.blocks.{BlockReceiver, BlockReceiverState}
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode.Effect
-import coop.rchain.casper.protocol.{BlockMessage, Justification}
+import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.GenesisBuilder.buildGenesis
 import coop.rchain.casper.util.scalatest.Fs2StreamMatchers
@@ -61,7 +61,7 @@ class BlockReceiverSpec
 
   private def makeBlock(
       node: TestNode[Task],
-      justifications: Seq[BlockHash] = Seq()
+      justifications: List[BlockHash] = List()
   ): Task[BlockMessage] =
     for {
       deploy <- makeDeploy
@@ -69,7 +69,7 @@ class BlockReceiverSpec
                 .createBlockUnsafe(deploy)
                 .map(
                   _.copy(
-                    justifications = justifications.map(Justification(ByteString.EMPTY, _)).toList
+                    justifications = justifications
                   )
                 )
       (sk, _)     = Secp256k1.newKeyPair
@@ -137,7 +137,7 @@ class BlockReceiverSpec
         for {
           // Received a parent with an empty list of justifications and its child
           a1 <- makeBlock(node)
-          a2 <- makeBlock(node, Seq(a1.blockHash))
+          a2 <- makeBlock(node, List(a1.blockHash))
 
           // Put the parent and child in the input queue
           _ <- incomingQueue.enqueue1(a2)

--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -19,9 +19,7 @@ object CompilerSettings {
     Seq(
       "-Xfuture",
       "-Ypartial-unification",
-      // To prevent "dead code following this construct" error when using * mockito-scala library
-      // https://github.com/mockito/mockito-scala/issues/29
-      // "-Ywarn-dead-code",
+      "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-deprecation",
       "-encoding", "UTF-8",
@@ -68,6 +66,9 @@ object CompilerSettings {
         )
       )
     },
-    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
+    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
+    // To prevent "dead code following this construct" error when using * mockito-scala library
+    // https://github.com/mockito/mockito-scala/issues/29
+    scalacOptions in Test -= "-Ywarn-dead-code"
   )
 }

--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -19,7 +19,9 @@ object CompilerSettings {
     Seq(
       "-Xfuture",
       "-Ypartial-unification",
-      "-Ywarn-dead-code",
+      // To prevent "dead code following this construct" error when using * mockito-scala library
+      // https://github.com/mockito/mockito-scala/issues/29
+      // "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-deprecation",
       "-encoding", "UTF-8",

--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -19,7 +19,11 @@ object CompilerSettings {
     Seq(
       "-Xfuture",
       "-Ypartial-unification",
-      "-Ywarn-dead-code",
+      // To prevent "dead code following this construct" error when using `*` from mockito-scala library
+      // https://github.com/mockito/mockito-scala/#dead-code-warning
+      // This warning should be disabled only for Tests but in that case IntelliJ cannot compile project.
+      // Related issues https://youtrack.jetbrains.com/issue/SCL-11824, https://youtrack.jetbrains.com/issue/IDEA-232043
+      // "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-deprecation",
       "-encoding", "UTF-8",
@@ -66,9 +70,6 @@ object CompilerSettings {
         )
       )
     },
-    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
-    // To prevent "dead code following this construct" error when using * mockito-scala library
-    // https://github.com/mockito/mockito-scala/#dead-code-warning
-    scalacOptions in Test -= "-Ywarn-dead-code"
+    scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
   )
 }

--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -68,7 +68,7 @@ object CompilerSettings {
     },
     scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
     // To prevent "dead code following this construct" error when using * mockito-scala library
-    // https://github.com/mockito/mockito-scala/issues/29
+    // https://github.com/mockito/mockito-scala/#dead-code-warning
     scalacOptions in Test -= "-Ywarn-dead-code"
   )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,6 +68,7 @@ object Dependencies {
   val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "6.6"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
   val magnolia            = "com.propensive"             %% "magnolia"                  % "0.17.0"
+  val mockito             = "org.mockito"                %% "mockito-scala-cats"        % "1.16.42" % "test"
   val monix               = "io.monix"                   %% "monix"                     % monixVersion
   val monixTesting        = "io.monix"                   %% "monix-testing-scalatest"   % "0.3.0"
   val pureconfig          = "com.github.pureconfig"      %% "pureconfig"                % "0.14.0"
@@ -140,7 +141,7 @@ object Dependencies {
     "org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full
   )
 
-  private val testing = Seq(scalactic, scalatest, scalacheck, scalatestPlus, monixTesting)
+  private val testing = Seq(scalactic, scalatest, scalacheck, scalatestPlus, monixTesting, mockito)
 
   private val logging = Seq(slf4j, julToSlf4j, scalaLogging, logbackClassic, logstashLogback)
 


### PR DESCRIPTION
## Overview

Unit-tests for BlockReceiver. Continuation of PR #3738, but for effects tests.

Since the interaction with the BlockReceiver performs via Streams/Queues, the tests checks if the desired blocks get into the output stream.

Most tests check that a block is dropped for various reasons: invalid hash or block signature or shard name, etc.

The last test checks the full logic of the BlockReceiver.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
