### PR TITLE
Add shard name (Id) in log

### DIFF
--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -416,7 +416,8 @@ object Main {
     Log[F].info(s"Starting with profile ${profile.name}") *>
       (if (configFile.isEmpty) Log[F].warn("No configuration file found, using defaults")
        else Log[F].info(s"Using configuration file: ${configFile.get.getAbsolutePath}")) *>
-      Log[F].info(s"Running on network: ${conf.protocolServer.networkId}")
+      Log[F].info(s"Running on network: ${conf.protocolServer.networkId}") *>
+      Log[F].info(s"Running on shard name (id): ${conf.casper.shardName}")
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   private def consoleIO[F[_]: Sync]: ConsoleIO[F] = {


### PR DESCRIPTION
## Overview
Work according to the task #3745

### Notes
Added info message in Log[F]. The massage output `conf.casper.shardName` parameter.

### Result
For configuration:
`run -s --shard-name dharshroot --host 127.0.0.1 --allow-private-addresses --data-dir /rchain_test/standalone`.
Now output:
![image](https://user-images.githubusercontent.com/81892279/174590103-b1df89cb-66f6-4bb4-bb48-c1c2dd7e0c52.png)

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
