### PR TITLE
Added check that shard name contains only ASCII characters

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockRandomSeed.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockRandomSeed.scala
@@ -2,6 +2,7 @@ package coop.rchain.casper
 
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
+import coop.rchain.models.syntax._
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import scodec.bits.ByteVector
 import scodec.codecs.{bytes, uint8, ulong, utf8, variableSizeBytes}
@@ -20,7 +21,10 @@ object BlockRandomSeed {
       blockNumber: Long,
       sender: PublicKey,
       preStateHash: Blake2b256Hash
-  ): BlockRandomSeed = new BlockRandomSeed(shardId, blockNumber, sender, preStateHash)
+  ): BlockRandomSeed = {
+    assert(shardId.onlyAscii, "Shard name should contain only ASCII characters")
+    new BlockRandomSeed(shardId, blockNumber, sender, preStateHash)
+  }
 
   private val codecPublicKey: Codec[PublicKey] = variableSizeBytes(uint8, bytes)
     .xmap[PublicKey](bv => PublicKey(bv.toArray), pk => ByteVector(pk.bytes))

--- a/models/src/main/scala/coop/rchain/models/StringSyntax.scala
+++ b/models/src/main/scala/coop/rchain/models/StringSyntax.scala
@@ -1,5 +1,6 @@
 package coop.rchain.models
 
+import com.google.common.base.CharMatcher
 import com.google.protobuf.ByteString
 import coop.rchain.shared.Base16
 
@@ -13,4 +14,5 @@ class StringOps(private val s: String) extends AnyVal {
   def hexToByteString: Option[ByteString] = decodeHex.map(ByteString.copyFrom)
   def decodeHex: Option[Array[Byte]]      = Base16.decode(s)
   def unsafeDecodeHex: Array[Byte]        = Base16.unsafeDecode(s)
+  def onlyAscii: Boolean                  = CharMatcher.ascii().matchesAllOf(s)
 }

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -3,12 +3,12 @@ package coop.rchain.node
 import cats.Parallel
 import cats.effect._
 import cats.syntax.all._
-import com.google.common.base.CharMatcher
 import coop.rchain.casper.protocol.client.{DeployRuntime, GrpcDeployService, GrpcProposeService}
 import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.{Secp256k1, SignaturesAlg}
 import coop.rchain.crypto.util.KeyUtil
+import coop.rchain.models.syntax._
 import coop.rchain.monix.Monixable
 import coop.rchain.node.configuration.Configuration.Profile
 import coop.rchain.node.configuration._
@@ -401,7 +401,7 @@ object Main {
   private def checkShardNameOnlyAscii[F[_]: Sync: Log](shardName: String): F[Unit] =
     (Log[F].error("Shard name should contain only ASCII characters") >>
       Sync[F].raiseError(new RuntimeException("Invalid shard name")))
-      .whenA(!CharMatcher.ascii().matchesAllOf(shardName))
+      .whenA(!shardName.onlyAscii)
 
   private def logConfiguration[F[_]: Sync: Log](
       conf: NodeConf,

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -99,7 +99,6 @@ object Main {
             .whenA(options.run.allowPrivateAddresses.isSupplied)
 
       _ <- checkShardNameOnlyAscii(nodeConf.casper.shardName)
-            .whenA(options.run.shardName.isSupplied)
 
       // Create node runtime
       _ <- NodeRuntime.start[F](confWithDecrypt, kamonConf)


### PR DESCRIPTION
## Overview

The check ensures that the shard name used in random seed generator contains only ASCII characters. This is required to reduce incompatibility issues.

The check is performed when the node is started. If the shard name contains non-ASCII characters, the node exits with a log message.

### Checking

* shard name contains cyrillic characters (`тест`)

```shell
$ ./rnode run -s --shard-name тест
12:20:21.341 [INFO ] [main                ] [coop.rchain.node.Main$       ] - RChain Node 0.13.0-alpha-474-g7320c21 (7320c21d64aedda43f0adc83d38cab84f395787f)
12:20:21.347 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Starting with profile default
12:20:21.348 [WARN ] [main                ] [coop.rchain.node.Main$       ] - No configuration file found, using defaults
12:20:21.348 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Running on network: testnet
12:20:21.348 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Running on shard name (id): тест
12:20:21.380 [ERROR] [main                ] [coop.rchain.node.Main$       ] - Shard name should contain only ASCII characters
12:20:21.443 [ERROR] [main                ] [coop.rchain.node.Main$       ] - Unhandled exception in thread main
java.lang.RuntimeException: Invalid shard name
        at coop.rchain.node.Main$.$anonfun$checkShardNameOnlyAscii$2(Main.scala:403)
```

* shard name contains ASCII characters (`test`)

```shell
./rnode run -s --shard-name test
12:20:43.861 [INFO ] [main                ] [coop.rchain.node.Main$       ] - RChain Node 0.13.0-alpha-474-g7320c21 (7320c21d64aedda43f0adc83d38cab84f395787f)
12:20:43.869 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Starting with profile default
12:20:43.870 [WARN ] [main                ] [coop.rchain.node.Main$       ] - No configuration file found, using defaults
12:20:43.870 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Running on network: testnet
12:20:43.870 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Running on shard name (id): test
12:20:44.212 [INFO ] [main                ] [c.r.node.NodeEnvironment$    ] - Using data dir: /home/<home_dir>/.rnode
12:20:44.220 [INFO ] [main                ] [t.GenerateCertificateIfAbsent] - No certificate found at path /home/<home_dir>/.rnode/node.certificate.pem
12:20:44.221 [INFO ] [main                ] [t.GenerateCertificateIfAbsent] - Generating a X.509 certificate for the node
12:20:44.224 [INFO ] [main                ] [t.GenerateCertificateIfAbsent] - Generating a PEM secret key for the node
```

* shard name contains mixed characters: ASCII + cyrillic (`teст`)

```shell
 ./rnode run -s --shard-name teст
12:32:07.337 [INFO ] [main                ] [coop.rchain.node.Main$       ] - RChain Node 0.13.0-alpha-474-g7320c21 (7320c21d64aedda43f0adc83d38cab84f395787f)
12:32:07.342 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Starting with profile default
12:32:07.342 [WARN ] [main                ] [coop.rchain.node.Main$       ] - No configuration file found, using defaults
12:32:07.342 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Running on network: testnet
12:32:07.343 [INFO ] [main                ] [coop.rchain.node.Main$       ] - Running on shard name (id): teст
12:32:07.360 [ERROR] [main                ] [coop.rchain.node.Main$       ] - Shard name should contain only ASCII characters
12:32:07.418 [ERROR] [main                ] [coop.rchain.node.Main$       ] - Unhandled exception in thread main
java.lang.RuntimeException: Invalid shard name
        at coop.rchain.node.Main$.$anonfun$checkShardNameOnlyAscii$2(Main.scala:403)
```

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
