### PR TITLE
Implement host check for peers to prevent loopback connections

### DIFF
--- a/comm/src/test/scala/coop/rchain/comm/rp/HandleProtocolHandshakeSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/HandleProtocolHandshakeSpec.scala
@@ -1,97 +1,140 @@
 package coop.rchain.comm.rp
 
+import cats.effect.Concurrent
 import cats.effect.concurrent.Ref
-import cats.{catsInstancesForId => _, _}
-import coop.rchain.catscontrib.effect.implicits._
-import coop.rchain.catscontrib.ski.kp
-import coop.rchain.comm.CommError._
+import cats.syntax.all._
 import coop.rchain.comm._
-import coop.rchain.comm.protocol.routing.Protocol
 import coop.rchain.comm.rp.Connect._
 import coop.rchain.metrics.Metrics
 import coop.rchain.p2p.EffectsTestInstances._
 import coop.rchain.shared._
 import coop.rchain.shared.scalatestcontrib.convertToAnyShouldWrapper
 import fs2.concurrent.Queue
+import monix.eval.Task
+import monix.execution.Scheduler.Implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class HandleProtocolHandshakeSpec extends AnyFlatSpec {
-  private val currentLocalPeer  = peerNode("src", "127.0.0.1", 40400)
-  private val currentInetPeer   = peerNode("src", "169.10.0.2", 40400)
-  private val incomingLocalPeer = peerNode("remote", "0.0.0.0")
-  private val incomingInetPeer  = peerNode("remote", "169.10.0.1")
+class HandleProtocolHandshakeSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
 
-  type Effect[A] = CommErrT[Id, A]
-  implicit private val transportLayerEff = new TransportLayerStub[Effect]
-  implicit private val logEffTest        = new Log.NOPLog[Effect]
-  implicit private val connectionsCellEff =
-    Ref.unsafe[Effect, Connections](Connect.Connections.empty)
-  implicit private val metricEffEff = new Metrics.MetricsNOP[Effect]
+  implicit private val logEffTest   = new Log.NOPLog[Task]
+  implicit private val metricEffEff = new Metrics.MetricsNOP[Task]
 
-  {
-    implicit val rpConfAskLocalEff = createRPConfAsk[Effect](currentLocalPeer)
-    "node with local address when connecting to other local node" should "accept connection" in {
-      for {
-        _           <- tryToHandshake(incomingLocalPeer)
-        connections <- connectionsCellEff.get
-        _           = connections.size shouldBe 1
-      } yield ()
-    }
-    "node with local address when connecting to Internet node" should "decline connection" in {
-      for {
-        _           <- tryToHandshake(incomingInetPeer)
-        connections <- connectionsCellEff.get
+  val validConnections = Table(
+    ("src", "remote"),
+    // Both local
+    // 0.0.0.0
+    ("0.0.0.0", "0.0.0.0"),
+    ("0.0.0.0", "127.114.61.218"),
+    ("0.0.0.0", "10.3.103.123"),
+    ("0.0.0.0", "172.30.209.12"),
+    ("0.0.0.0", "192.168.1.184"),
+    // 127.0.0.0/8
+    ("127.37.107.115", "0.0.0.0"),
+    ("127.37.107.115", "127.114.61.218"),
+    ("127.37.107.115", "10.3.103.123"),
+    ("127.37.107.115", "172.30.209.12"),
+    ("127.37.107.115", "192.168.1.184"),
+    // 10.0.0.0/8
+    ("10.84.153.6", "0.0.0.0"),
+    ("10.84.153.6", "127.114.61.218"),
+    ("10.84.153.6", "10.3.103.123"),
+    ("10.84.153.6", "172.30.209.12"),
+    ("10.84.153.6", "192.168.1.184"),
+    // 172.16.0.0/12
+    ("172.30.123.1", "0.0.0.0"),
+    ("172.30.123.1", "127.114.61.218"),
+    ("172.30.123.1", "10.3.103.123"),
+    ("172.30.123.1", "172.30.209.12"),
+    ("172.30.123.1", "192.168.1.184"),
+    // 192.168.0.0/16
+    ("192.168.1.121", "0.0.0.0"),
+    ("192.168.1.121", "127.114.61.218"),
+    ("192.168.1.121", "10.3.103.123"),
+    ("192.168.1.121", "172.30.209.12"),
+    ("192.168.1.121", "192.168.1.184"),
+    // Both public
+    ("205.115.163.25", "151.46.21.153"),
+    ("14.239.205.45", "166.116.242.146"),
+    ("35.169.51.192", "79.23.150.252"),
+    ("35.133.188.29", "241.184.72.49"),
+    ("120.124.224.240", "249.250.80.142")
+  )
 
-        _ = connections.size shouldBe 0
-      } yield ()
+  "peer connection" should "be accepted if in the same subnetwork" in {
+    forAll(validConnections) {
+      case (srcHost, remoteHost) =>
+        val src    = peerNode(srcHost)
+        val remote = peerNode(remoteHost)
+        val run = for {
+          conn <- tryToHandshake[Task](src, remote)
+
+          _ = conn.size shouldBe 1
+        } yield ()
+
+        run.runSyncUnsafe()
     }
   }
-  {
-    implicit val rpConfAskInetEff = createRPConfAsk[Effect](currentInetPeer)
-    "node with public Internet address when connecting to other Internet node" should "accept connection" in {
-      for {
-        _           <- tryToHandshake(incomingInetPeer)
-        connections <- connectionsCellEff.get
 
-        _ = connections.size shouldBe 1
-      } yield ()
-    }
+  val inValidConnections = Table(
+    ("src", "remote"),
+    // Node is on local network, remote peer on public
+    ("0.0.0.0", "151.46.21.153"),
+    ("127.114.61.218", "166.116.242.146"),
+    ("10.3.103.123", "79.23.150.252"),
+    ("172.30.209.12", "241.184.72.49"),
+    ("192.168.1.184", "249.250.80.142"),
+    // Node is on public network, remote peer on local
+    ("205.115.163.25", "0.0.0.0"),
+    ("14.239.205.45", "127.114.61.218"),
+    ("35.169.51.192", "10.3.103.123"),
+    ("35.133.188.29", "172.30.209.12"),
+    ("120.124.224.240", "192.168.1.184")
+  )
 
-    "node with public Internet address when connecting to local node" should "decline connection" in {
-      for {
-        _           <- tryToHandshake(incomingLocalPeer)
-        connections <- connectionsCellEff.get
+  it should "be rejected if not in the same subnetwork" in {
+    forAll(inValidConnections) {
+      case (srcHost, remoteHost) =>
+        val src    = peerNode(srcHost)
+        val remote = peerNode(remoteHost)
+        val run = for {
+          conn <- tryToHandshake[Task](src, remote)
 
-        _ = connections.size shouldBe 0
-      } yield ()
+          _ = conn.size shouldBe 0
+        } yield ()
+
+        run.runSyncUnsafe()
     }
   }
 
-  private def tryToHandshake(
-      peer: PeerNode
-  )(implicit rpConfAskEff: ConstApplicativeAsk[Effect, RPConf]) = {
-    transportLayerEff.reset()
-    Connect.resetConnections[Effect]
+  private def tryToHandshake[F[_]: Concurrent: Log: Metrics](
+      srcPeer: PeerNode,
+      remotePeer: PeerNode
+  ): F[Connections] = {
+    // Init local (src) node connection config
+    implicit val rpConfAsk = createRPConfAsk[F](srcPeer)
 
-    val networkId = "test-network-id"
-    val protocol  = ProtocolHelper.protocolHandshake(peer, networkId)
-    transportLayerEff.setResponses(kp(alwaysSuccess))
+    // Init transport layer (set response to succeed always)
+    implicit val transportLayerEff = new TransportLayerStub[F]
+    transportLayerEff.setResponses(_ => _ => ().asRight)
+
+    // Init connections Ref
+    implicit val connectionRef = Ref.unsafe(Connect.Connections.empty)
+
     for {
-      routingMessageQueue <- Queue.unbounded[Effect, RoutingMessage]
+      routingMessageQueue <- Queue.unbounded[F, RoutingMessage]
 
-      _ <- HandleMessages.handle[Effect](protocol, routingMessageQueue)
-    } yield ()
+      // Remote peer protocol handshake message
+      protocol = ProtocolHelper.protocolHandshake(remotePeer, networkId = "test-network")
+
+      // Handle remote message
+      _ <- HandleMessages.handle[F](protocol, routingMessageQueue)
+
+      // Remote peer is added to connections if from allowed host
+      connections <- connectionRef.get
+    } yield connections
   }
 
-  private def endpoint(host: String, tcpPort: Int, udpPort: Int): Endpoint =
-    Endpoint(host, tcpPort, udpPort)
-  private def peerNode(
-      name: String,
-      host: String,
-      tcpPort: Int = 40401,
-      udpPort: Int = 40402
-  ): PeerNode =
-    PeerNode(NodeIdentifier(name.getBytes), endpoint(host, tcpPort, udpPort))
-
-  private def alwaysSuccess: Protocol => CommErr[Unit] = kp(Right(()))
+  private def peerNode(host: String): PeerNode =
+    PeerNode(NodeIdentifier("node-name".getBytes), Endpoint(host, tcpPort = 0, udpPort = 0))
 }

--- a/comm/src/test/scala/coop/rchain/comm/rp/HandleProtocolHandshakeSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/rp/HandleProtocolHandshakeSpec.scala
@@ -1,0 +1,97 @@
+package coop.rchain.comm.rp
+
+import cats.effect.concurrent.Ref
+import cats.{catsInstancesForId => _, _}
+import coop.rchain.catscontrib.effect.implicits._
+import coop.rchain.catscontrib.ski.kp
+import coop.rchain.comm.CommError._
+import coop.rchain.comm._
+import coop.rchain.comm.protocol.routing.Protocol
+import coop.rchain.comm.rp.Connect._
+import coop.rchain.metrics.Metrics
+import coop.rchain.p2p.EffectsTestInstances._
+import coop.rchain.shared._
+import coop.rchain.shared.scalatestcontrib.convertToAnyShouldWrapper
+import fs2.concurrent.Queue
+import org.scalatest.flatspec.AnyFlatSpec
+
+class HandleProtocolHandshakeSpec extends AnyFlatSpec {
+  private val currentLocalPeer  = peerNode("src", "127.0.0.1", 40400)
+  private val currentInetPeer   = peerNode("src", "169.10.0.2", 40400)
+  private val incomingLocalPeer = peerNode("remote", "0.0.0.0")
+  private val incomingInetPeer  = peerNode("remote", "169.10.0.1")
+
+  type Effect[A] = CommErrT[Id, A]
+  implicit private val transportLayerEff = new TransportLayerStub[Effect]
+  implicit private val logEffTest        = new Log.NOPLog[Effect]
+  implicit private val connectionsCellEff =
+    Ref.unsafe[Effect, Connections](Connect.Connections.empty)
+  implicit private val metricEffEff = new Metrics.MetricsNOP[Effect]
+
+  {
+    implicit val rpConfAskLocalEff = createRPConfAsk[Effect](currentLocalPeer)
+    "node with local address when connecting to other local node" should "accept connection" in {
+      for {
+        _           <- tryToHandshake(incomingLocalPeer)
+        connections <- connectionsCellEff.get
+        _           = connections.size shouldBe 1
+      } yield ()
+    }
+    "node with local address when connecting to Internet node" should "decline connection" in {
+      for {
+        _           <- tryToHandshake(incomingInetPeer)
+        connections <- connectionsCellEff.get
+
+        _ = connections.size shouldBe 0
+      } yield ()
+    }
+  }
+  {
+    implicit val rpConfAskInetEff = createRPConfAsk[Effect](currentInetPeer)
+    "node with public Internet address when connecting to other Internet node" should "accept connection" in {
+      for {
+        _           <- tryToHandshake(incomingInetPeer)
+        connections <- connectionsCellEff.get
+
+        _ = connections.size shouldBe 1
+      } yield ()
+    }
+
+    "node with public Internet address when connecting to local node" should "decline connection" in {
+      for {
+        _           <- tryToHandshake(incomingLocalPeer)
+        connections <- connectionsCellEff.get
+
+        _ = connections.size shouldBe 0
+      } yield ()
+    }
+  }
+
+  private def tryToHandshake(
+      peer: PeerNode
+  )(implicit rpConfAskEff: ConstApplicativeAsk[Effect, RPConf]) = {
+    transportLayerEff.reset()
+    Connect.resetConnections[Effect]
+
+    val networkId = "test-network-id"
+    val protocol  = ProtocolHelper.protocolHandshake(peer, networkId)
+    transportLayerEff.setResponses(kp(alwaysSuccess))
+    for {
+      routingMessageQueue <- Queue.unbounded[Effect, RoutingMessage]
+
+      _ <- HandleMessages.handle[Effect](protocol, routingMessageQueue)
+    } yield ()
+  }
+
+  private def endpoint(host: String, tcpPort: Int, udpPort: Int): Endpoint =
+    Endpoint(host, tcpPort, udpPort)
+  private def peerNode(
+      name: String,
+      host: String,
+      tcpPort: Int = 40401,
+      udpPort: Int = 40402
+  ): PeerNode =
+    PeerNode(NodeIdentifier(name.getBytes), endpoint(host, tcpPort, udpPort))
+
+  private def alwaysSuccess: Protocol => CommErr[Unit] = kp(Right(()))
+}


### PR DESCRIPTION
## Overview
Second part of the issue #3707 


### Notes
1. Restored method isValidPublicInetAddress for checking incoming peer address
2. Added host check to method HandleMessages.handleProtocolHandshake
3. Added unit - tests that check addresses of incoming peers. Connection with other peer will be accepted if these both peers are local or public


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
