### PR TITLE
Move RhoType to models project

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/BlockApiImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockApiImpl.scala
@@ -31,7 +31,7 @@ import coop.rchain.crypto.signatures.Signed
 import coop.rchain.graphz._
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
-import coop.rchain.models.rholang.RhoType.DeployId
+import coop.rchain.models.rholang.RhoType.RhoDeployId
 import coop.rchain.models.rholang.sorter.Sortable._
 import coop.rchain.models.serialization.implicits._
 import coop.rchain.models.syntax._
@@ -174,7 +174,7 @@ class BlockApiImpl[F[_]: Concurrent: RuntimeManager: BlockDagStorage: BlockStore
     def findProcessedDeployResultAndStatus: OptionT[F, DeployExecStatus] = {
       val lookupDeploy = OptionT(BlockDagStorage[F].lookupByDeployId(deployId))
       lookupDeploy.semiflatMap { blockHash =>
-        val deployIdCh = DeployId(deployId.toByteArray)
+        val deployIdCh = RhoDeployId(deployId.toByteArray)
         for {
           block     <- BlockStore[F].getUnsafe(blockHash)
           deployOpt = block.state.deploys.find(_.deploy.sig == deployId)

--- a/casper/src/main/scala/coop/rchain/casper/api/BlockApiImpl.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/BlockApiImpl.scala
@@ -9,7 +9,6 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
 import coop.rchain.blockstorage.dag._
-import coop.rchain.casper.MultiParentCasper.parsingError
 import coop.rchain.casper._
 import coop.rchain.casper.api.BlockApi._
 import coop.rchain.casper.blocks.proposer.ProposeResult._
@@ -22,7 +21,7 @@ import coop.rchain.casper.protocol.deploy.v1.{
   ProcessedWithError,
   ProcessedWithSuccess
 }
-import coop.rchain.casper.rholang.{InterpreterUtil, RuntimeManager}
+import coop.rchain.casper.rholang.RuntimeManager
 import coop.rchain.casper.state.instances.ProposerState
 import coop.rchain.casper.syntax._
 import coop.rchain.casper.util._
@@ -32,12 +31,11 @@ import coop.rchain.crypto.signatures.Signed
 import coop.rchain.graphz._
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
-import coop.rchain.models.Validator.Validator
+import coop.rchain.models.rholang.RhoType.DeployId
 import coop.rchain.models.rholang.sorter.Sortable._
 import coop.rchain.models.serialization.implicits._
 import coop.rchain.models.syntax._
-import coop.rchain.models.{BlockMetadata, NormalizerEnv, Par}
-import coop.rchain.rholang.interpreter.RhoType.DeployId
+import coop.rchain.models.{BlockMetadata, Par}
 import coop.rchain.rspace.hashing.StableHashProvider
 import coop.rchain.rspace.trace.{COMM, Consume, Produce}
 import coop.rchain.sdk.syntax.all._

--- a/casper/src/main/scala/coop/rchain/casper/protocol/client/ListenAtName.scala
+++ b/casper/src/main/scala/coop/rchain/casper/protocol/client/ListenAtName.scala
@@ -4,7 +4,7 @@ import cats.Id
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.casper.rholang.InterpreterUtil
-import coop.rchain.models.rholang.RhoType.Name
+import coop.rchain.models.rholang.RhoType.RhoName
 import coop.rchain.models.{NormalizerEnv, Par}
 import coop.rchain.shared.Time
 
@@ -39,7 +39,7 @@ object ListenAtName {
         InterpreterUtil.mkTerm(content, NormalizerEnv.Empty)
       case PrivName(content) =>
         Sync[F].delay {
-          Name(content.getBytes)
+          RhoName(content.getBytes)
         }
     }
 

--- a/casper/src/main/scala/coop/rchain/casper/protocol/client/ListenAtName.scala
+++ b/casper/src/main/scala/coop/rchain/casper/protocol/client/ListenAtName.scala
@@ -3,12 +3,10 @@ package coop.rchain.casper.protocol.client
 import cats.Id
 import cats.effect.Sync
 import cats.syntax.all._
-import com.google.protobuf.ByteString
 import coop.rchain.casper.rholang.InterpreterUtil
-import coop.rchain.models.{GPrivate, NormalizerEnv, Par}
+import coop.rchain.models.rholang.RhoType.Name
+import coop.rchain.models.{NormalizerEnv, Par}
 import coop.rchain.shared.Time
-import coop.rchain.models.syntax._
-import coop.rchain.rholang.interpreter.RhoType.Name
 
 object ListenAtName {
   sealed trait Name
@@ -35,9 +33,7 @@ object ListenAtName {
         f.flatMap(_.traverse(buildParId[F]))
     }
 
-  private def buildParId[F[_]: Sync](name: Name): F[Par] = {
-    import coop.rchain.models.rholang.implicits._
-
+  private def buildParId[F[_]: Sync](name: Name): F[Par] =
     name match {
       case PubName(content) =>
         InterpreterUtil.mkTerm(content, NormalizerEnv.Empty)
@@ -46,7 +42,6 @@ object ListenAtName {
           Name(content.getBytes)
         }
     }
-  }
 
   private def applyUntil[A, F[_]: Sync: Time](retrieve: F[A])(breakCond: A => Boolean): F[A] = {
     import scala.concurrent.duration._

--- a/casper/src/main/scala/coop/rchain/casper/rholang/BlockRandomSeed.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/BlockRandomSeed.scala
@@ -4,8 +4,8 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
+import coop.rchain.models.rholang.RhoType.Name
 import coop.rchain.models.syntax._
-import coop.rchain.rholang.interpreter.RhoType.Name
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import scodec.bits.ByteVector
 import scodec.codecs.{bytes, uint8, utf8, variableSizeBytes, vlong}

--- a/casper/src/main/scala/coop/rchain/casper/rholang/BlockRandomSeed.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/BlockRandomSeed.scala
@@ -4,7 +4,7 @@ import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.Par
-import coop.rchain.models.rholang.RhoType.Name
+import coop.rchain.models.rholang.RhoType.RhoName
 import coop.rchain.models.syntax._
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import scodec.bits.ByteVector
@@ -125,7 +125,7 @@ object BlockRandomSeed {
     val nonNegativeContractIndex: Byte = 3
     val rand                           = splitRandomNumberFromGenesis(shardId, nonNegativeContractIndex, UserDeploySplitIndex)
     val unforgeableByte                = Iterator.continually(rand.next()).drop(1).next()
-    Name(unforgeableByte)
+    RhoName(unforgeableByte)
   }
 
   // This is the unforgeable name for
@@ -136,7 +136,7 @@ object BlockRandomSeed {
     val rand =
       splitRandomNumberFromGenesis(shardId, RevVaultContractDeployIndex, UserDeploySplitIndex)
     val unfogeableBytes = Iterator.continually(rand.next()).drop(10).next()
-    Name(unfogeableBytes)
+    RhoName(unfogeableBytes)
   }
 
   def storeTokenUnforgeable(shardId: String): Par = {
@@ -145,7 +145,7 @@ object BlockRandomSeed {
     val rand =
       splitRandomNumberFromGenesis(shardId, TreeHashMapContractDeployIndex, UserDeploySplitIndex)
     val target = LazyList.continually(rand.next()).drop(9).head
-    Name(target)
+    RhoName(target)
   }
 
   def revVaultUnforgeable(shardId: String): Par = {
@@ -154,7 +154,7 @@ object BlockRandomSeed {
     val rand =
       splitRandomNumberFromGenesis(shardId, RevVaultContractDeployIndex, UserDeploySplitIndex)
     val unfogeableBytes = rand.next()
-    Name(unfogeableBytes)
+    RhoName(unfogeableBytes)
   }
 
 }

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
@@ -36,9 +36,9 @@ import coop.rchain.models.Validator.Validator
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.block.StateHash.StateHash
+import coop.rchain.models.rholang.RhoType.Name
 import coop.rchain.models.syntax.modelsSyntaxByteString
 import coop.rchain.rholang.interpreter.RhoRuntime.bootstrapRegistry
-import coop.rchain.rholang.interpreter.RhoType.Name
 import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.errors.BugFoundError

--- a/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/syntax/RuntimeSyntax.scala
@@ -36,7 +36,7 @@ import coop.rchain.models.Validator.Validator
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
 import coop.rchain.models.block.StateHash.StateHash
-import coop.rchain.models.rholang.RhoType.Name
+import coop.rchain.models.rholang.RhoType.RhoName
 import coop.rchain.models.syntax.modelsSyntaxByteString
 import coop.rchain.rholang.interpreter.RhoRuntime.bootstrapRegistry
 import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
@@ -461,7 +461,7 @@ final class RuntimeOps[F[_]](private val runtime: RhoRuntime[F]) extends AnyVal 
 
     // Create return channel as first private name created in deploy term
     val rand       = Blake2b512Random.defaultRandom
-    val returnName = Name(rand.copy().next())
+    val returnName = RhoName(rand.copy().next())
 
     // Execute deploy on top of specified block hash
     captureResults(hash, deploy, rand, returnName)
@@ -492,7 +492,7 @@ final class RuntimeOps[F[_]](private val runtime: RhoRuntime[F]) extends AnyVal 
   )(implicit s: Sync[F]): F[Seq[Par]] = {
     // Create return channel as first unforgeable name created in deploy term
     val rand       = Blake2b512Random.defaultRandom
-    val returnName = Name(rand.copy().next())
+    val returnName = RhoName(rand.copy().next())
     captureResults(start, deploy, rand, returnName)
   }
 

--- a/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/CheckBalance.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/CheckBalance.scala
@@ -5,7 +5,7 @@ import coop.rchain.casper.rholang.types.{SystemDeploy, SystemDeployUserError}
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.NormalizerEnv.{Contains, ToEnvMap}
-import coop.rchain.rholang.interpreter.RhoType.{Extractor, RhoNumber}
+import coop.rchain.models.rholang.RhoType.{Extractor, RhoNumber}
 
 class CheckBalance(pk: PublicKey, rand: Blake2b512Random) extends SystemDeploy(rand) {
 

--- a/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/CloseBlockDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/CloseBlockDeploy.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper.rholang.sysdeploys
 import coop.rchain.casper.rholang.types.{SystemDeploy, SystemDeployUserError}
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.NormalizerEnv.{Contains, ToEnvMap}
-import coop.rchain.rholang.interpreter.RhoType._
+import coop.rchain.models.rholang.RhoType._
 
 // Currently we use parentHash as initial random seed
 final case class CloseBlockDeploy(initialRand: Blake2b512Random) extends SystemDeploy(initialRand) {

--- a/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/PreChargeDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/PreChargeDeploy.scala
@@ -4,7 +4,7 @@ import coop.rchain.casper.rholang.types.{SystemDeploy, SystemDeployUserError}
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.NormalizerEnv.{Contains, ToEnvMap}
-import coop.rchain.rholang.interpreter.RhoType._
+import coop.rchain.models.rholang.RhoType._
 
 final class PreChargeDeploy(chargeAmount: Long, pk: PublicKey, rand: Blake2b512Random)
     extends SystemDeploy(rand) {

--- a/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/RefundDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/RefundDeploy.scala
@@ -3,7 +3,7 @@ package coop.rchain.casper.rholang.sysdeploys
 import coop.rchain.casper.rholang.types.{SystemDeploy, SystemDeployUserError}
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.NormalizerEnv.{Contains, ToEnvMap}
-import coop.rchain.rholang.interpreter.RhoType._
+import coop.rchain.models.rholang.RhoType._
 
 final class RefundDeploy(refundAmount: Long, rand: Blake2b512Random) extends SystemDeploy(rand) {
   import coop.rchain.models._

--- a/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/SlashDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/sysdeploys/SlashDeploy.scala
@@ -4,7 +4,7 @@ import coop.rchain.casper.rholang.types.{SystemDeploy, SystemDeployUserError}
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.NormalizerEnv.{Contains, ToEnvMap}
 import coop.rchain.models.Validator.Validator
-import coop.rchain.rholang.interpreter.RhoType._
+import coop.rchain.models.rholang.RhoType._
 
 final case class SlashDeploy(
     slashedValidator: Validator,
@@ -12,10 +12,8 @@ final case class SlashDeploy(
 ) extends SystemDeploy(initialRand) {
   import coop.rchain.models._
   import Expr.ExprInstance._
-  import coop.rchain.models.syntax._
   import rholang.{implicits => toPar}
   import shapeless._
-  import shapeless.record._
   import shapeless.syntax.singleton._
 
   type Output = (RhoBoolean, Either[RhoString, RhoNil])

--- a/casper/src/main/scala/coop/rchain/casper/rholang/types/SystemDeploy.scala
+++ b/casper/src/main/scala/coop/rchain/casper/rholang/types/SystemDeploy.scala
@@ -7,7 +7,7 @@ import coop.rchain.casper.rholang.types.SystemDeployPlatformFailure.UnexpectedRe
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.NormalizerEnv.{Contains, ToEnvMap}
-import coop.rchain.rholang.interpreter.RhoType.Extractor
+import coop.rchain.models.rholang.RhoType.Extractor
 import shapeless.Witness
 
 abstract class SystemDeploy(initialRand: Blake2b512Random) {

--- a/casper/src/test/scala/coop/rchain/casper/genesis/AuthKeyUpdateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/AuthKeyUpdateSpec.scala
@@ -6,7 +6,7 @@ import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.models.GDeployId
-import coop.rchain.models.rholang.RhoType.{Boolean, String, Tuple2}
+import coop.rchain.models.rholang.RhoType.{RhoBoolean, RhoString, RhoTuple2}
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.syntax._
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
@@ -126,8 +126,8 @@ class AuthKeyUpdateSpec extends AnyFlatSpec with Matchers with Inspectors {
         _  = assert(!b2.state.deploys.head.isFailed, s"$b2 deploy failed")
 
         // Get update contract result
-        updateResult                               <- rm.getData(b2.postStateHash)(GDeployId(updateDeploy.sig))
-        Tuple2((Boolean(success), String(errMsg))) = updateResult.head
+        updateResult                                        <- rm.getData(b2.postStateHash)(GDeployId(updateDeploy.sig))
+        RhoTuple2((RhoBoolean(success), RhoString(errMsg))) = updateResult.head
         // Expect failed update
         _ = assert(!success, s"update should fail, instead: $errMsg")
       } yield ()

--- a/casper/src/test/scala/coop/rchain/casper/genesis/AuthKeyUpdateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/AuthKeyUpdateSpec.scala
@@ -6,15 +6,15 @@ import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.models.GDeployId
+import coop.rchain.models.rholang.RhoType.{Boolean, String, Tuple2}
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.syntax._
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
-import coop.rchain.rholang.interpreter.RhoType.{Boolean, String, Tuple2}
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.Inspectors
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source

--- a/casper/src/test/scala/coop/rchain/casper/genesis/PosUpdateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/PosUpdateSpec.scala
@@ -2,21 +2,20 @@ package coop.rchain.casper.genesis
 
 import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode._
-import coop.rchain.casper.protocol.ProcessedDeploy
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.Secp256k1
+import coop.rchain.models.GDeployId
+import coop.rchain.models.rholang.RhoType.{Boolean, Number, String, Tuple2}
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.syntax._
-import coop.rchain.models.{GDeployId, PCost}
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
-import coop.rchain.rholang.interpreter.RhoType.{Boolean, Number, String, Tuple2}
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.shared.scalatestcontrib._
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.Inside.inside
-import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.Inspectors
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source

--- a/casper/src/test/scala/coop/rchain/casper/genesis/PosUpdateSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/genesis/PosUpdateSpec.scala
@@ -6,7 +6,7 @@ import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.models.GDeployId
-import coop.rchain.models.rholang.RhoType.{Boolean, Number, String, Tuple2}
+import coop.rchain.models.rholang.RhoType.{RhoBoolean, RhoNumber, RhoString, RhoTuple2}
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.syntax._
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
@@ -114,10 +114,10 @@ class PosUpdateSpec extends AnyFlatSpec with Matchers with Inspectors {
                           exploreUpdateResultTerm,
                           genesis.genesisBlock.postStateHash
                         )
-        _ = originalEpoch should matchPattern { case Seq(Number(1000)) => }
+        _ = originalEpoch should matchPattern { case Seq(RhoNumber(1000)) => }
 
-        ret                  <- rm.playExploratoryDeploy(getBalanceTerm, b2.postStateHash)
-        Seq(Number(balance)) = ret
+        ret                     <- rm.playExploratoryDeploy(getBalanceTerm, b2.postStateHash)
+        Seq(RhoNumber(balance)) = ret
 
         b5 <- node
                .addBlock(
@@ -129,10 +129,10 @@ class PosUpdateSpec extends AnyFlatSpec with Matchers with Inspectors {
         _ = assert(!b5.state.deploys.head.isFailed, s"$b5 deploy failed")
 
         ret2 <- rm.playExploratoryDeploy(getBalanceTerm, b5.postStateHash)
-        _    = inside(ret2) { case Seq(Number(n)) => n shouldBe balance + transferAmount.toLong }
+        _    = inside(ret2) { case Seq(RhoNumber(n)) => n shouldBe balance + transferAmount.toLong }
 
         ret3 <- rm.playExploratoryDeploy(explorePosNewMethod, b5.postStateHash)
-        _    = ret3 should matchPattern { case Seq(String("hello")) => }
+        _    = ret3 should matchPattern { case Seq(RhoString("hello")) => }
       } yield ()
     }
   }
@@ -158,7 +158,7 @@ class PosUpdateSpec extends AnyFlatSpec with Matchers with Inspectors {
         updateResult <- rm.getData(b2.postStateHash)(GDeployId(updateDeploy.sig))
         // Expect failed update
         _ = updateResult should matchPattern {
-          case Seq(Tuple2((Boolean(false), String(_)))) =>
+          case Seq(RhoTuple2((RhoBoolean(false), RhoString(_)))) =>
         }
       } yield ()
     }

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDataContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDataContract.scala
@@ -3,8 +3,9 @@ package coop.rchain.casper.helper
 import cats.effect.Concurrent
 import coop.rchain.crypto.PublicKey
 import coop.rchain.metrics.Span
+import coop.rchain.models.rholang.RhoType
 import coop.rchain.models.{ListParWithRandom, Par}
-import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
+import coop.rchain.rholang.interpreter.ContractCall
 import coop.rchain.rholang.interpreter.SystemProcesses.ProcessContext
 
 object BlockDataContract {

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDataContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDataContract.scala
@@ -19,7 +19,7 @@ object BlockDataContract {
     message match {
       case isContractCall(
           produce,
-          Seq(RhoType.String("sender"), RhoType.ByteArray(pk), ackCh)
+          Seq(RhoType.RhoString("sender"), RhoType.RhoByteArray(pk), ackCh)
           ) =>
         for {
           _ <- ctx.blockData.update(_.copy(sender = PublicKey(pk)))
@@ -28,7 +28,7 @@ object BlockDataContract {
 
       case isContractCall(
           produce,
-          Seq(RhoType.String("blockNumber"), RhoType.Number(n), ackCh)
+          Seq(RhoType.RhoString("blockNumber"), RhoType.RhoNumber(n), ackCh)
           ) =>
         for {
           _ <- ctx.blockData.update(_.copy(blockNumber = n))

--- a/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
@@ -2,8 +2,9 @@ package coop.rchain.casper.helper
 import cats.effect.Concurrent
 import coop.rchain.metrics.Span
 import coop.rchain.models.ListParWithRandom
+import coop.rchain.models.rholang.RhoType
+import coop.rchain.rholang.interpreter.ContractCall
 import coop.rchain.rholang.interpreter.SystemProcesses.ProcessContext
-import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
 
 /**
   * Warning: This should under no circumstances be available in production

--- a/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/DeployerIdContract.scala
@@ -20,10 +20,10 @@ object DeployerIdContract {
     message match {
       case isContractCall(
           produce,
-          Seq(RhoType.String("deployerId"), RhoType.ByteArray(pk), ackCh)
+          Seq(RhoType.RhoString("deployerId"), RhoType.RhoByteArray(pk), ackCh)
           ) =>
         for {
-          _ <- produce(Seq(RhoType.DeployerId(pk)), ackCh)
+          _ <- produce(Seq(RhoType.RhoDeployerId(pk)), ackCh)
         } yield ()
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoLoggerContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoLoggerContract.scala
@@ -2,8 +2,9 @@ package coop.rchain.casper.helper
 import cats.effect.Concurrent
 import coop.rchain.metrics.Span
 import coop.rchain.models.ListParWithRandom
+import coop.rchain.models.rholang.RhoType
 import coop.rchain.rholang.interpreter.SystemProcesses.ProcessContext
-import coop.rchain.rholang.interpreter.{ContractCall, PrettyPrinter, RhoType}
+import coop.rchain.rholang.interpreter.{ContractCall, PrettyPrinter}
 import coop.rchain.shared.{Log, LogSource}
 
 object RhoLoggerContract {

--- a/casper/src/test/scala/coop/rchain/casper/helper/RhoLoggerContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/RhoLoggerContract.scala
@@ -17,7 +17,7 @@ object RhoLoggerContract {
     val isContractCall = new ContractCall(ctx.space, ctx.dispatcher)
 
     message match {
-      case isContractCall(_, Seq(RhoType.String(logLevel), par)) =>
+      case isContractCall(_, Seq(RhoType.RhoString(logLevel), par)) =>
         val msg         = prettyPrinter.buildString(par)
         implicit val ev = LogSource.matLogSource
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/Secp256k1SignContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/Secp256k1SignContract.scala
@@ -4,8 +4,8 @@ import cats.effect.Concurrent
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.metrics.Span
 import coop.rchain.models.ListParWithRandom
-import coop.rchain.rholang.interpreter.SystemProcesses
-import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
+import coop.rchain.models.rholang.RhoType
+import coop.rchain.rholang.interpreter.{ContractCall, SystemProcesses}
 
 object Secp256k1SignContract {
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/Secp256k1SignContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/Secp256k1SignContract.scala
@@ -16,10 +16,10 @@ object Secp256k1SignContract {
     message match {
       case isContractCall(
           produce,
-          Seq(RhoType.ByteArray(hash), RhoType.ByteArray(sk), ackCh)
+          Seq(RhoType.RhoByteArray(hash), RhoType.RhoByteArray(sk), ackCh)
           ) =>
         val sig = Secp256k1.sign(hash, sk)
-        produce(Seq(RhoType.ByteArray(sig)), ackCh)
+        produce(Seq(RhoType.RhoByteArray(sig)), ackCh)
     }
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/helper/SysAuthTokenContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/SysAuthTokenContract.scala
@@ -2,8 +2,9 @@ package coop.rchain.casper.helper
 
 import cats.effect.Concurrent
 import coop.rchain.metrics.Span
+import coop.rchain.models.rholang.RhoType
 import coop.rchain.models.{GSysAuthToken, ListParWithRandom}
-import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
+import coop.rchain.rholang.interpreter.ContractCall
 import coop.rchain.rholang.interpreter.SystemProcesses.ProcessContext
 
 /**

--- a/casper/src/test/scala/coop/rchain/casper/helper/SysAuthTokenContract.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/SysAuthTokenContract.scala
@@ -24,7 +24,7 @@ object SysAuthTokenContract {
           Seq(ackCh)
           ) =>
         for {
-          _ <- produce(Seq(RhoType.SysAuthToken(GSysAuthToken())), ackCh)
+          _ <- produce(Seq(RhoType.RhoSysAuthToken(GSysAuthToken())), ackCh)
         } yield ()
     }
   }

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestResultCollector.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestResultCollector.scala
@@ -5,10 +5,11 @@ import cats.syntax.all._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Span
 import coop.rchain.models.Expr.ExprInstance.{ETupleBody, GBool}
+import coop.rchain.models.rholang.RhoType
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.{ETuple, Expr, ListParWithRandom, Par}
+import coop.rchain.rholang.interpreter.ContractCall
 import coop.rchain.rholang.interpreter.SystemProcesses.ProcessContext
-import coop.rchain.rholang.interpreter.{ContractCall, RhoType}
 
 object IsAssert {
   def unapply(

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestResultCollector.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestResultCollector.scala
@@ -17,10 +17,10 @@ object IsAssert {
   ): Option[(String, Long, Par, String, Par)] =
     p match {
       case Seq(
-          RhoType.String(testName),
-          RhoType.Number(attempt),
+          RhoType.RhoString(testName),
+          RhoType.RhoNumber(attempt),
           assertion,
-          RhoType.String(clue),
+          RhoType.RhoString(clue),
           ackChannel
           ) =>
         Some((testName, attempt, assertion, clue, ackChannel))
@@ -33,14 +33,14 @@ object IsComparison {
       p: Par
   ): Option[(Par, String, Par)] =
     p.singleExpr().collect {
-      case Expr(ETupleBody(ETuple(List(expected, RhoType.String(operator), actual), _, _))) =>
+      case Expr(ETupleBody(ETuple(List(expected, RhoType.RhoString(operator), actual), _, _))) =>
         (expected, operator, actual)
     }
 }
 object IsSetFinished {
   def unapply(p: Seq[Par]): Option[Boolean] =
     p match {
-      case Seq(RhoType.Boolean(hasFinished)) =>
+      case Seq(RhoType.RhoBoolean(hasFinished)) =>
         Some(hasFinished)
       case _ => None
     }
@@ -112,7 +112,7 @@ class TestResultCollector[F[_]: Concurrent: Span](result: Ref[F, TestResult]) {
               _ <- result.update(_.addAssertion(attempt, assertion))
               _ <- produce(Seq(Expr(GBool(assertion.isSuccess))), ackChannel)
             } yield ()
-          case RhoType.Boolean(condition) =>
+          case RhoType.RhoBoolean(condition) =>
             for {
               _ <- result.update(_.addAssertion(attempt, RhoAssertTrue(testName, condition, clue)))
               _ <- produce(Seq(Expr(GBool(condition))), ackChannel)

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -9,23 +9,17 @@ import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.EventConverter
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Span
-import coop.rchain.models.{GPrivate, Par}
+import coop.rchain.models.Par
+import coop.rchain.models.rholang.RhoType.{Name, Number}
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
-import coop.rchain.rholang.interpreter.RhoType.{Name, Number}
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.merging.RholangMergingLogic
 import coop.rchain.rholang.interpreter.merging.RholangMergingLogic.convertToReadNumber
 import coop.rchain.rholang.syntax._
 import coop.rchain.rspace.HotStoreTrieAction
-import coop.rchain.models.syntax._
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.merger.EventLogMergingLogic.NumberChannelsDiff
-import coop.rchain.rspace.merger.{
-  ChannelChange,
-  EventLogMergingLogic,
-  StateChange,
-  StateChangeMerger
-}
+import coop.rchain.rspace.merger.{ChannelChange, StateChange, StateChangeMerger}
 import coop.rchain.rspace.serializers.ScodecSerialize
 import coop.rchain.rspace.syntax._
 import coop.rchain.sdk.dag.merging.DagMergingLogic

--- a/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/merging/MergeNumberChannelSpec.scala
@@ -10,7 +10,7 @@ import coop.rchain.casper.util.EventConverter
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Span
 import coop.rchain.models.Par
-import coop.rchain.models.rholang.RhoType.{Name, Number}
+import coop.rchain.models.rholang.RhoType.{RhoName, RhoNumber}
 import coop.rchain.p2p.EffectsTestInstances.LogicalTime
 import coop.rchain.rholang.interpreter.accounting.Cost
 import coop.rchain.rholang.interpreter.merging.RholangMergingLogic
@@ -91,7 +91,7 @@ class MergeNumberChannelSpec extends AnyFlatSpec {
   }
 
   val unforgeableNameSeed: Par = {
-    Name(baseRhoSeed.next())
+    RhoName(baseRhoSeed.next())
   }
 
   def testCase[F[_]: Concurrent: ContextShift: Parallel: Span: Log](
@@ -293,7 +293,7 @@ class MergeNumberChannelSpec extends AnyFlatSpec {
 
         res <- runtime.playExploratoryDeploy(rhoExploreRead, finalHash.toByteString)
 
-        Number(finalBalance) = res.head
+        RhoNumber(finalBalance) = res.head
 
         _ = finalBalance shouldBe expectedFinalResult
 

--- a/casper/src/test/scala/coop/rchain/casper/rholang/Resources.scala
+++ b/casper/src/test/scala/coop/rchain/casper/rholang/Resources.scala
@@ -3,15 +3,11 @@ package coop.rchain.casper.rholang
 import cats.Parallel
 import cats.effect.{Concurrent, ContextShift, Resource, Sync}
 import cats.syntax.all._
-import coop.rchain.models.syntax._
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager.rnodeDbMapping
-import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics
 import coop.rchain.metrics.{NoopSpan, Span}
 import coop.rchain.models.Par
 import coop.rchain.rholang.Resources.mkTempDir
-import coop.rchain.rholang.interpreter.RhoRuntime.RhoHistoryRepository
-import coop.rchain.rholang.interpreter.RhoType.Name
 import coop.rchain.rspace.syntax._
 import coop.rchain.shared.Log
 import coop.rchain.store.LmdbDirStoreManager.mb

--- a/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala
@@ -179,7 +179,7 @@ object RhoType {
     def apply(expr: Expr): Par = expr
   }
 
-  object SysAuthToken {
+  object RhoSysAuthToken {
     def unapply(p: Par): Option[GSysAuthToken] =
       p.singleUnforgeable().collect {
         case GUnforgeable(GSysAuthTokenBody(token)) => token

--- a/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala
@@ -14,13 +14,13 @@ import coop.rchain.models.syntax._
 object RhoType {
   import coop.rchain.models.rholang.implicits._
 
-  type RhoNil = Nil.type
-  object Nil {
+  type RhoNil = RhoNil.type
+  object RhoNil {
     def unapply(p: Par): Boolean = p.isNil()
     def apply(): Par             = Par()
   }
-  type RhoByteArray = ByteArray.type
-  object ByteArray {
+  type RhoByteArray = RhoByteArray.type
+  object RhoByteArray {
     def unapply(p: Par): Option[Array[Byte]] =
       p.singleExpr().collect {
         case Expr(GByteArray(bs)) => bs.toByteArray
@@ -30,8 +30,8 @@ object RhoType {
       Expr(GByteArray(ByteString.copyFrom(bytes)))
   }
 
-  type RhoString = String.type
-  object String {
+  type RhoString = RhoString.type
+  object RhoString {
     def unapply(p: Par): Option[String] =
       p.singleExpr().collect {
         case Expr(GString(bs)) => bs
@@ -40,8 +40,8 @@ object RhoType {
     def apply(s: String): Par = GString(s)
   }
 
-  type RhoBoolean = Boolean.type
-  object Boolean {
+  type RhoBoolean = RhoBoolean.type
+  object RhoBoolean {
     def apply(b: Boolean): Par = Expr(GBool(b))
 
     def unapply(p: Par): Option[Boolean] =
@@ -50,8 +50,8 @@ object RhoType {
       }
   }
 
-  type RhoNumber = Number.type
-  object Number {
+  type RhoNumber = RhoNumber.type
+  object RhoNumber {
     def unapply(p: Par): Option[Long] =
       p.singleExpr().collect {
         case Expr(GInt(v)) => v
@@ -60,41 +60,41 @@ object RhoType {
     def apply(i: Long): Par = Expr(GInt(i))
   }
 
-  type RhoTupleN = TupleN.type
-  object TupleN {
+  type RhoTupleN = RhoTupleN.type
+  object RhoTupleN {
     def apply(tuple: Seq[Par]): Par = ETuple(tuple)
 
     def unapply(p: Par): Option[Seq[Par]] =
       p.singleExpr().collect { case Expr(ETupleBody(ETuple(tuple, _, _))) => tuple }
   }
 
-  type RhoTuple2 = Tuple2.type
-  object Tuple2 {
+  type RhoTuple2 = RhoTuple2.type
+  object RhoTuple2 {
     def apply(tuple: (Par, Par)): Par = ETuple(Seq(tuple._1, tuple._2))
 
     def unapply(p: Par): Option[(Par, Par)] =
-      TupleN.unapply(p).collect { case Seq(a, b) => (a, b) }
+      RhoTupleN.unapply(p).collect { case Seq(a, b) => (a, b) }
   }
 
-  type RhoTuple3 = Tuple3.type
-  object Tuple3 {
+  type RhoTuple3 = RhoTuple3.type
+  object RhoTuple3 {
     def apply(tuple: (Par, Par, Par)): Par = ETuple(Seq(tuple._1, tuple._2, tuple._3))
 
     def unapply(p: Par): Option[(Par, Par, Par)] =
-      TupleN.unapply(p).collect { case Seq(a, b, c) => (a, b, c) }
+      RhoTupleN.unapply(p).collect { case Seq(a, b, c) => (a, b, c) }
   }
 
-  type RhoTuple4 = Tuple4.type
-  object Tuple4 {
+  type RhoTuple4 = RhoTuple4.type
+  object RhoTuple4 {
     def apply(tuple: (Par, Par, Par, Par)): Par =
       ETuple(Seq(tuple._1, tuple._2, tuple._3, tuple._4))
 
     def unapply(p: Par): Option[(Par, Par, Par, Par)] =
-      TupleN.unapply(p).collect { case Seq(a, b, c, d) => (a, b, c, d) }
+      RhoTupleN.unapply(p).collect { case Seq(a, b, c, d) => (a, b, c, d) }
   }
 
-  type RhoUri = Uri.type
-  object Uri {
+  type RhoUri = RhoUri.type
+  object RhoUri {
     def unapply(p: Par): Option[String] =
       p.singleExpr().collect {
         case Expr(GUri(s)) => s
@@ -103,8 +103,8 @@ object RhoType {
     def apply(s: String): Par = GUri(s)
   }
 
-  type RhoList = List.type
-  object List {
+  type RhoList = RhoList.type
+  object RhoList {
     def unapply(p: Par): Option[List[Par]] =
       p.singleExpr().collect {
         case Expr(EListBody(EList(s, _, _, _))) => s.toList
@@ -113,8 +113,8 @@ object RhoType {
     def apply(s: List[Par]): Par = EListBody(EList(s))
   }
 
-  type RhoSet = Set.type
-  object Set {
+  type RhoSet = RhoSet.type
+  object RhoSet {
     def unapply(p: Par): Option[Set[Par]] =
       p.singleExpr().collect {
         case Expr(ESetBody(ParSet(s, _, _, _))) => s.toSet
@@ -123,8 +123,8 @@ object RhoType {
     def apply(s: Seq[Par]): Par = ESetBody(ParSet(s))
   }
 
-  type RhoMap = Map.type
-  object Map {
+  type RhoMap = RhoMap.type
+  object RhoMap {
     def unapply(p: Par): Option[Map[Par, Par]] =
       p.singleExpr().collect {
         case Expr(EMapBody(ParMap(s, _, _, _))) => s.toMap
@@ -133,8 +133,8 @@ object RhoType {
     def apply(s: Map[Par, Par]): Par = EMapBody(ParMap(s.toSeq))
   }
 
-  type RhoDeployerId = DeployerId.type
-  object DeployerId {
+  type RhoDeployerId = RhoDeployerId.type
+  object RhoDeployerId {
     def unapply(p: Par): Option[Array[Byte]] =
       p.singleUnforgeable().collect {
         case GUnforgeable(GDeployerIdBody(id)) => id.publicKey.toByteArray
@@ -143,8 +143,8 @@ object RhoType {
     def apply(bytes: Array[Byte]): Par = GDeployerId(bytes.toByteString)
   }
 
-  type RhoDeployId = DeployerId.type
-  object DeployId {
+  type RhoDeployId = RhoDeployerId.type
+  object RhoDeployId {
     def unapply(p: Par): Option[Array[Byte]] =
       p.singleUnforgeable().collect {
         case GUnforgeable(GDeployIdBody(id)) => id.sig.toByteArray
@@ -153,8 +153,8 @@ object RhoType {
     def apply(bytes: Array[Byte]): Par = GDeployId(bytes.toByteString)
   }
 
-  type RhoName = Name.type
-  object Name {
+  type RhoName = RhoName.type
+  object RhoName {
     def unapply(p: Par): Option[GPrivate] =
       p.singleUnforgeable().collect {
         case GUnforgeable(GPrivateBody(gprivate)) => gprivate
@@ -165,14 +165,19 @@ object RhoType {
     def apply(gprivateBytes: ByteString): Par  = apply(GPrivate(gprivateBytes))
   }
 
-  type RhoUnforgeable = Unforgeable.type
-  object Unforgeable {
+  type RhoUnforgeable = RhoUnforgeable.type
+  object RhoUnforgeable {
     def unapply(p: Par): Option[GUnforgeable] = p.singleUnforgeable()
 
     def apply(unforgeable: GUnforgeable): Par = unforgeable
   }
 
-  type RhoExpression = Expression.type
+  type RhoExpression = RhoExpression.type
+  object RhoExpression {
+    def unapply(p: Par): Option[Expr] = p.singleExpr()
+
+    def apply(expr: Expr): Par = expr
+  }
 
   object SysAuthToken {
     def unapply(p: Par): Option[GSysAuthToken] =
@@ -183,12 +188,6 @@ object RhoType {
     def apply(token: GSysAuthToken): Par = GUnforgeable(GSysAuthTokenBody(token))
   }
 
-  object Expression {
-    def unapply(p: Par): Option[Expr] = p.singleExpr()
-
-    def apply(expr: Expr): Par = expr
-  }
-
   sealed abstract class Extractor[RhoType] {
     type ScalaType
     def unapply(p: Par): Option[ScalaType]
@@ -197,45 +196,45 @@ object RhoType {
   object Extractor {
     def derive[RhoType, Aux](implicit ev: Extractor[RhoType] { type ScalaType = Aux }) = ev
 
-    implicit object BooleanExtractor extends Extractor[Boolean.type] {
+    implicit object BooleanExtractor extends Extractor[RhoBoolean.type] {
       override type ScalaType = Boolean
-      override def unapply(p: Par) = Boolean.unapply(p)
+      override def unapply(p: Par) = RhoBoolean.unapply(p)
     }
-    implicit object ByteArrayExtractor extends Extractor[ByteArray.type] {
+    implicit object ByteArrayExtractor extends Extractor[RhoByteArray.type] {
       override type ScalaType = Array[Byte]
-      override def unapply(p: Par) = ByteArray.unapply(p)
+      override def unapply(p: Par) = RhoByteArray.unapply(p)
     }
-    implicit object DeployerIdExtractor extends Extractor[DeployerId.type] {
+    implicit object DeployerIdExtractor extends Extractor[RhoDeployerId.type] {
       override type ScalaType = Array[Byte]
-      override def unapply(p: Par) = DeployerId.unapply(p)
+      override def unapply(p: Par) = RhoDeployerId.unapply(p)
     }
-    implicit object NameExtractor extends Extractor[Name.type] {
+    implicit object NameExtractor extends Extractor[RhoName.type] {
       override type ScalaType = GPrivate
-      override def unapply(p: Par) = Name.unapply(p)
+      override def unapply(p: Par) = RhoName.unapply(p)
     }
-    implicit object NilExtractor extends Extractor[Nil.type] {
+    implicit object NilExtractor extends Extractor[RhoNil.type] {
       override type ScalaType = Unit
-      override def unapply(p: Par) = if (Nil.unapply(p)) Some(()) else None
+      override def unapply(p: Par) = if (RhoNil.unapply(p)) Some(()) else None
     }
-    implicit object NumberExtractor extends Extractor[Number.type] {
+    implicit object NumberExtractor extends Extractor[RhoNumber.type] {
       override type ScalaType = Long
-      override def unapply(p: Par) = Number.unapply(p)
+      override def unapply(p: Par) = RhoNumber.unapply(p)
     }
-    implicit object StringExtractor extends Extractor[String.type] {
+    implicit object StringExtractor extends Extractor[RhoString.type] {
       override type ScalaType = String
-      override def unapply(p: Par) = String.unapply(p)
+      override def unapply(p: Par) = RhoString.unapply(p)
     }
-    implicit object UriExtractor extends Extractor[Uri.type] {
+    implicit object UriExtractor extends Extractor[RhoUri.type] {
       override type ScalaType = String
-      override def unapply(p: Par) = Uri.unapply(p)
+      override def unapply(p: Par) = RhoUri.unapply(p)
     }
-    implicit object UnforgeableExtractor extends Extractor[Unforgeable.type] {
+    implicit object UnforgeableExtractor extends Extractor[RhoUnforgeable.type] {
       override type ScalaType = GUnforgeable
-      override def unapply(p: Par) = Unforgeable.unapply(p)
+      override def unapply(p: Par) = RhoUnforgeable.unapply(p)
     }
-    implicit object ExpressionExtractor extends Extractor[Expression.type] {
+    implicit object ExpressionExtractor extends Extractor[RhoExpression.type] {
       override type ScalaType = Expr
-      override def unapply(p: Par) = Expression.unapply(p)
+      override def unapply(p: Par) = RhoExpression.unapply(p)
     }
 
     implicit def Tuple2Extractor[A, B](
@@ -248,7 +247,7 @@ object RhoType {
         override type ScalaType = (A.ScalaType, B.ScalaType)
         override def unapply(p: Par) =
           for {
-            (p1, p2) <- Tuple2.unapply(p)
+            (p1, p2) <- RhoTuple2.unapply(p)
             a        <- A.unapply(p1)
             b        <- B.unapply(p2)
           } yield (a, b)

--- a/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala
@@ -143,7 +143,7 @@ object RhoType {
     def apply(bytes: Array[Byte]): Par = GDeployerId(bytes.toByteString)
   }
 
-  type RhoDeployId = RhoDeployerId.type
+  type RhoDeployId = RhoDeployId.type
   object RhoDeployId {
     def unapply(p: Par): Option[Array[Byte]] =
       p.singleUnforgeable().collect {

--- a/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala
+++ b/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala
@@ -1,4 +1,4 @@
-package coop.rchain.rholang.interpreter
+package coop.rchain.models.rholang
 
 import com.google.protobuf.ByteString
 import coop.rchain.models.Expr.ExprInstance._

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -389,13 +389,12 @@ object WebApi {
 
   private def toDataAtNameResponse(req: (Seq[DataWithBlockInfo], Int)): DataAtNameResponse = {
     val (dbs, length) = req
-    val exprsWithBlock = dbs.foldLeft(collection.immutable.List[RhoExprWithBlock]()) {
-      (acc, data) =>
-        val exprs = data.postBlockData.flatMap(exprFromParProto)
-        // Implements semantic of Par with Unit: P | Nil ==> P
-        val expr  = if (exprs.size == 1) exprs.head else ExprPar(exprs.toList)
-        val block = data.block
-        RhoExprWithBlock(expr, block) +: acc
+    val exprsWithBlock = dbs.foldLeft(List[RhoExprWithBlock]()) { (acc, data) =>
+      val exprs = data.postBlockData.flatMap(exprFromParProto)
+      // Implements semantic of Par with Unit: P | Nil ==> P
+      val expr  = if (exprs.size == 1) exprs.head else ExprPar(exprs.toList)
+      val block = data.block
+      RhoExprWithBlock(expr, block) +: acc
     }
     DataAtNameResponse(exprsWithBlock, length)
   }

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -361,24 +361,24 @@ object WebApi {
   def rhoExprToParProto(exp: RhoExpr): Par = exp match {
     // Nested expressions (Par, Tuple, List and Set are converted to JSON list)
     case ExprPar(data)   => data.map(rhoExprToParProto).combineAll
-    case ExprTuple(data) => TupleN(data.map(rhoExprToParProto))
-    case ExprList(data)  => List(data.map(rhoExprToParProto))
-    case ExprSet(data)   => Set(data.map(rhoExprToParProto).toSeq)
-    case ExprMap(data)   => Map(data.map { case (k, v) => (String(k), rhoExprToParProto(v)) })
+    case ExprTuple(data) => RhoTupleN(data.map(rhoExprToParProto))
+    case ExprList(data)  => RhoList(data.map(rhoExprToParProto))
+    case ExprSet(data)   => RhoSet(data.map(rhoExprToParProto).toSeq)
+    case ExprMap(data)   => RhoMap(data.map { case (k, v) => (RhoString(k), rhoExprToParProto(v)) })
     // Terminal expressions (here is the data)
-    case ExprBool(data)   => Boolean(data)
-    case ExprInt(data)    => Number(data)
-    case ExprString(data) => String(data)
-    case ExprUri(data)    => Uri(data)
+    case ExprBool(data)   => RhoBoolean(data)
+    case ExprInt(data)    => RhoNumber(data)
+    case ExprString(data) => RhoString(data)
+    case ExprUri(data)    => RhoUri(data)
     // Binary data is decoded from base16 string
-    case ExprBytes(data)  => ByteArray(data.unsafeHexToByteString.toByteArray)
+    case ExprBytes(data)  => RhoByteArray(data.unsafeHexToByteString.toByteArray)
     case ExprUnforg(data) => unforgToParProto(data)
   }
 
   private def unforgToParProto(unforg: RhoUnforg): Par = unforg match {
-    case UnforgPrivate(name)  => Name(name.unsafeHexToByteString)
-    case UnforgDeploy(name)   => DeployId(name.unsafeDecodeHex)
-    case UnforgDeployer(name) => DeployerId(name.unsafeDecodeHex)
+    case UnforgPrivate(name)  => RhoName(name.unsafeHexToByteString)
+    case UnforgDeploy(name)   => RhoDeployId(name.unsafeDecodeHex)
+    case UnforgDeployer(name) => RhoDeployerId(name.unsafeDecodeHex)
   }
 
   // Data request/response protobuf wrappers

--- a/node/src/main/scala/coop/rchain/node/api/WebApi.scala
+++ b/node/src/main/scala/coop/rchain/node/api/WebApi.scala
@@ -8,12 +8,12 @@ import coop.rchain.casper.api.BlockApi
 import coop.rchain.casper.protocol.{BlockInfo, DataWithBlockInfo, DeployData, LightBlockInfo}
 import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.signatures.{SignaturesAlg, Signed}
+import coop.rchain.models.rholang.RhoType._
 import coop.rchain.models.rholang.implicits.VectorPar
 import coop.rchain.models.syntax._
-import coop.rchain.models.{Bundle, ETuple, Expr, GUnforgeable, Par}
+import coop.rchain.models.{Bundle, Expr, GUnforgeable, Par}
 import coop.rchain.node.api.WebApi._
 import coop.rchain.node.web.{CacheTransactionAPI, TransactionResponse}
-import coop.rchain.rholang.interpreter.RhoType._
 
 trait WebApi[F[_]] {
   def status: F[ApiStatus]

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/RhoTrieTraverser.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/RhoTrieTraverser.scala
@@ -2,25 +2,15 @@ package coop.rchain.node.revvaultexport
 
 import cats.effect.Sync
 import cats.implicits._
-import com.google.protobuf.ByteString
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.casper.genesis.contracts.StandardDeploys
-import coop.rchain.casper.rholang.RuntimeManager.emptyStateHashFixed
-import coop.rchain.casper.rholang.{BlockRandomSeed, Tools}
-import coop.rchain.crypto.PublicKey
 import coop.rchain.crypto.hash.Keccak256
 import coop.rchain.models.Expr.ExprInstance._
-import coop.rchain.models.GUnforgeable.UnfInstance.GPrivateBody
 import coop.rchain.models._
-import coop.rchain.models.syntax._
-import coop.rchain.rholang.interpreter.RhoType.Name
+import coop.rchain.models.rholang.RhoType
+import coop.rchain.rholang.interpreter.RhoRuntime
 import coop.rchain.rholang.interpreter.storage.serializePar
-import coop.rchain.rholang.interpreter.{RhoRuntime, RhoType}
-import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.shared.Serialize
 
 import scala.annotation.tailrec
-import scala.collection.compat.immutable.LazyList
 
 /**
   * Traverse a Rholang Trie.

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/RhoTrieTraverser.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/RhoTrieTraverser.scala
@@ -18,7 +18,7 @@ import scala.annotation.tailrec
   * According to the trie implemenetation in rholang, the methods below are hacks in scala to traverse the trie.
   */
 object RhoTrieTraverser {
-  private def keccakHash(input: Array[Byte]): Par = RhoType.ByteArray(Keccak256.hash(input))
+  private def keccakHash(input: Array[Byte]): Par = RhoType.RhoByteArray(Keccak256.hash(input))
   private val depthEach                           = Vector(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
   private val powers =
     List(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536)

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/StateBalances.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/StateBalances.scala
@@ -5,17 +5,13 @@ import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.casper.rholang.BlockRandomSeed
-import coop.rchain.casper.rholang.RuntimeManager.emptyStateHashFixed
+import coop.rchain.casper.BlockRandomSeed
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager
 import coop.rchain.metrics.{Metrics, NoopSpan}
-import coop.rchain.models.syntax._
-import coop.rchain.models.{BindPattern, ListParWithRandom, Par, TaggedContinuation}
 import coop.rchain.models.Expr.ExprInstance.{ETupleBody, GString}
-import coop.rchain.models.{ETuple, Expr}
+import coop.rchain.models.syntax._
+import coop.rchain.models._
 import coop.rchain.rholang.interpreter.RhoRuntime
-import coop.rchain.rholang.interpreter.RhoType.Name
 import coop.rchain.rspace.syntax._
 import coop.rchain.rspace.{Match, RSpace}
 import coop.rchain.shared.Log

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/StateBalances.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/StateBalances.scala
@@ -5,7 +5,7 @@ import cats.effect.{Concurrent, ContextShift, Sync}
 import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
-import coop.rchain.casper.BlockRandomSeed
+import coop.rchain.casper.rholang.BlockRandomSeed
 import coop.rchain.casper.storage.RNodeKeyValueStoreManager
 import coop.rchain.metrics.{Metrics, NoopSpan}
 import coop.rchain.models.Expr.ExprInstance.{ETupleBody, GString}

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/mainnet1/StateBalanceMain.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/mainnet1/StateBalanceMain.scala
@@ -1,14 +1,11 @@
 package coop.rchain.node.revvaultexport.mainnet1
 
 import cats.effect._
-import coop.rchain.casper.genesis.Genesis
-import coop.rchain.crypto.PublicKey
+import coop.rchain.models.Par
+import coop.rchain.models.rholang.RhoType.Name
 import coop.rchain.models.syntax._
-import coop.rchain.models.{GPrivate, Par}
 import coop.rchain.node.revvaultexport.StateBalances
 import coop.rchain.shared.Base16
-import coop.rchain.models.syntax._
-import coop.rchain.rholang.interpreter.RhoType.Name
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.rogach.scallop.ScallopConf
@@ -59,7 +56,6 @@ final case class StateOptions(arguments: Seq[String]) extends ScallopConf(argume
 
 }
 object StateBalanceMain {
-  import coop.rchain.models.rholang.implicits._
 
   // hard-coded value in RevVault.rho
   val genesisVaultMapDepth = 2

--- a/node/src/main/scala/coop/rchain/node/revvaultexport/mainnet1/StateBalanceMain.scala
+++ b/node/src/main/scala/coop/rchain/node/revvaultexport/mainnet1/StateBalanceMain.scala
@@ -2,7 +2,7 @@ package coop.rchain.node.revvaultexport.mainnet1
 
 import cats.effect._
 import coop.rchain.models.Par
-import coop.rchain.models.rholang.RhoType.Name
+import coop.rchain.models.rholang.RhoType.RhoName
 import coop.rchain.models.syntax._
 import coop.rchain.node.revvaultexport.StateBalances
 import coop.rchain.shared.Base16
@@ -62,7 +62,7 @@ object StateBalanceMain {
 
   // TODO support mainnet1 and mainnetx
   val mainnet1VaultMapPar: Par =
-    Name("af4c5fc5336f34ded026393db44916a664a5dc7e48027448f278b62ce902deda".unsafeDecodeHex)
+    RhoName("af4c5fc5336f34ded026393db44916a664a5dc7e48027448f278b62ce902deda".unsafeDecodeHex)
 
   @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
   def main(args: Array[String]): Unit = {

--- a/node/src/test/scala/coop/rchain/node/revvaultexport/RhoTrieTraverserTest.scala
+++ b/node/src/test/scala/coop/rchain/node/revvaultexport/RhoTrieTraverserTest.scala
@@ -8,7 +8,7 @@ import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
-import coop.rchain.models.rholang.RhoType.Name
+import coop.rchain.models.rholang.RhoType.RhoName
 import coop.rchain.models.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
@@ -72,7 +72,7 @@ class RhoTrieTraverserTest extends AnyFlatSpec {
           storeToken = {
             val r      = rand.copy()
             val target = LazyList.continually(r.next()).drop(9).head
-            Name(target)
+            RhoName(target)
           }
           rd <- runtime.processDeploy(
                  StandardDeploys.registryGenerator(registry, SHARD_ID),

--- a/node/src/test/scala/coop/rchain/node/revvaultexport/RhoTrieTraverserTest.scala
+++ b/node/src/test/scala/coop/rchain/node/revvaultexport/RhoTrieTraverserTest.scala
@@ -1,21 +1,17 @@
 package coop.rchain.node.revvaultexport
 
 import cats.effect.Concurrent
-import com.google.protobuf.ByteString
 import coop.rchain.casper.genesis.contracts.{Registry, StandardDeploys}
 import coop.rchain.casper.helper.TestNode.Effect
 import coop.rchain.casper.helper.TestRhoRuntime.rhoRuntimeEff
 import coop.rchain.casper.syntax._
-import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
+import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
-import coop.rchain.models.GUnforgeable.UnfInstance.GPrivateBody
-import coop.rchain.models.{GPrivate, GUnforgeable, Par}
-import coop.rchain.rspace.hashing.Blake2b256Hash
+import coop.rchain.models.rholang.RhoType.Name
+import coop.rchain.models.syntax._
 import coop.rchain.shared.Log
 import monix.eval.Task
-import coop.rchain.models.syntax._
-import coop.rchain.rholang.interpreter.RhoType.Name
 import monix.execution.Scheduler.Implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -11,6 +11,7 @@ import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.models.Var.VarInstance
 import coop.rchain.models.Var.VarInstance.{BoundVar, FreeVar, Wildcard}
 import coop.rchain.models._
+import coop.rchain.models.rholang.RhoType
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.serialization.implicits._
 import coop.rchain.models.syntax._

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -413,10 +413,10 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
           neu.injections
             .get(urn)
             .map {
-              case RhoType.Unforgeable(GUnforgeable(unfInstance)) if unfInstance.isDefined =>
+              case RhoType.RhoUnforgeable(GUnforgeable(unfInstance)) if unfInstance.isDefined =>
                 newEnv.put(unfInstance).asRight[InterpreterError]
 
-              case RhoType.Expression(Expr(exprInstance)) if exprInstance.isDefined =>
+              case RhoType.RhoExpression(Expr(exprInstance)) if exprInstance.isDefined =>
                 newEnv.put(exprInstance).asRight[InterpreterError]
 
               case _ =>
@@ -1531,7 +1531,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
         locallyFree: Coeval[BitSet],
         remainder: Option[Var]
     ) = {
-      val keyPairs = ps.map(RhoType.Tuple2.unapply)
+      val keyPairs = ps.map(RhoType.RhoTuple2.unapply)
       if (keyPairs.exists(_.isEmpty))
         MethodNotDefined("toMap", "types except List[(K,V)]").raiseError[M, Par]
       else

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rholang.interpreter
 
-import cats.effect.{Concurrent, Sync}
+import cats.effect.Concurrent
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
 import com.google.protobuf.ByteString
@@ -11,10 +11,11 @@ import coop.rchain.crypto.hash.{Blake2b256, Keccak256, Sha256}
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
 import coop.rchain.metrics.Span
 import coop.rchain.models._
+import coop.rchain.models.rholang.RhoType
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.interpreter.RhoRuntime.RhoTuplespace
-import coop.rchain.rholang.interpreter.registry.Registry
 import coop.rchain.rholang.interpreter.RholangAndScalaDispatcher.RhoDispatch
+import coop.rchain.rholang.interpreter.registry.Registry
 import coop.rchain.rholang.interpreter.util.RevAddress
 import coop.rchain.rspace.{ContResult, Result}
 import coop.rchain.shared.Base16

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/SystemProcesses.scala
@@ -325,8 +325,8 @@ object SystemProcesses {
             Seq(RhoType.RhoString("check"), argument, ack)
             ) =>
           val response = argument match {
-            case RhoType.SysAuthToken(_) => RhoType.RhoBoolean(true)
-            case _                       => RhoType.RhoBoolean(false)
+            case RhoType.RhoSysAuthToken(_) => RhoType.RhoBoolean(true)
+            case _                          => RhoType.RhoBoolean(false)
           }
           produce(Seq(response), ack)
       }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.ListParWithRandom
-import coop.rchain.models.rholang.RhoType.Number
+import coop.rchain.models.rholang.RhoType.RhoNumber
 import coop.rchain.rholang.interpreter.storage
 import coop.rchain.rspace.hashing.Blake2b256Hash.codecBlake2b256Hash
 import coop.rchain.rspace.hashing.{Blake2b256Hash, StableHashProvider}
@@ -140,7 +140,7 @@ object RholangMergingLogic {
       s"Number channel should contain single Int term, found ${parWithRnd.pars}."
     })
 
-    val Number(num) = parWithRnd.pars.head
+    val RhoNumber(num) = parWithRnd.pars.head
 
     (num, parWithRnd.randomState)
   }
@@ -151,7 +151,7 @@ object RholangMergingLogic {
       rnd: Blake2b512Random
   ): ByteVector = {
     // Create value with random generator
-    val numPar     = Number(num)
+    val numPar     = RhoNumber(num)
     val parWithRnd = ListParWithRandom(Seq(numPar), rnd)
     // Create hash of the data
     val dataHash = StableHashProvider.hash(channelHash.bytes, parWithRnd, persist = false)(

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/merging/RholangMergingLogic.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 import com.google.protobuf.ByteString
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.models.ListParWithRandom
-import coop.rchain.rholang.interpreter.RhoType.Number
+import coop.rchain.models.rholang.RhoType.Number
 import coop.rchain.rholang.interpreter.storage
 import coop.rchain.rspace.hashing.Blake2b256Hash.codecBlake2b256Hash
 import coop.rchain.rspace.hashing.{Blake2b256Hash, StableHashProvider}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -4,15 +4,14 @@ import cats.Parallel
 import cats.effect.Sync
 import cats.effect.concurrent.Ref
 import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.models.syntax._
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.Expr.ExprInstance.{EVarBody, GString}
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
+import coop.rchain.models.rholang.RhoType.Name
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.Resources.mkRhoISpace
 import coop.rchain.rholang.interpreter.RhoRuntime.{RhoISpace, RhoTuplespace}
-import coop.rchain.rholang.interpreter.RhoType.Name
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
 import coop.rchain.rholang.interpreter.storage.{ISpaceStub, _}

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CostAccountingReducerTest.scala
@@ -8,13 +8,13 @@ import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.Expr.ExprInstance.{EVarBody, GString}
 import coop.rchain.models.Var.VarInstance.FreeVar
 import coop.rchain.models._
-import coop.rchain.models.rholang.RhoType.Name
+import coop.rchain.models.rholang.RhoType.RhoName
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.rholang.Resources.mkRhoISpace
 import coop.rchain.rholang.interpreter.RhoRuntime.{RhoISpace, RhoTuplespace}
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.errors.OutOfPhlogistonsError
-import coop.rchain.rholang.interpreter.storage.{ISpaceStub, _}
+import coop.rchain.rholang.interpreter.storage._
 import coop.rchain.rspace._
 import coop.rchain.rspace.internal.{Datum, Row}
 import coop.rchain.shared.Log
@@ -41,7 +41,7 @@ class CostAccountingReducerTest extends AnyFlatSpec with Matchers with TripleEqu
       urnMap: Map[String, Par]
   ): (Dispatch[M, ListParWithRandom, TaggedContinuation], Reduce[M]) = {
     val emptyMergeableRef = Ref.unsafe[M, Set[Par]](Set.empty)
-    val dummyMergeableTag = Name(Array[Byte]())
+    val dummyMergeableTag = RhoName(Array[Byte]())
     RholangAndScalaDispatcher(
       tuplespace,
       dispatchTable,

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -102,7 +102,7 @@ class CryptoChannelsSpec
       val byteArrayToSend: Par     = GByteArray(ByteString.copyFrom(toByteArray))
       val data: List[Par]          = List(byteArrayToSend, ackChannel)
       val send                     = Send(hashChannel, data, persistent = false, BitSet())
-      val expected                 = RhoType.ByteArray(hashFn(toByteArray))
+      val expected                 = RhoType.RhoByteArray(hashFn(toByteArray))
 
       // Send byte array on hash channel. This should:
       // 1. meet with the system process in the tuplespace

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -10,6 +10,7 @@ import coop.rchain.models.Expr.ExprInstance.{GBool, GByteArray, GString}
 import coop.rchain.models.Var.VarInstance.Wildcard
 import coop.rchain.models.Var.WildcardMsg
 import coop.rchain.models._
+import coop.rchain.models.rholang.RhoType
 import coop.rchain.models.rholang.implicits._
 import coop.rchain.models.testImplicits._
 import coop.rchain.rholang.Resources


### PR DESCRIPTION
## Overview

Small refactoring. [RhoType.scala](https://github.com/rchain/rchain/blob/8ec21031aab5553c8cfd2db631712089ad2a7665/models/src/main/scala/coop/rchain/models/rholang/RhoType.scala) moved to `models`. `Rho` prefix added to types to avoid overlap with built-in types.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
