### PR TITLE
Add description for system-contract-pub-key configuration parameter

### DIFF
--- a/node/src/main/resources/defaults.conf
+++ b/node/src/main/resources/defaults.conf
@@ -278,6 +278,9 @@ casper {
     # This public key is used to make transfer from PoS vault defined in PoS contract
     pos-vault-pub-key = ""
 
+    # Public key to manage updates of system contracts.
+    # It should be set when network is started (genesis block is created).
+    # Not setting this key will disable possibility to update system contracts.
     system-contract-pub-key = ""
   }
 

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -455,7 +455,9 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
     )
 
     val systemContractPubKey = opt[String](
-      descr = "System contract public key"
+      descr = "Public key to manage updates of system contracts. " +
+        "It should be set when network is started (genesis block is created). " +
+        "Not setting this key will disable possibility to update system contracts."
     )
 
     val prometheus = opt[Flag](


### PR DESCRIPTION
## Overview
issue #3748 


### Notes
Added description for system-contract-pub-key configuration parameter

![Screenshot from 2022-07-02 18-25-35](https://user-images.githubusercontent.com/90717554/177006701-04478ec3-45c1-4190-ad18-87ef2ef4cf83.png)

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
