### PR TITLE
Move BlockRetriever to blocks folder

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/BlockStore.scala
@@ -15,9 +15,7 @@ object BlockStore {
 
   def apply[F[_]](implicit instance: BlockStore[F]): instance.type = instance
 
-  def apply[F[_]: Sync](
-      kvm: KeyValueStoreManager[F]
-  ): F[KeyValueTypedStore[F, BlockHash, BlockMessage]] =
+  def apply[F[_]: Sync](kvm: KeyValueStoreManager[F]): F[BlockStore[F]] =
     kvm
       .store("blocks")
       .map(_.toTypedStore[BlockHash, BlockMessage](codecBlockHash, codecBlockMessage))

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
@@ -7,7 +7,6 @@ import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
-import coop.rchain.casper.engine.BlockRetriever
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.syntax._
 import coop.rchain.casper.{PrettyPrinter, Validate}

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockRetriever.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockRetriever.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper.engine
+package coop.rchain.casper.blocks
 
 import cats.Monad
 import cats.effect.Timer

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -10,15 +10,9 @@ import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.rholang.sysdeploys.{CloseBlockDeploy, SlashDeploy}
-import coop.rchain.casper.rholang.{InterpreterUtil, RuntimeManager}
+import coop.rchain.casper.rholang.{BlockRandomSeed, InterpreterUtil, RuntimeManager}
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
-import coop.rchain.casper.{
-  BlockRandomSeed,
-  MultiParentCasper,
-  ParentsMergedState,
-  PrettyPrinter,
-  ValidatorIdentity
-}
+import coop.rchain.casper.{MultiParentCasper, ParentsMergedState, PrettyPrinter, ValidatorIdentity}
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.crypto.signatures.Signed

--- a/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
+++ b/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
@@ -36,7 +36,6 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
     deployIndex: KeyValueTypedStore[F, DeployId, BlockHash],
     deployStore: KeyValueTypedStore[F, DeployId, Signed[DeployData]]
 ) extends BlockDagStorage[F] {
-  implicit private val logSource: LogSource = LogSource(BlockDagKeyValueStorage.getClass)
 
   def getRepresentation: F[DagRepresentation] = representationState.get
 

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeLaunch.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeLaunch.scala
@@ -9,6 +9,7 @@ import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.approvedStore.ApprovedStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
+import coop.rchain.casper.blocks.BlockRetriever
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts.{ProofOfStake, Registry, Validator}
 import coop.rchain.casper.protocol._

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
@@ -8,6 +8,7 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
+import coop.rchain.casper.blocks.BlockRetriever
 import coop.rchain.casper.protocol.{CommUtil, _}
 import coop.rchain.casper.syntax._
 import coop.rchain.comm.PeerNode

--- a/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
+++ b/casper/src/main/scala/coop/rchain/casper/genesis/Genesis.scala
@@ -5,10 +5,10 @@ import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.casper.genesis.contracts._
 import coop.rchain.casper.protocol._
-import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
 import coop.rchain.casper.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.util.ProtoUtil.unsignedBlockProto
-import coop.rchain.casper.{BlockRandomSeed, PrettyPrinter, ValidatorIdentity}
+import coop.rchain.casper.{PrettyPrinter, ValidatorIdentity}
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.signatures.Signed
 import coop.rchain.models.BlockVersion

--- a/casper/src/main/scala/coop/rchain/casper/merging/BlockHashDagMerger.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/BlockHashDagMerger.scala
@@ -113,7 +113,7 @@ object BlockHashDagMerger {
       (newState, applyActionsTime)      = r
       overallChanges                    = s"${allChanges.datumsChanges.size} D, ${allChanges.kontChanges.size} K, ${allChanges.consumeChannelsToJoinSerializedMap.size} J"
       logStr = s"Merging done. Changes: $overallChanges; " +
-        s"trie actions (${trieActions.size}) compited in ${computeActionsTime}; " +
+        s"trie actions (${trieActions.size}) computed in ${computeActionsTime}; " +
         s"actions applied in ${applyActionsTime}"
       _ <- Log[F].debug(logStr)
     } yield newState

--- a/casper/src/main/scala/coop/rchain/casper/reporting/ReportingCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/reporting/ReportingCasper.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.models.syntax._
 import coop.rchain.blockstorage.dag.BlockDagStorage
-import coop.rchain.casper.{BlockRandomSeed, PrettyPrinter}
+import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.{
   BlockMessage,
@@ -16,6 +16,7 @@ import coop.rchain.casper.protocol.{
   SystemDeployData
 }
 import coop.rchain.casper.reporting.ReportingCasper.RhoReportingRspace
+import coop.rchain.casper.rholang.BlockRandomSeed
 import coop.rchain.casper.syntax._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Metrics.Source

--- a/casper/src/main/scala/coop/rchain/casper/rholang/BlockRandomSeed.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/BlockRandomSeed.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper
+package coop.rchain.casper.rholang
 
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.PublicKey

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeReplaySyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeReplaySyntax.scala
@@ -4,7 +4,7 @@ import cats.data.EitherT
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
-import coop.rchain.casper.{BlockRandomSeed, CasperMetricsSource}
+import coop.rchain.casper.CasperMetricsSource
 import coop.rchain.casper.protocol.{
   CloseBlockSystemDeployData,
   Empty,
@@ -40,6 +40,7 @@ import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsEndVal
 import coop.rchain.rspace.util.ReplayException
 import coop.rchain.shared.Log
 import RuntimeReplaySyntax._
+import coop.rchain.casper.rholang.BlockRandomSeed
 import coop.rchain.casper.syntax._
 import coop.rchain.crypto.hash.Blake2b512Random
 

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
@@ -8,6 +8,7 @@ import cats.{Functor, Monad}
 import com.google.protobuf.ByteString
 import coop.rchain.casper.protocol.ProcessedSystemDeploy.Failed
 import coop.rchain.casper.protocol.{DeployData, Event, ProcessedDeploy, SystemDeployData}
+import coop.rchain.casper.rholang.BlockRandomSeed
 import coop.rchain.casper.rholang.InterpreterUtil.printDeployErrors
 import coop.rchain.casper.rholang.RuntimeDeployResult._
 import coop.rchain.casper.rholang.syntax.RuntimeSyntax._
@@ -25,7 +26,7 @@ import coop.rchain.casper.rholang.types.SystemDeployPlatformFailure.{
 }
 import coop.rchain.casper.rholang.types._
 import coop.rchain.casper.util.{ConstructDeploy, EventConverter}
-import coop.rchain.casper.{BlockRandomSeed, CasperMetricsSource, PrettyPrinter}
+import coop.rchain.casper.{CasperMetricsSource, PrettyPrinter}
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
 import coop.rchain.metrics.implicits._

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -8,6 +8,7 @@ import coop.rchain.casper.blocks.proposer.NoNewDeploys
 import coop.rchain.casper.helper.TestNode._
 import coop.rchain.casper.helper.{BlockUtil, TestNode}
 import coop.rchain.casper.protocol._
+import coop.rchain.casper.rholang.BlockRandomSeed
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil, RSpaceUtil}
 import coop.rchain.comm.rp.ProtocolHelper.packet
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
@@ -15,7 +16,6 @@ import coop.rchain.models.PCost
 import coop.rchain.models.syntax._
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
-import coop.rchain.models.syntax._
 import coop.rchain.shared.scalatestcontrib._
 import coop.rchain.shared.syntax._
 import monix.eval.Task

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -10,7 +10,7 @@ import coop.rchain.casper._
 import coop.rchain.casper.helper.{BlockApiFixture, BlockDagStorageFixture}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkRuntimeManager
-import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.blockImplicits.getRandomBlock

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -7,13 +7,11 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
-import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.helper.{BlockApiFixture, BlockDagStorageFixture}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkRuntimeManager
 import coop.rchain.casper.rholang.RuntimeManager
-import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
-import coop.rchain.catscontrib.TaskContrib._
+import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.blockImplicits.getRandomBlock
 import coop.rchain.models.syntax._
@@ -52,7 +50,7 @@ class BlockQueryResponseAPITest
   val randomDeploys =
     (0 until deployCount).toList
       .traverse(i => ConstructDeploy.basicProcessedDeploy[Task](i))
-      .unsafeRunSync(scheduler)
+      .runSyncUnsafe()
 
   val senderString: String =
     "3456789101112131415161718192345678910111213141516171819261718192113456789101112131415161718192345678910111213141516171819261718192"

--- a/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlocksResponseAPITest.scala
@@ -3,11 +3,10 @@ package coop.rchain.casper.api
 import cats.effect.Resource
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper._
 import coop.rchain.casper.rholang.Resources.mkRuntimeManager
-import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
 import coop.rchain.metrics.{NoopSpan, Span}
 import coop.rchain.shared.Log
 import monix.eval.Task

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperRholangSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperRholangSpec.scala
@@ -1,10 +1,9 @@
 package coop.rchain.casper.batch1
 
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode.Effect
 import coop.rchain.casper.protocol.BlockMessage
-import coop.rchain.casper.rholang.{RuntimeManager, Tools}
+import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager, Tools}
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil, RSpaceUtil}
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -7,9 +7,8 @@ import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.{BlockDagStorage, DagMessageState, DagRepresentation}
 import coop.rchain.casper.ValidatorIdentity
-import coop.rchain.casper.blocks.{BlockReceiver, BlockReceiverState}
-import coop.rchain.casper.engine.BlockRetriever
-import coop.rchain.casper.engine.BlockRetriever.{AdmitHashResult, Ignore}
+import coop.rchain.casper.blocks.BlockRetriever.{AdmitHashResult, Ignore}
+import coop.rchain.casper.blocks.{BlockReceiver, BlockReceiverState, BlockRetriever}
 import coop.rchain.casper.protocol.{BlockMessage, BlockMessageProto}
 import coop.rchain.casper.util.scalatest.Fs2StreamMatchers
 import coop.rchain.crypto.signatures.Secp256k1

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -6,16 +6,15 @@ import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper._
-import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.helper.BlockGenerator._
 import coop.rchain.casper.helper.BlockUtil.generateValidator
 import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkTestRNodeStoreManager
-import coop.rchain.casper.rholang.{InterpreterUtil, RuntimeManager}
+import coop.rchain.casper.rholang.{BlockRandomSeed, InterpreterUtil, RuntimeManager}
 import coop.rchain.casper.util.GenesisBuilder.buildGenesis
 import coop.rchain.casper.util._
-import coop.rchain.crypto.{PrivateKey, PublicKey}
+import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.BlockHash.BlockHash

--- a/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/engine/RunningHandleHasBlockSpec.scala
@@ -3,16 +3,16 @@ package coop.rchain.casper.engine
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.engine
-import coop.rchain.casper.engine.BlockRetriever.RequestState
+import coop.rchain.casper.blocks.BlockRetriever
+import coop.rchain.casper.blocks.BlockRetriever.{RequestState, RequestedBlocks}
 import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm.CommError._
 import coop.rchain.comm.protocol.routing.Protocol
 import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
 import coop.rchain.comm.rp.ProtocolHelper.toPacket
-import coop.rchain.comm.rp.{ProtocolHelper, RPConf}
-import coop.rchain.comm.{CommError, Endpoint, NodeIdentifier, PeerNode}
+import coop.rchain.comm.rp.RPConf
+import coop.rchain.comm.{Endpoint, NodeIdentifier, PeerNode}
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances.{
@@ -22,10 +22,10 @@ import coop.rchain.p2p.EffectsTestInstances.{
   TransportLayerStub
 }
 import monix.eval.Task
-import org.scalatest.funspec.AnyFunSpec
-import org.scalatest.matchers.should.Matchers
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 class RunningHandleHasBlockSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
 
@@ -33,7 +33,7 @@ class RunningHandleHasBlockSpec extends AnyFunSpec with BeforeAndAfterEach with 
 
   implicit val log     = new LogStub[Task]
   implicit val metrics = new Metrics.MetricsNOP[Task]
-  implicit val currentRequests: engine.BlockRetriever.RequestedBlocks[Task] =
+  implicit val currentRequests: RequestedBlocks[Task] =
     Ref.unsafe[Task, Map[BlockHash, RequestState]](Map.empty[BlockHash, RequestState])
   implicit val connectionsCell: ConnectionsCell[Task] =
     Ref.unsafe[Task, Connections](List(local))

--- a/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/GenesisTest.scala
@@ -4,12 +4,12 @@ import cats.Parallel
 import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.casper.{BlockRandomSeed, ValidatorIdentity}
+import coop.rchain.casper.ValidatorIdentity
 import coop.rchain.casper.genesis.Genesis.createGenesisBlock
 import coop.rchain.casper.genesis.contracts.{ProofOfStake, Registry, Validator}
 import coop.rchain.casper.helper.BlockDagStorageFixture
 import coop.rchain.casper.protocol.BlockMessage
-import coop.rchain.casper.rholang.{InterpreterUtil, Resources, RuntimeManager}
+import coop.rchain.casper.rholang.{BlockRandomSeed, InterpreterUtil, Resources, RuntimeManager}
 import coop.rchain.casper.util.{BondsParser, GenesisBuilder, VaultParser}
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.metrics

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -1,36 +1,30 @@
 package coop.rchain.casper.helper
 
-import cats.effect.Concurrent
+import cats.effect.{Concurrent, Resource}
 import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
-import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.rholang.{Resources, RuntimeManager}
-import coop.rchain.casper.storage.RNodeKeyValueStoreManager
 import coop.rchain.casper.util.GenesisBuilder.GenesisContext
-import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP
 import coop.rchain.rholang
 import coop.rchain.shared.Log
 import monix.eval.Task
-import monix.execution.Scheduler
+import monix.execution.Scheduler.Implicits.global
 import org.scalatest.{BeforeAndAfter, Suite}
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Path
 
 trait BlockDagStorageFixture extends BeforeAndAfter { self: Suite =>
-  val scheduler = Scheduler.fixedPool("block-dag-storage-fixture-scheduler", 4)
-
   val dummyParentsPreState = BlockGenerator.dummyParentsPreState
 
   def withGenesis[R](
       context: GenesisContext
   )(f: BlockStore[Task] => BlockDagStorage[Task] => RuntimeManager[Task] => Task[R]): R = {
-    implicit val s       = scheduler
     implicit val metrics = new MetricsNOP[Task]()
     implicit val log     = Log.log[Task]
 
@@ -50,43 +44,21 @@ trait BlockDagStorageFixture extends BeforeAndAfter { self: Suite =>
       .copyStorage[Task](context.storageDirectory)
       .evalMap(create)
       .use(Function.uncurried(f).tupled)
-      .unsafeRunSync
+      .runSyncUnsafe()
   }
 
   def withStorage[R](f: BlockStore[Task] => BlockDagStorage[Task] => Task[R]): R = {
-    implicit val s       = scheduler
     implicit val metrics = new MetricsNOP[Task]()
     implicit val log     = Log.log[Task]
 
-    BlockDagStorageTestFixture.withStorageF[Task, R](f).unsafeRunSync
+    BlockDagStorageTestFixture.withStorageF[Task].use(Function.uncurried(f).tupled).runSyncUnsafe()
   }
 }
 
 object BlockDagStorageTestFixture {
-  def blockDagStorageDir: Path = Files.createTempDirectory("casper-block-dag-storage-test-")
-  def blockStorageDir: Path    = Files.createTempDirectory("casper-block-storage-test-")
 
-  val mapSize: Long = 1024L * 1024L * 1024L
-  def createBlockStorage[F[_]: Concurrent: Log](
-      blockStorageDir: Path
-  ): F[BlockStore[F]] =
-    for {
-      storeManager <- RNodeKeyValueStoreManager[F](blockStorageDir)
-      blockStore   <- BlockStore[F](storeManager)
-    } yield blockStore
-
-  def createBlockDagStorage[F[_]: Concurrent](blockDagStorageDir: Path)(
-      implicit log: Log[F],
-      metrics: Metrics[F]
-  ): F[BlockDagStorage[F]] =
-    for {
-      storeManager    <- RNodeKeyValueStoreManager[F](blockDagStorageDir)
-      blockDagStorage <- BlockDagKeyValueStorage.create[F](storeManager)
-    } yield blockDagStorage
-
-  def withStorageF[F[_]: Concurrent: Metrics: Log, R](
-      f: BlockStore[F] => BlockDagStorage[F] => F[R]
-  ): F[R] = {
+  def withStorageF[F[_]: Concurrent: Metrics: Log]
+      : Resource[F, (BlockStore[F], BlockDagStorage[F])] = {
     def create(dir: Path) =
       for {
         kvm        <- Resources.mkTestRNodeStoreManager[F](dir)
@@ -98,6 +70,5 @@ object BlockDagStorageTestFixture {
     rholang.Resources
       .mkTempDir[F]("casper-block-dag-storage-test-")
       .evalMap(create)
-      .use(Function.uncurried(f).tupled)
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -5,9 +5,8 @@ import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
-import coop.rchain.casper.rholang.{Resources, RuntimeManager}
+import coop.rchain.casper.rholang.{BlockRandomSeed, Resources, RuntimeManager}
 import coop.rchain.casper.util.GenesisBuilder.GenesisContext
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockGenerator.scala
@@ -13,12 +13,12 @@ import coop.rchain.casper.rholang.InterpreterUtil.{
   computeDeploysCheckpoint,
   computeParentsPostState
 }
-import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
 import coop.rchain.casper.rholang.types.SystemDeploy
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.{CasperMetricsSource, ParentsMergedState}
 import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
-import coop.rchain.casper.{BlockRandomSeed, CasperMetricsSource}
+import coop.rchain.casper.CasperMetricsSource
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.Validator.Validator

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoSpec.scala
@@ -2,13 +2,12 @@ package coop.rchain.casper.helper
 
 import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts.TestUtil
 import coop.rchain.casper.genesis.contracts.TestUtil.eval
 import coop.rchain.casper.protocol.DeployData
 import coop.rchain.casper.rholang.Resources.{copyStorage, mkTestRNodeStoreManager}
-import coop.rchain.casper.rholang.{Resources, Tools}
+import coop.rchain.casper.rholang.{BlockRandomSeed, Resources, Tools}
 import coop.rchain.casper.util.GenesisBuilder
 import coop.rchain.casper.util.GenesisBuilder.GenesisParameters
 import coop.rchain.crypto.PrivateKey

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -38,7 +38,6 @@ import coop.rchain.shared._
 import fs2.concurrent.Queue
 import monix.eval.Task
 import monix.execution.Scheduler
-import org.scalatest.Assertions
 
 import java.nio.file.Path
 import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
@@ -76,10 +75,8 @@ case class TestNode[F[_]: Concurrent: Timer](
     shardName: String,
     minPhloPrice: Long
 ) {
-  // Scalatest `assert` macro needs some member of the Assertions trait.
-  // An (inferior) alternative would be to inherit the trait...
-  private val scalatestAssertions = new Assertions {}
-  import scalatestAssertions._
+  // Use ScalaTest asserts (overrides Scala Predef asserts)
+  import org.scalatest.Assertions._
 
   val defaultTimeout: FiniteDuration = FiniteDuration(1000, MILLISECONDS)
   val apiMaxBlocksLimit              = 50

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -9,14 +9,13 @@ import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage._
 import coop.rchain.blockstorage.approvedStore.ApprovedStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
-import coop.rchain.casper
 import coop.rchain.casper._
 import coop.rchain.casper.blocks.BlockProcessor
 import coop.rchain.casper.blocks.BlockRetriever.{RequestState, RequestedBlocks}
 import coop.rchain.casper.blocks.proposer._
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
 import coop.rchain.casper.protocol._
-import coop.rchain.casper.rholang.{Resources, RuntimeManager}
+import coop.rchain.casper.rholang.{BlockRandomSeed, Resources, RuntimeManager}
 import coop.rchain.casper.util.GenesisBuilder.GenesisContext
 import coop.rchain.casper.util.comm.TestNetwork.TestNetwork
 import coop.rchain.casper.util.comm._

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -12,9 +12,9 @@ import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper
 import coop.rchain.casper._
 import coop.rchain.casper.blocks.BlockProcessor
+import coop.rchain.casper.blocks.BlockRetriever.{RequestState, RequestedBlocks}
 import coop.rchain.casper.blocks.proposer._
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
-import coop.rchain.casper.engine.BlockRetriever._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.{Resources, RuntimeManager}
 import coop.rchain.casper.util.GenesisBuilder.GenesisContext
@@ -223,9 +223,7 @@ case class TestNode[F[_]: Concurrent: Timer](
   val maxSyncAttempts = 10
   def syncWith(nodes: Seq[TestNode[F]]): F[Unit] = {
     val networkMap = nodes.filterNot(_.local == local).map(node => node.local -> node).toMap
-    val asked = casper.engine.BlockRetriever
-      .RequestedBlocks[F]
-      .get
+    val asked = RequestedBlocks[F].get
       .map(
         _.values
           .flatMap(

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -370,21 +370,4 @@ class MergeNumberChannelSpec extends AnyFlatSpec {
       expectedFinalResult = 10
     )
   }
-
-  "TEMP encode multiple values" should "show stored binary size" in {
-    val rnd = Blake2b512Random.defaultRandom
-
-    val (res, _) = (1L to 10L).foldLeft((Vector[ByteVector](), rnd)) {
-      case ((acc, r), n) =>
-        val ch      = Blake2b256Hash.create(Array[Byte](n.toByte))
-        val encoded = RholangMergingLogic.createDatumEncoded(ch, n, r)
-        val newAcc  = acc :+ encoded
-
-        newAcc -> r.splitByte(n.toByte)
-    }
-
-    val total = ScodecSerialize.encodeDatumsBinary(res)
-
-    println(s"Values ${res.size}, encoded bytes: ${total.size}")
-  }
 }

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergingCases.scala
@@ -2,10 +2,9 @@ package coop.rchain.casper.merging
 
 import cats.effect.Resource
 import cats.syntax.all._
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.rholang.sysdeploys.CloseBlockDeploy
-import coop.rchain.casper.rholang.{Resources, RuntimeManager}
+import coop.rchain.casper.rholang.{BlockRandomSeed, Resources, RuntimeManager}
 import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
 import coop.rchain.models.syntax.modelsSyntaxByteString

--- a/casper/src/test/scala/coop/rchain/casper/rholang/BlockRandomSeedSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/BlockRandomSeedSpec.scala
@@ -1,4 +1,4 @@
-package coop.rchain.casper
+package coop.rchain.casper.rholang
 
 import coop.rchain.crypto.PublicKey
 import coop.rchain.rspace.hashing.Blake2b256Hash

--- a/casper/src/test/scala/coop/rchain/casper/rholang/BlockRandomSeedSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/BlockRandomSeedSpec.scala
@@ -49,7 +49,8 @@ class BlockRandomSeedSpec extends AnyFlatSpec with Checkers {
     }
   }
 
-  "generate random seed from constant BlockRandomSeed object" should "give expected value" in {
+  // If random generator seed logic changes, node will not able to replay previous blocks
+  "BlockRandomSeed serializer and random generator" should "not change without hard-fork" in {
     val pubKeyStr =
       "0406A102343B05BDF86DF2552C125430CC319323792507328DCC9456713E1E7A24E715171E43ACA3288E41DD346E840901A5D1588C2170AD1D55C0885A3230343A"
     val preStateStr = "AD1356323FFEBE9083687265928AD3CAD1356323FDEBE9083687265928AD3918"
@@ -76,14 +77,16 @@ class BlockRandomSeedSpec extends AnyFlatSpec with Checkers {
     }
 
     // Reference values as hex strings
-    val seedHexRef =
-      "06414434353136000000000000000282080d420468760b7bf0dbe4aa5824a86198632646f24a0e651b9928ace27c3cf449ce2a2e3c875946511c83ba68dd0812034ba2b11842e15a3aab8110b4646068755a26ac647ffd7d2106d0e4cb2515a795a26ac647fbd7d2106d0e4cb2515a7230"
-    val rndHexRef = "0C338721fa06CAf348C9E013922E8B6D27C6E31FDC2B18FC6A83F144CA22D375"
+    val seedHexExpected =
+      "0641443435313601410406a102343b05bdf86df2552c125430cc319323792507328dcc9456713e1e7a24e715171e43aca3288e41dd346e840901a5d1588c2170ad1d55c0885a3230343aad1356323ffebe9083687265928ad3cad1356323fdebe9083687265928ad3918"
+    val rndHexExpected = "5d92fa794d3e68dcbdc0716de2b5799f95d04ef122109e21cb42f5fd7d64b359"
 
     // Reference values - seed and first random value
-    val (seedRef, rndRef) = (ByteVector.fromHex(seedHexRef).get, ByteVector.fromHex(rndHexRef).get)
+    val (seedExpected, rndExpected) =
+      (ByteVector.fromHex(seedHexExpected).get, ByteVector.fromHex(rndHexExpected).get)
 
-    seed shouldBe seedRef
-    rnd shouldBe rndRef
+    seed shouldBe seedExpected
+    // Checking of random number is not part of the seed logic so it's here just debugging information
+    rnd shouldBe rndExpected
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/rholang/DeployIdTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/DeployIdTest.scala
@@ -3,7 +3,6 @@ package coop.rchain.casper.rholang
 import cats.effect.Resource
 import cats.syntax.all._
 import cats.implicits.catsSyntaxApplicativeId
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.protocol.DeployData

--- a/casper/src/test/scala/coop/rchain/casper/rholang/DeployerIdTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/DeployerIdTest.scala
@@ -3,7 +3,6 @@ package coop.rchain.casper.rholang
 import cats.effect.Resource
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.rholang.Resources._

--- a/casper/src/test/scala/coop/rchain/casper/rholang/InterpreterUtilTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/InterpreterUtilTest.scala
@@ -5,7 +5,6 @@ import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.helper._
 import coop.rchain.casper.protocol._

--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeManagerTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeManagerTest.scala
@@ -5,7 +5,6 @@ import cats.effect.{Resource, Sync}
 import cats.syntax.all._
 import cats.{Applicative, Functor, Id}
 import com.google.protobuf.ByteString
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.ProcessedSystemDeploy.Failed
 import coop.rchain.casper.protocol.{DeployData, ProcessedDeploy, ProcessedSystemDeploy}

--- a/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/RuntimeSpec.scala
@@ -1,6 +1,5 @@
 package coop.rchain.casper.rholang
 
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.syntax._
 import coop.rchain.models.syntax._

--- a/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverRequesAllSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverRequesAllSpec.scala
@@ -2,9 +2,8 @@ package coop.rchain.casper.sync
 
 import cats.effect.concurrent.Ref
 import com.google.protobuf.ByteString
-import coop.rchain.casper.engine
-import coop.rchain.casper.engine.BlockRetriever
-import coop.rchain.casper.engine.BlockRetriever.RequestState
+import coop.rchain.casper.blocks.BlockRetriever
+import coop.rchain.casper.blocks.BlockRetriever.{RequestState, RequestedBlocks}
 import coop.rchain.casper.protocol._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm.CommError._
@@ -34,7 +33,7 @@ class BlockRetrieverRequestAllSpec extends AnyFunSpec with BeforeAndAfterEach wi
 
   implicit val log     = new LogStub[Task]
   implicit val metrics = new Metrics.MetricsNOP[Task]
-  implicit val currentRequests: engine.BlockRetriever.RequestedBlocks[Task] =
+  implicit val currentRequests: RequestedBlocks[Task] =
     Ref.unsafe[Task, Map[BlockHash, RequestState]](Map.empty[BlockHash, RequestState])
   implicit val connectionsCell: ConnectionsCell[Task] =
     Ref.unsafe[Task, Connections](List(local))

--- a/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/sync/BlockRetrieverSpec.scala
@@ -2,13 +2,12 @@ package coop.rchain.casper.sync
 
 import cats.effect.concurrent.Ref
 import com.google.protobuf.ByteString
-import coop.rchain.casper.engine
-import coop.rchain.casper.engine.BlockRetriever
-import coop.rchain.casper.engine.BlockRetriever.RequestState
+import coop.rchain.casper.blocks.BlockRetriever
+import coop.rchain.casper.blocks.BlockRetriever.{RequestState, RequestedBlocks}
 import coop.rchain.casper.protocol._
-import coop.rchain.comm.{Endpoint, NodeIdentifier, PeerNode}
 import coop.rchain.comm.rp.Connect.{Connections, ConnectionsCell}
 import coop.rchain.comm.rp.ProtocolHelper._
+import coop.rchain.comm.{Endpoint, NodeIdentifier, PeerNode}
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.p2p.EffectsTestInstances.{createRPConfAsk, LogStub, TransportLayerStub}
@@ -34,7 +33,7 @@ class BlockRetrieverSpec extends AnyFunSpec with BeforeAndAfterEach with Matcher
 
   implicit val log     = new LogStub[Task]
   implicit val metrics = new Metrics.MetricsNOP[Task]
-  implicit val currentRequests: engine.BlockRetriever.RequestedBlocks[Task] =
+  implicit val currentRequests: RequestedBlocks[Task] =
     Ref.unsafe[Task, Map[BlockHash, RequestState]](Map.empty[BlockHash, RequestState])
   implicit val connectionsCell: ConnectionsCell[Task] =
     Ref.unsafe[Task, Connections](List(local))

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -2,13 +2,13 @@ package coop.rchain.casper.util
 
 import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.casper.{BlockRandomSeed, ValidatorIdentity}
+import coop.rchain.casper.ValidatorIdentity
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkTestRNodeStoreManager
-import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
 import coop.rchain.casper.rholang.{Resources, RuntimeManager}
 import coop.rchain.casper.util.ConstructDeploy._
 import coop.rchain.catscontrib.TaskContrib.TaskOps

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/RhoTrieTraverser.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/RhoTrieTraverser.scala
@@ -3,11 +3,10 @@ package coop.rchain.node.revvaultexport
 import cats.effect.Sync
 import cats.implicits._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.genesis.contracts.StandardDeploys
 import coop.rchain.casper.rholang.RuntimeManager.emptyStateHashFixed
-import coop.rchain.casper.rholang.Tools
+import coop.rchain.casper.rholang.{BlockRandomSeed, Tools}
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Keccak256
 import coop.rchain.models.Expr.ExprInstance._

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/StateBalances.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/StateBalances.scala
@@ -5,8 +5,8 @@ import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.Genesis
+import coop.rchain.casper.rholang.BlockRandomSeed
 import coop.rchain.casper.rholang.RuntimeManager.emptyStateHashFixed
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager
 import coop.rchain.metrics.{Metrics, NoopSpan}

--- a/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/NodeRuntime.scala
@@ -1,13 +1,12 @@
 package coop.rchain.node.runtime
 
 import cats.Parallel
-import cats.effect._
+import cats.effect.{ConcurrentEffect, ContextShift, Resource, Sync, Timer}
 import cats.effect.concurrent.Ref
 import cats.mtl._
 import cats.syntax.all._
 import com.typesafe.config.Config
-import coop.rchain.casper._
-import coop.rchain.casper.engine.BlockRetriever
+import coop.rchain.casper.blocks.BlockRetriever
 import coop.rchain.casper.protocol.CommUtil
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager
 import coop.rchain.comm._
@@ -129,7 +128,7 @@ class NodeRuntime[F[_]: Monixable: ConcurrentEffect: Parallel: Timer: ContextShi
       peerNode        = rpConf(local, initPeer)
       rpConfState     = effects.rpConfState[F](peerNode)
       rpConfAsk       = effects.rpConfAsk[F](rpConfState)
-      requestedBlocks <- Ref.of[F, Map[BlockHash, engine.BlockRetriever.RequestState]](Map.empty)
+      requestedBlocks <- Ref.of[F, Map[BlockHash, BlockRetriever.RequestState]](Map.empty)
 
       commUtil = {
         implicit val (tr, cn, cc) = (transport, rpConfAsk, rpConnections)

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -12,10 +12,9 @@ import coop.rchain.casper.blocks.proposer.{Proposer, ProposerResult}
 import coop.rchain.casper.blocks.{BlockProcessor, BlockReceiver, BlockReceiverState, BlockRetriever}
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
 import coop.rchain.casper.engine.{NodeLaunch, PeerMessage}
-import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.{toCasperMessageProto, BlockMessage, CasperMessage, CommUtil}
 import coop.rchain.casper.reporting.{ReportStore, ReportingCasper}
-import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
 import coop.rchain.casper.state.instances.{BlockStateManagerImpl, ProposerState}
 import coop.rchain.casper.syntax._
 import coop.rchain.comm.RoutingMessage

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -9,9 +9,9 @@ import coop.rchain.blockstorage.{approvedStore, BlockStore}
 import coop.rchain.casper._
 import coop.rchain.casper.api.{BlockApiImpl, BlockReportApi}
 import coop.rchain.casper.blocks.proposer.{Proposer, ProposerResult}
-import coop.rchain.casper.blocks.{BlockProcessor, BlockReceiver, BlockReceiverState}
+import coop.rchain.casper.blocks.{BlockProcessor, BlockReceiver, BlockReceiverState, BlockRetriever}
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
-import coop.rchain.casper.engine.{BlockRetriever, NodeLaunch, PeerMessage}
+import coop.rchain.casper.engine.{NodeLaunch, PeerMessage}
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.{toCasperMessageProto, BlockMessage, CasperMessage, CommUtil}
 import coop.rchain.casper.reporting.{ReportStore, ReportingCasper}

--- a/node/src/test/scala/coop/rchain/node/TransactionAPISpec.scala
+++ b/node/src/test/scala/coop/rchain/node/TransactionAPISpec.scala
@@ -1,9 +1,8 @@
 package coop.rchain.node
 
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.api.BlockReportApi
 import coop.rchain.casper.helper.TestNode
-import coop.rchain.casper.rholang.Resources
+import coop.rchain.casper.rholang.{BlockRandomSeed, Resources}
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.casper.util.GenesisBuilder.{buildGenesis, GenesisContext}
 import coop.rchain.casper.reporting.{ReportStore, ReportingCasper}

--- a/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/MergingBranchMergerSpec.scala
@@ -5,14 +5,13 @@ import cats.effect.{Concurrent, Resource}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.dag.BlockDagStorage
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
 import coop.rchain.casper.merging.{BlockHashDagMerger, BlockIndex, DeployChainIndex}
 import coop.rchain.casper.genesis.Genesis
 import coop.rchain.casper.protocol.{BlockMessage, ProcessedDeploy, ProcessedSystemDeploy}
 import coop.rchain.casper.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.rholang.sysdeploys.CloseBlockDeploy
-import coop.rchain.casper.rholang.{Resources, RuntimeManager}
+import coop.rchain.casper.rholang.{BlockRandomSeed, Resources, RuntimeManager}
 import coop.rchain.casper.syntax.casperSyntaxRuntimeManager
 import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
 import coop.rchain.crypto.signatures.Secp256k1

--- a/node/src/test/scala/coop/rchain/node/mergeablity/TreeHashMapMergeabilitySpec.scala
+++ b/node/src/test/scala/coop/rchain/node/mergeablity/TreeHashMapMergeabilitySpec.scala
@@ -4,8 +4,8 @@ import cats.effect.Sync
 import cats.implicits.catsSyntaxApplicative
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.genesis.contracts.{Registry, StandardDeploys}
+import coop.rchain.casper.rholang.BlockRandomSeed
 import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
 import coop.rchain.crypto.hash.Blake2b512Random

--- a/node/src/test/scala/coop/rchain/node/revvaultexport/VaultBalanceGetterTest.scala
+++ b/node/src/test/scala/coop/rchain/node/revvaultexport/VaultBalanceGetterTest.scala
@@ -1,8 +1,8 @@
 package coop.rchain.node.revvaultexport
 
 import com.google.protobuf.ByteString
-import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.helper.TestNode
+import coop.rchain.casper.rholang.BlockRandomSeed
 import coop.rchain.models.syntax._
 import coop.rchain.casper.util.GenesisBuilder.{buildGenesis, buildGenesisParameters}
 import coop.rchain.node.revvaultexport.mainnet1.StateBalanceMain


### PR DESCRIPTION
## Overview

This PR moves BlockRetriever to blocks folder and includes small changes to tests to prepare for future modifications.

It also fixes `insert` method in DagStorage to only update state is block is inserted.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
