### PR TITLE
Make mergeable overflow rejections discard the whole dependency tree

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
@@ -152,7 +152,13 @@ object BlockIndex {
 
       index <- deployChains.toVector
                 .traverse(
-                  DeployChainIndex(blockHash, _, preStateHash, postStateHash, historyRepository)
+                  DeployChainIndex(
+                    blockHash.toBlake2b256Hash,
+                    _,
+                    preStateHash,
+                    postStateHash,
+                    historyRepository
+                  )
                 )
     } yield BlockIndex(blockHash, index)
   }

--- a/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
@@ -152,12 +152,7 @@ object BlockIndex {
 
       index <- deployChains.toVector
                 .traverse(
-                  DeployChainIndex(
-                    _,
-                    preStateHash,
-                    postStateHash,
-                    historyRepository
-                  )
+                  DeployChainIndex(blockHash, _, preStateHash, postStateHash, historyRepository)
                 )
     } yield BlockIndex(blockHash, index)
   }

--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
@@ -3,26 +3,18 @@ package coop.rchain.casper.merging
 import cats.effect.Concurrent
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.rholang.interpreter.RhoRuntime.RhoHistoryRepository
-import coop.rchain.rholang.interpreter.merging.RholangMergingLogic
-import coop.rchain.rspace.HotStoreTrieAction
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.history.HistoryRepository
-import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsDiff
 import coop.rchain.rspace.merger._
 import coop.rchain.rspace.syntax._
-import coop.rchain.models.syntax._
-import coop.rchain.shared.{Log, Stopwatch}
-import scodec.bits.ByteVector
 
 import java.util.Objects
-import scala.util.Random
 
 final case class DeployIdWithCost(id: ByteString, cost: Long)
 
 /** index of deploys depending on each other inside a single block (state transition) */
 final case class DeployChainIndex(
-    hostBlock: ByteString,
+    hostBlock: Blake2b256Hash,
     deploysWithCost: Set[DeployIdWithCost],
     preStateHash: Blake2b256Hash,
     postStateHash: Blake2b256Hash,
@@ -45,7 +37,7 @@ object DeployChainIndex {
   implicit val ord = Ordering.by((x: DeployChainIndex) => (x.hostBlock, x.postStateHash))
 
   def apply[F[_]: Concurrent, C, P, A, K](
-      hostBlock: ByteString,
+      hostBlock: Blake2b256Hash,
       deploys: Set[DeployIndex],
       preStateHash: Blake2b256Hash,
       postStateHash: Blake2b256Hash,
@@ -77,23 +69,6 @@ object DeployChainIndex {
       Objects.hash(deploysWithCost.map(_.id).toSeq: _*)
     )
   }
-
-  def random: Iterator[DeployChainIndex] =
-    Iterator.continually[Int](Random.nextInt(10) + 1).map { size =>
-      val deployIds = Range(0, size)
-        .map(
-          _ => ByteString.copyFrom(Array.fill(64)((scala.util.Random.nextInt(256) - 128).toByte))
-        )
-      DeployChainIndex(
-        ByteString.copyFrom(new Array[Byte](32)),
-        deployIds.map(id => DeployIdWithCost(id, 0)).toSet,
-        Blake2b256Hash.fromByteArray(new Array[Byte](32)),
-        Blake2b256Hash.fromByteArray(new Array[Byte](32)),
-        EventLogIndex.empty,
-        StateChange.empty,
-        Objects.hash(deployIds.map(id => DeployIdWithCost(id, 0)).map(_.id): _*)
-      )
-    }
 
   def deployChainCost(r: DeployChainIndex) = r.deploysWithCost.map(_.cost).sum
   def isDependency(a: DeployChainIndex, dependencyFor: DeployChainIndex) =

--- a/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/DeployChainIndex.scala
@@ -11,6 +11,7 @@ import coop.rchain.rspace.history.HistoryRepository
 import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsDiff
 import coop.rchain.rspace.merger._
 import coop.rchain.rspace.syntax._
+import coop.rchain.models.syntax._
 import coop.rchain.shared.{Log, Stopwatch}
 import scodec.bits.ByteVector
 
@@ -21,6 +22,7 @@ final case class DeployIdWithCost(id: ByteString, cost: Long)
 
 /** index of deploys depending on each other inside a single block (state transition) */
 final case class DeployChainIndex(
+    hostBlock: ByteString,
     deploysWithCost: Set[DeployIdWithCost],
     preStateHash: Blake2b256Hash,
     postStateHash: Blake2b256Hash,
@@ -40,9 +42,10 @@ final case class DeployChainIndex(
 
 object DeployChainIndex {
 
-  implicit val ord = Ordering.by((_: DeployChainIndex).postStateHash)
+  implicit val ord = Ordering.by((x: DeployChainIndex) => (x.hostBlock, x.postStateHash))
 
   def apply[F[_]: Concurrent, C, P, A, K](
+      hostBlock: ByteString,
       deploys: Set[DeployIndex],
       preStateHash: Blake2b256Hash,
       postStateHash: Blake2b256Hash,
@@ -65,6 +68,7 @@ object DeployChainIndex {
                        historyRepository.getSerializeC
                      )
     } yield DeployChainIndex(
+      hostBlock,
       deploysWithCost,
       preStateHash,
       postStateHash,
@@ -81,6 +85,7 @@ object DeployChainIndex {
           _ => ByteString.copyFrom(Array.fill(64)((scala.util.Random.nextInt(256) - 128).toByte))
         )
       DeployChainIndex(
+        ByteString.copyFrom(new Array[Byte](32)),
         deployIds.map(id => DeployIdWithCost(id, 0)).toSet,
         Blake2b256Hash.fromByteArray(new Array[Byte](32)),
         Blake2b256Hash.fromByteArray(new Array[Byte](32)),

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -199,7 +199,7 @@ class MergeNumberChannelSpec extends AnyFlatSpec {
 
         leftDeployChains <- leftDeployIndices.toList.traverse(
                              DeployChainIndex(
-                               ByteString.copyFromUtf8("a"),
+                               Blake2b256Hash.fromHex("a".padTo(64, '0')),
                                _,
                                baseCp.root,
                                leftPostState,
@@ -208,7 +208,7 @@ class MergeNumberChannelSpec extends AnyFlatSpec {
                            )
         rightDeployChains <- rightDeployIndices.toList.traverse(
                               DeployChainIndex(
-                                ByteString.copyFromUtf8("b"),
+                                Blake2b256Hash.fromHex("b".padTo(64, '0')),
                                 _,
                                 baseCp.root,
                                 rightPostState,

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -198,10 +198,22 @@ class MergeNumberChannelSpec extends AnyFlatSpec {
         // Calculate deploy chains / deploy dependency
 
         leftDeployChains <- leftDeployIndices.toList.traverse(
-                             DeployChainIndex(_, baseCp.root, leftPostState, historyRepo)
+                             DeployChainIndex(
+                               ByteString.copyFromUtf8("a"),
+                               _,
+                               baseCp.root,
+                               leftPostState,
+                               historyRepo
+                             )
                            )
         rightDeployChains <- rightDeployIndices.toList.traverse(
-                              DeployChainIndex(_, baseCp.root, rightPostState, historyRepo)
+                              DeployChainIndex(
+                                ByteString.copyFromUtf8("b"),
+                                _,
+                                baseCp.root,
+                                rightPostState,
+                                historyRepo
+                              )
                             )
 
         _ = println(s"DEPLOY_CHAINS LEFT : ${leftDeployChains.size}")
@@ -337,8 +349,8 @@ class MergeNumberChannelSpec extends AnyFlatSpec {
         DeployTestInfo(rhoChange(-60), 10L, "0x22"),
         DeployTestInfo(parRho(rhoChange(-20), "for(_ <- @\"X\") {Nil}"), 11L, "0x21")
       ),
-      expectedRejected = Set(makeSig("0x11")),
-      expectedFinalResult = 10
+      expectedRejected = Set(makeSig("0x11"), makeSig("0x12")),
+      expectedFinalResult = 20
     )
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
@@ -93,9 +93,15 @@ class MergingCases extends AnyFlatSpec with Matchers {
                   y: EventLogIndex
               ): Int = 1
             }
+            val dependencyMap =
+              DagMergingLogic.computeDependencyMap(
+                idxs.toSet,
+                idxs.toSet,
+                EventLogMergingLogic.depends
+              )
             DagMergingLogic.computeGreedyNonIntersectingBranches[EventLogIndex](
               idxs.toSet,
-              EventLogMergingLogic.depends
+              dependencyMap
             )
           }
           // deploys inside one state transition never conflict, as executed in a sequence (for now)


### PR DESCRIPTION
## Overview
This PR is a fix for leftover from https://github.com/rchain/rchain/pull/3742. Since mentioned PR disables pre computation of branches to do conflict resolution, folding of mergeable values seeking for overflow have to be adjusted to account for dependencies. Once deploys is rejected because it leads to overflow, the whole dependency tree should be rejected.
This PR is the implementation of this logic.
### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
