### PR TITLE
Make conflict resolution logic pure

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/ConflictSetMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/ConflictSetMerger.scala
@@ -2,33 +2,22 @@ package coop.rchain.casper.merging
 
 import cats.effect.Concurrent
 import cats.syntax.all._
-import coop.rchain.models.ListParWithRandom
-import coop.rchain.rspace.HotStoreTrieAction
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.rspace.history.HistoryReaderBinary
 import coop.rchain.rspace.merger.EventLogMergingLogic._
-import coop.rchain.rspace.merger.StateChange._
-import coop.rchain.rspace.merger._
-import coop.rchain.rspace.serializers.ScodecSerialize.DatumB
 import coop.rchain.shared.{Log, Stopwatch}
-import coop.rchain.rholang.interpreter.merging.RholangMergingLogic.convertToReadNumber
-import coop.rchain.rspace.internal.Datum
 
 object ConflictSetMerger {
 
   /** R is a type for minimal rejection unit */
-  def merge[F[_]: Concurrent: Log, R: Ordering](
+  def merge[R: Ordering](
       actualSet: Set[R],
       lateSet: Set[R],
       depends: (R, R) => Boolean,
       conflicts: (Set[R], Set[R]) => Boolean,
       cost: R => Long,
-      stateChanges: R => F[StateChange],
       mergeableChannels: R => NumberChannelsDiff,
-      computeTrieActions: (StateChange, NumberChannelsDiff) => F[Vector[HotStoreTrieAction]],
-      applyTrieActions: Seq[HotStoreTrieAction] => F[Blake2b256Hash],
       baseMergeableChRes: Map[Blake2b256Hash, Long]
-  ): F[(Blake2b256Hash, Set[R])] = {
+  ): (Set[R], Set[R], String) = {
 
     type Branch = Set[R]
 
@@ -131,33 +120,16 @@ object ConflictSetMerger {
     )
     val optimalRejection = getOptimalRejection(rejectionOptionsWithOverflow, rejectionTargetF)
     val rejected         = lateSet ++ rejectedAsDependents ++ optimalRejection.flatten
-    val toMerge          = branches diff optimalRejection
-    for {
-      r <- Stopwatch.duration(toMerge.toList.flatten.traverse(stateChanges).map(_.combineAll))
-
-      (allChanges, combineAllChanges) = r
-
-      // All number channels merged
-      // TODO: Negative or overflow should be rejected before!
-      allMergeableChannels = toMerge.toList.flatten.map(mergeableChannels).combineAll
-
-      r                                 <- Stopwatch.duration(computeTrieActions(allChanges, allMergeableChannels))
-      (trieActions, computeActionsTime) = r
-      r                                 <- Stopwatch.duration(applyTrieActions(trieActions))
-      (newState, applyActionsTime)      = r
-      overallChanges                    = s"${allChanges.datumsChanges.size} D, ${allChanges.kontChanges.size} K, ${allChanges.consumeChannelsToJoinSerializedMap.size} J"
-      logStr = s"Merging done: " +
-        s"late set size ${lateSet.size}; " +
-        s"actual set size ${actualSet.size}; " +
+    val logStr =
+      s"conflicts map in ${conflictsMapTime}; " +
         s"computed branches (${branches.size}) in ${branchesTime}; " +
-        s"conflicts map in ${conflictsMapTime}; " +
         s"rejection options (${rejectionOptions.size}) in ${rejectionOptionsTime}; " +
         s"optimal rejection set size ${optimalRejection.size}; " +
-        s"rejected as late dependency ${rejectedAsDependents.size}; " +
-        s"changes combined (${overallChanges}) in ${combineAllChanges}; " +
-        s"trie actions (${trieActions.size}) in ${computeActionsTime}; " +
-        s"actions applied in ${applyActionsTime}"
-      _ <- Log[F].debug(logStr)
-    } yield (newState, rejected)
+        s"rejected as late dependency ${rejectedAsDependents.size}; "
+    (
+      (branches diff optimalRejection).flatten,
+      rejected,
+      logStr
+    )
   }
 }


### PR DESCRIPTION
## Overview
Effects in conflict resolution logic are required now only for reading initial values of mergeable channels to be able to find out optimal rejection under possible overflow of the mergeable channel value or its going negative. But this can be done before conflict resolution for all mergeable channels in the conflict scope.
New conflict resolution code will be pure, so this PR is a preparation refactoring.

The second commit is just moving pieces of code from one function to another. 
Only the first one changes the logic. Previously reading of init values for mergeable channels were done after conflict resolution. But it can be done before, so this is the change.

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
