### PR TITLE
Add release/** pattern to trigger CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,6 +15,7 @@ on:
     branches:
       - dev
       - 'feature/**'
+      - 'release/**'
 
 env:
   # This is read by every new JVM. Every JVM thinks it can use up to 80% of


### PR DESCRIPTION
## Overview

With CI trigger for `feature/**` branches we have ability to work on features and merged them without bors in case some tests are temporarily failing.

Currently we are also using _feature_ branched to publish multiple releases besides the main version like RPC releases [v0.12.5+rpc](https://github.com/rchain/rchain/releases/tag/v0.12.5%2Brpc) or patches [v0.12.4+rholang-1.1-rc1](https://github.com/rchain/rchain/releases/tag/v0.12.4%2Brholang-1.1-rc1).
For the purpose of _release_ branches this may not be ideal because we want to have the same protection as on the main branch (dev).
This PR adds  `release/**` pattern to CI trigger so that we can use _release_ prefix to branches which has purpose to hold special release versions of RNode. Together with this change _release_ pattern will be added to protected branches in GitHub repository settings so that behavior will be the same as on _dev_ branch.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
