### PR TITLE
Add CLI options for POS multi-sig wallet

### DIFF
--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -1,5 +1,7 @@
 package coop.rchain.node.configuration
 
+import cats.syntax.all._
+
 import java.io.File
 import java.nio.file.{Path, Paths}
 
@@ -79,7 +81,14 @@ object Configuration {
     val mergedConf = optionsConfig
       .withFallback(fileConfig)
       .withFallback(defaultConfig)
-    val nodeConfE = mergedConf.load[NodeConf]
+
+    val nodeConfE = if (options.run.posMultiSigPublicKeys.isSupplied) {
+      implicit val listOfStringsReader =
+        ConfigReader.fromString[List[String]](_.split(" ").toList.asRight)
+      mergedConf.load[NodeConf]
+    } else {
+      mergedConf.load[NodeConf]
+    }
 
     nodeConfE match {
       case Left(t) =>

--- a/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/Configuration.scala
@@ -93,7 +93,7 @@ object Configuration {
     }
     val nodeConf = nodeConfE.right.get
 
-    // Throw an error if pos-multi-sig-quorum greater then pos-multi-sig-public-keys length
+    // Throw an error if pos-multi-sig-quorum greater than pos-multi-sig-public-keys length
     val posMultiSigQuorum           = nodeConf.casper.genesisBlockData.posMultiSigQuorum
     val posMultiSigPublicKeysLength = nodeConf.casper.genesisBlockData.posMultiSigPublicKeys.length
     if (posMultiSigQuorum > posMultiSigPublicKeysLength) {

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/ConfigMapper.scala
@@ -80,6 +80,8 @@ object ConfigMapper {
       add("casper.genesis-block-data.pos-vault-pub-key", run.posVaultPubKey)
       add("casper.genesis-block-data.system-contract-pub-key", run.systemContractPubKey)
       add("casper.genesis-block-data.genesis-block-number", run.genesisBlockNumber)
+      add("casper.genesis-block-data.pos-multi-sig-public-keys", run.posMultiSigPublicKeys)
+      add("casper.genesis-block-data.pos-multi-sig-quorum", run.posMultiSigQuorum)
 
       add("casper.autogen-shard-size", run.autogenShardSize)
 
@@ -133,6 +135,8 @@ object ConfigMapper {
     implicit val peerNodeConverter: OptionConverter[PeerNode] = (p: PeerNode) => p.toAddress
     implicit val durationConverter: OptionConverter[FiniteDuration] =
       (d: FiniteDuration) => java.time.Duration.ofNanos(d.toNanos)
+    implicit val listOfStringConverter: OptionConverter[List[String]] = (l: List[String]) =>
+      l.mkString(" ")
   }
 
   private object AddScallopOptionToMap {

--- a/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
+++ b/node/src/main/scala/coop/rchain/node/configuration/commandline/Options.scala
@@ -495,6 +495,16 @@ final case class Options(arguments: Seq[String]) extends ScallopConf(arguments) 
       validate = _ >= 0
     )
 
+    val posMultiSigPublicKeys = opt[List[String]](
+      descr = "Space-separated list of public keys",
+      required = false
+    )(stringListConverter)
+
+    val posMultiSigQuorum = opt[Int](
+      descr = "How many confirmations are necessary to use multi-sig vault",
+      required = false
+    )
+
   }
   addSubcommand(run)
 


### PR DESCRIPTION
## Overview

Added two CLI options for POS multi-sig wallet. This PR is an additional [PR](https://github.com/rchain/rchain/pull/3638). Now parameters can be set not only in the configuration file, but also in command line parameters.

Example of usage:

```
./rnode run -s --pos-multi-sig-public-keys a b c --pos-multi-sig-quorum 2
```

### --pos-multi-sig-public-keys

List of public keys (as strings) separated by space. If parameter is not provided default list from [defaults.conf](https://github.com/rchain/rchain/blob/f6eb77a222b7742e6f218f1b9f99a1a6e3285452/node/src/main/resources/defaults.conf#L267-L271) will be used.

### --pos-multi-sig-quorum

Number of confirmations (as integer value) are necessary to use multi-sig vault. If parameter is not provided default value from [defaults.conf](https://github.com/rchain/rchain/blob/f6eb77a222b7742e6f218f1b9f99a1a6e3285452/node/src/main/resources/defaults.conf#L275) will be used.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
