### PR TITLE
Remove custom unsafeRunSync as duplicated from Task

### DIFF
--- a/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
+++ b/casper/src/slowcooker/scala/coop.rchain.casper/HashSetCasperSpecification.scala
@@ -8,7 +8,6 @@ import coop.rchain.casper.helper.TestNode
 import coop.rchain.casper.helper.TestNode._
 import coop.rchain.casper.protocol.{BlockMessage, DeployData}
 import coop.rchain.casper.util.{ConstructDeploy, GenesisBuilder}
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.signatures.Signed
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
@@ -62,7 +61,7 @@ object HashSetCasperActions {
     ConstructDeploy.sourceDeploy(s"new x in { x!(0) }", ts, shardId = "root")
 
   implicit class EffectOps[A](f: Effect[A]) {
-    def result: A = f.unsafeRunSync
+    def result: A = f.runSyncUnsafe()
   }
 }
 

--- a/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/addblock/MultiParentCasperAddBlockSpec.scala
@@ -67,7 +67,7 @@ class MultiParentCasperAddBlockSpec extends AnyFlatSpec with Matchers with Inspe
 //        } yield result
 //      }
 //    val threadStatuses: (ValidBlockProcessing, ValidBlockProcessing) =
-//      testProgram.unsafeRunSync(scheduler)
+//      testProgram.runSyncUnsafe()
 //
 //    threadStatuses should matchPattern {
 //      case (Left(CasperIsBusy), Right(Valid)) | (Right(Valid), Left(CasperIsBusy)) =>

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -10,7 +10,7 @@ import coop.rchain.casper._
 import coop.rchain.casper.helper.{BlockApiFixture, BlockDagStorageFixture}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkRuntimeManager
-import coop.rchain.casper.rholang.RuntimeManager
+import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.blockImplicits.getRandomBlock

--- a/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/api/BlockQueryResponseAPITest.scala
@@ -10,7 +10,7 @@ import coop.rchain.casper._
 import coop.rchain.casper.helper.{BlockApiFixture, BlockDagStorageFixture}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkRuntimeManager
-import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
+import coop.rchain.casper.rholang.RuntimeManager
 import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.blockImplicits.getRandomBlock

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -6,7 +6,7 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
-import coop.rchain.casper.rholang.{Resources, RuntimeManager}
+import coop.rchain.casper.rholang.{BlockRandomSeed, Resources, RuntimeManager}
 import coop.rchain.casper.util.GenesisBuilder.GenesisContext
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP
@@ -50,7 +50,7 @@ trait BlockDagStorageFixture extends BeforeAndAfter { self: Suite =>
     implicit val metrics = new MetricsNOP[Task]()
     implicit val log     = Log.log[Task]
 
-    BlockDagStorageTestFixture.withStorageF[Task, R](f).runSyncUnsafe()
+    BlockDagStorageTestFixture.withStorageF[Task].use(Function.uncurried(f).tupled).runSyncUnsafe()
   }
 }
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/BlockDagStorageFixture.scala
@@ -6,7 +6,7 @@ import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper.dag.BlockDagKeyValueStorage
-import coop.rchain.casper.rholang.{BlockRandomSeed, Resources, RuntimeManager}
+import coop.rchain.casper.rholang.{Resources, RuntimeManager}
 import coop.rchain.casper.util.GenesisBuilder.GenesisContext
 import coop.rchain.metrics.Metrics
 import coop.rchain.metrics.Metrics.MetricsNOP
@@ -50,7 +50,7 @@ trait BlockDagStorageFixture extends BeforeAndAfter { self: Suite =>
     implicit val metrics = new MetricsNOP[Task]()
     implicit val log     = Log.log[Task]
 
-    BlockDagStorageTestFixture.withStorageF[Task].use(Function.uncurried(f).tupled).runSyncUnsafe()
+    BlockDagStorageTestFixture.withStorageF[Task, R](f).runSyncUnsafe()
   }
 }
 

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -9,9 +9,7 @@ import coop.rchain.casper.genesis.contracts._
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkTestRNodeStoreManager
 import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
-import coop.rchain.casper.rholang.{Resources, RuntimeManager}
 import coop.rchain.casper.util.ConstructDeploy._
-import coop.rchain.casper.{BlockRandomSeed, ValidatorIdentity}
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.metrics

--- a/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/GenesisBuilder.scala
@@ -11,7 +11,7 @@ import coop.rchain.casper.rholang.Resources.mkTestRNodeStoreManager
 import coop.rchain.casper.rholang.{BlockRandomSeed, RuntimeManager}
 import coop.rchain.casper.rholang.{Resources, RuntimeManager}
 import coop.rchain.casper.util.ConstructDeploy._
-import coop.rchain.catscontrib.TaskContrib.TaskOps
+import coop.rchain.casper.{BlockRandomSeed, ValidatorIdentity}
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.crypto.{PrivateKey, PublicKey}
 import coop.rchain.metrics
@@ -191,7 +191,8 @@ object GenesisBuilder {
       _               <- blockStore.put(genesis.blockHash, genesis)
       blockDagStorage <- BlockDagKeyValueStorage.create[Task](kvsManager)
       _               <- blockDagStorage.insert(genesis, invalid = false, approved = true)
-    } yield GenesisContext(genesis, validavalidatorKeyPairs, genesisVaults, storageDirectory)).unsafeRunSync
+    } yield GenesisContext(genesis, validavalidatorKeyPairs, genesisVaults, storageDirectory))
+      .runSyncUnsafe()
   }
 
   case class GenesisContext(

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CommUtilSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CommUtilSpec.scala
@@ -46,7 +46,7 @@ class CommUtilSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
           implicit val connectionsCell = initConnectionsCell(connections = peers)
           implicit val commUtil        = CommUtil.of[Task]
           // when
-          CommUtil[Task].sendBlockRequest(hash).unsafeRunSync
+          CommUtil[Task].sendBlockRequest(hash).runSyncUnsafe()
           // then
           val requested = transport.requests
             .map(_.msg)
@@ -68,7 +68,7 @@ class CommUtilSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
           implicit val connectionsCell = initConnectionsCell(connections = peers)
           implicit val commUtil        = CommUtil.of[Task]
           // when
-          CommUtil[Task].sendBlockRequest(hash).unsafeRunSync
+          CommUtil[Task].sendBlockRequest(hash).runSyncUnsafe()
           // then
           log.infos contains (s"Requested missing block ${PrettyPrinter.buildString(hash)} from peers")
         }
@@ -78,9 +78,9 @@ class CommUtilSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
           implicit val connectionsCell = initConnectionsCell()
           implicit val commUtil        = CommUtil.of[Task]
           // when
-          CommUtil[Task].sendBlockRequest(hash).unsafeRunSync
+          CommUtil[Task].sendBlockRequest(hash).runSyncUnsafe()
           // then
-          requestedBlocks.read.unsafeRunSync.contains(hash) should be(true)
+          requestedBlocks.read.runSyncUnsafe().contains(hash) should be(true)
         }
       }
       describe("if given block was already requested") {
@@ -99,7 +99,7 @@ class CommUtilSpec extends AnyFunSpec with BeforeAndAfterEach with Matchers {
           implicit val connectionsCell = initConnectionsCell(connections = peers)
           implicit val commUtil        = CommUtil.of[Task]
           // when
-          CommUtil[Task].sendBlockRequest(hash).unsafeRunSync
+          CommUtil[Task].sendBlockRequest(hash).runSyncUnsafe()
           // then
           transport.requests.size shouldBe 0
           log.infos.size shouldBe 0

--- a/casper/src/test/scala/coop/rchain/casper/util/comm/CommUtilSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/util/comm/CommUtilSpec.scala
@@ -3,7 +3,6 @@ package coop.rchain.casper.engine
 import com.google.protobuf.ByteString
 import coop.rchain.casper.PrettyPrinter
 import coop.rchain.casper.protocol.{CommUtil, _}
-import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.catscontrib.ski._
 import coop.rchain.comm.CommError._
 import coop.rchain.comm.protocol.routing.Protocol

--- a/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
+++ b/comm/src/test/scala/coop/rchain/comm/transport/StreamHandlerSpec.scala
@@ -104,7 +104,7 @@ class StreamHandlerSpec extends AnyFunSpec with Matchers with Inside {
   ): StreamMessage =
     StreamHandler
       .handleStream(stream, circuitBreaker = neverBreak, cache)
-      .unsafeRunSync
+      .runSyncUnsafe()
       .right
       .get
 
@@ -115,7 +115,7 @@ class StreamHandlerSpec extends AnyFunSpec with Matchers with Inside {
   ): StreamHandler.StreamError =
     StreamHandler
       .handleStream(stream, circuitBreaker = circuitBreaker, cache)
-      .unsafeRunSync
+      .runSyncUnsafe()
       .left
       .get
 

--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -1,6 +1,5 @@
 package coop.rchain.node
 
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.node.configuration._
 import coop.rchain.node.effects._
 import coop.rchain.node.runtime.NodeMain
@@ -35,17 +34,17 @@ object Main {
 
     // Ensure terminal is restored on exit
     sys.addShutdownHook {
-      console.close.unsafeRunSync
+      console.close.runSyncUnsafe()
     }
 
     // Parse CLI options
     val options = commandline.Options(args)
     if (options.subcommand.contains(options.run))
       // Start the node
-      NodeMain.startNode[Task](options).unsafeRunSync
+      NodeMain.startNode[Task](options).runSyncUnsafe()
     //or
     else
       // Execute CLI command
-      NodeMain.runCLI[Task](options).unsafeRunSync
+      NodeMain.runCLI[Task](options).runSyncUnsafe()
   }
 }

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/RholangCLI.scala
@@ -3,7 +3,6 @@ package coop.rchain.rholang.interpreter
 import cats._
 import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models._
 import coop.rchain.rholang.interpreter.accounting._
@@ -12,7 +11,6 @@ import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rholang.interpreter.storage.StoragePrinter
 import coop.rchain.rholang.syntax._
 import coop.rchain.rspace.syntax._
-import coop.rchain.sdk.syntax.all._
 import coop.rchain.shared.Log
 import coop.rchain.store.LmdbDirStoreManager.{mb, Db, LmdbEnvConfig}
 import coop.rchain.store.{KeyValueStoreManager, LmdbDirStoreManager}
@@ -73,7 +71,7 @@ object RholangCLI {
     val runtime = (for {
       store   <- kvm.rSpaceStores
       runtime <- RhoRuntime.createRuntime[Task](store, Par())
-    } yield runtime).unsafeRunSync
+    } yield runtime).runSyncUnsafe()
 
     val problems = try {
       if (conf.files.supplied) {
@@ -180,7 +178,7 @@ object RholangCLI {
     printPrompt()
     Option(scala.io.StdIn.readLine()) match {
       case Some(line) =>
-        evaluate(runtime, line).unsafeRunSync
+        evaluate(runtime, line).runSyncUnsafe()
       case None =>
         Console.println("\nExiting...")
         return
@@ -288,7 +286,7 @@ object RholangCLI {
 
     Try(waitForSuccess(evaluatorTask.runToFuture)).map { _ok =>
       if (!quiet) {
-        printStorageContents(runtime, unmatchedSendsOnly).unsafeRunSync
+        printStorageContents(runtime, unmatchedSendsOnly).runSyncUnsafe()
       }
     }
   }

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/CryptoChannelsSpec.scala
@@ -1,7 +1,6 @@
 package coop.rchain.rholang.interpreter
 
 import com.google.protobuf.ByteString
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.{Blake2b256, Blake2b512Random, Keccak256, Sha256}
 import coop.rchain.crypto.signatures.{Ed25519, Secp256k1}
 import coop.rchain.metrics
@@ -22,9 +21,9 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
-import org.scalatest.{Assertion, Outcome}
 import org.scalatest.flatspec.FixtureAnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{Assertion, Outcome}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import java.nio.file.Files
@@ -226,7 +225,7 @@ class CryptoChannelsSpec
       spaces                      <- Resources.createRuntimes[Task](store)
       (runtime, replayRuntime, _) = spaces
       _                           <- runtime.cost.set(Cost.UNSAFE_MAX)
-    } yield runtime).unsafeRunSync
+    } yield runtime).runSyncUnsafe()
 
     try {
       test(runtime)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/PersistentStoreTester.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/PersistentStoreTester.scala
@@ -1,6 +1,5 @@
 package coop.rchain.rholang.interpreter
 
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.{BindPattern, ListParWithRandom, Par, TaggedContinuation}
@@ -27,13 +26,13 @@ trait PersistentStoreTester {
     implicit val metricsEff: Metrics[Task] = new metrics.Metrics.MetricsNOP[Task]
     implicit val noopSpan: Span[Task]      = NoopSpan[Task]()
 
-    implicit val cost = CostAccounting.emptyCost[Task].unsafeRunSync
+    implicit val cost = CostAccounting.emptyCost[Task].runSyncUnsafe()
     implicit val m    = matchListPar[Task]
     implicit val kvm  = InMemoryStoreManager[Task]
-    val store         = kvm.rSpaceStores.unsafeRunSync
+    val store         = kvm.rSpaceStores.runSyncUnsafe()
     val space = RSpace
       .create[Task, Par, BindPattern, ListParWithRandom, TaggedContinuation](store)
-      .unsafeRunSync
+      .runSyncUnsafe()
     val reducer = RholangOnlyDispatcher(space)._2
     cost.set(Cost.UNSAFE_MAX).runSyncUnsafe(1.second)
 

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/ReduceSpec.scala
@@ -2,7 +2,6 @@ package coop.rchain.rholang.interpreter
 
 import cats.syntax.all._
 import com.google.protobuf.ByteString
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.Connective.ConnectiveInstance._
@@ -11,18 +10,18 @@ import coop.rchain.models.TaggedContinuation.TaggedCont.ParBody
 import coop.rchain.models.Var.VarInstance._
 import coop.rchain.models._
 import coop.rchain.models.rholang.implicits._
+import coop.rchain.models.syntax._
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rholang.interpreter.errors._
 import coop.rchain.rholang.interpreter.storage._
 import coop.rchain.rspace.internal.{Datum, Row, WaitingContinuation}
-import coop.rchain.models.syntax._
 import coop.rchain.shared.{Base16, Serialize}
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
-import org.scalatest.prop.TableDrivenPropertyChecks._
-import org.scalatest.{AppendedClues, Assertion}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks._
+import org.scalatest.{AppendedClues, Assertion}
 
 import scala.collection.SortedSet
 import scala.collection.immutable.BitSet
@@ -875,7 +874,7 @@ class ReduceSpec extends AnyFlatSpec with Matchers with AppendedClues with Persi
 
     val result = withTestSpace {
       case TestFixture(space, _) =>
-        implicit val cost          = CostAccounting.emptyCost[Task].unsafeRunSync
+        implicit val cost          = CostAccounting.emptyCost[Task].runSyncUnsafe()
         def byteName(b: Byte): Par = GPrivate(ByteString.copyFrom(Array[Byte](b)))
         val reducer                = RholangOnlyDispatcher(space, Map("rho:test:foo" -> byteName(42)))._2
         cost.set(Cost.UNSAFE_MAX).runSyncUnsafe(1.second)

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/accounting/RholangMethodsCostsSpec.scala
@@ -16,9 +16,9 @@ import coop.rchain.store.InMemoryStoreManager
 import monix.eval.Task
 import monix.execution.Scheduler.Implicits.global
 import org.scalactic.TripleEqualsSupport
-import org.scalatest.{Assertion, BeforeAndAfterAll}
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{Assertion, BeforeAndAfterAll}
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks._
 
 import java.nio.file.{Files, Path}
@@ -1043,13 +1043,12 @@ class RholangMethodsCostsSpec
   implicit val kvm                        = InMemoryStoreManager[Task]
   val rSpaceStore                         = kvm.rSpaceStores.runSyncUnsafe()
   protected override def beforeAll(): Unit = {
-    import coop.rchain.catscontrib.TaskContrib._
     import coop.rchain.rholang.interpreter.storage._
     implicit val m: Match[Task, BindPattern, ListParWithRandom] = matchListPar[Task]
     dbDir = Files.createTempDirectory("rholang-interpreter-test-")
     space = RSpace
       .create[Task, Par, BindPattern, ListParWithRandom, TaggedContinuation](rSpaceStore)
-      .unsafeRunSync
+      .runSyncUnsafe()
   }
 
   protected override def afterAll(): Unit = {

--- a/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
+++ b/rholang/src/test/scala/coop/rchain/rholang/interpreter/matcher/MatcherMonadSpec.scala
@@ -4,7 +4,6 @@ import cats.effect._
 import cats.mtl.implicits._
 import cats.syntax.all._
 import cats.{Alternative, Foldable, MonoidK, SemigroupK}
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.metrics.Metrics
 import coop.rchain.models.Par
 import coop.rchain.rholang.interpreter._
@@ -25,7 +24,7 @@ class MatcherMonadSpec extends AnyFlatSpec with Matchers {
 
   val A: Alternative[F] = Alternative[F]
 
-  implicit val cost = CostAccounting.emptyCost[Task].unsafeRunSync
+  implicit val cost = CostAccounting.emptyCost[Task].runSyncUnsafe()
 
   implicit val costF: _cost[F]   = matcherMonadCostLog[Task]
   implicit val matcherMonadError = implicitly[Sync[F]]
@@ -38,7 +37,7 @@ class MatcherMonadSpec extends AnyFlatSpec with Matchers {
       _        <- cost.set(Cost(phlo, "initial cost"))
       result   <- f
       phloLeft <- cost.get
-    } yield (phloLeft, result)).unsafeRunSync
+    } yield (phloLeft, result)).runSyncUnsafe()
 
   behavior of "MatcherMonad"
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/BasicBench.scala
@@ -1,7 +1,6 @@
 package coop.rchain.rspace.bench
 
 import cats.effect.{ContextShift, Sync}
-import coop.rchain.catscontrib.TaskContrib.TaskOps
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
@@ -11,7 +10,7 @@ import coop.rchain.models._
 import coop.rchain.rholang.interpreter.RholangCLI
 import coop.rchain.rholang.interpreter.accounting._
 import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
-import coop.rchain.rspace.{Match, RSpace, _}
+import coop.rchain.rspace.{Match, _}
 import coop.rchain.shared.Log
 import coop.rchain.shared.PathOps.RichPath
 import monix.eval.Task
@@ -47,22 +46,22 @@ class BasicBench {
           state.tc.head,
           false
         )
-        .unsafeRunSync
+        .runSyncUnsafe()
 
       assert(c1.isEmpty)
       bh.consume(c1)
 
       val r2 =
-        space.produce(state.channels(i), state.data(i), false).unsafeRunSync
+        space.produce(state.channels(i), state.data(i), false).runSyncUnsafe()
 
       assert(r2.nonEmpty)
       bh.consume(r2)
       if (state.debug) {
-        assert(space.toMap.unsafeRunSync.isEmpty)
+        assert(space.toMap.runSyncUnsafe().isEmpty)
       }
     }
     if (state.debug) {
-      assert(space.createCheckpoint().unsafeRunSync.log.size == 303)
+      assert(space.createCheckpoint().runSyncUnsafe().log.size == 303)
     }
   }
 
@@ -72,7 +71,7 @@ class BasicBench {
     val space = state.testSpace
     for (i <- 0 to 100) {
       val r2 =
-        space.produce(state.channels(i), state.data(i), false).unsafeRunSync
+        space.produce(state.channels(i), state.data(i), false).runSyncUnsafe()
 
       assert(r2.isEmpty)
       bh.consume(r2)
@@ -84,16 +83,16 @@ class BasicBench {
           state.tc.head,
           false
         )
-        .unsafeRunSync
+        .runSyncUnsafe()
 
       assert(c1.nonEmpty)
       bh.consume(c1)
       if (state.debug) {
-        assert(space.toMap.unsafeRunSync.isEmpty)
+        assert(space.toMap.runSyncUnsafe().isEmpty)
       }
     }
     if (state.debug) {
-      assert(space.createCheckpoint().unsafeRunSync.log.size == 303)
+      assert(space.createCheckpoint().runSyncUnsafe().log.size == 303)
     }
   }
 }
@@ -131,9 +130,9 @@ object BasicBench {
           ListParWithRandom,
           TaggedContinuation
         ](rSpaceStore)
-        .unsafeRunSync
+        .runSyncUnsafe()
 
-    implicit val cost = CostAccounting.initialCost[Task](Cost.UNSAFE_MAX).unsafeRunSync
+    implicit val cost = CostAccounting.initialCost[Task](Cost.UNSAFE_MAX).runSyncUnsafe()
 
     val initSeed = 123456789L
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/EvalBenchStateBase.scala
@@ -1,14 +1,13 @@
 package coop.rchain.rspace.bench
 
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.Par
 import coop.rchain.rholang.Resources
-import coop.rchain.rholang.interpreter.{ParBuilderUtil, RhoRuntime, RholangCLI}
-import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
+import coop.rchain.rholang.interpreter.RholangCLI
 import coop.rchain.rholang.interpreter.compiler.Compiler
+import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.shared.Log
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler.Implicits.global
@@ -26,8 +25,8 @@ trait EvalBenchStateBase {
 
   val rhoScriptSource: String
 
-  val store                       = kvm.rSpaceStores.unsafeRunSync
-  lazy val spaces                 = Resources.createRuntimes[Task](store).unsafeRunSync
+  val store                       = kvm.rSpaceStores.runSyncUnsafe()
+  lazy val spaces                 = Resources.createRuntimes[Task](store).runSyncUnsafe()
   val (runtime, replayRuntime, _) = spaces
 
   val rand: Blake2b512Random = Blake2b512Random.defaultRandom

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RhoBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RhoBenchBaseState.scala
@@ -1,14 +1,13 @@
 package coop.rchain.rspace.bench
 
-import coop.rchain.rholang.interpreter.{ReplayRhoRuntime, RhoRuntime, RholangCLI}
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.crypto.hash.Blake2b512Random
 import coop.rchain.metrics
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.Par
 import coop.rchain.rholang.Resources
-import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.rholang.interpreter.compiler.Compiler
+import coop.rchain.rholang.interpreter.{ReplayRhoRuntime, RhoRuntime, RholangCLI}
+import coop.rchain.rspace.syntax.rspaceSyntaxKeyValueStoreManager
 import coop.rchain.shared.Log
 import monix.eval.{Coeval, Task}
 import monix.execution.Scheduler
@@ -28,7 +27,7 @@ abstract class RhoBenchBaseState {
     val r = (for {
       result <- runTask
       _      <- runtime.createCheckpoint
-    } yield result).unsafeRunSync
+    } yield result).runSyncUnsafe()
     bh.consume(r)
   }
 

--- a/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RhoReplayBenchBaseState.scala
+++ b/rspace-bench/src/test/scala/coop/rchain/rspace/bench/RhoReplayBenchBaseState.scala
@@ -1,6 +1,5 @@
 package coop.rchain.rspace.bench
 
-import coop.rchain.catscontrib.TaskContrib._
 import org.openjdk.jmh.annotations.{Level, Setup}
 import org.openjdk.jmh.infra.Blackhole
 
@@ -10,7 +9,7 @@ abstract class RhoReplayBenchBaseState extends RhoBenchBaseState {
     val r = (for {
       result <- runTask
       _      <- replayRuntime.createCheckpoint
-    } yield result).unsafeRunSync
+    } yield result).runSyncUnsafe()
     bh.consume(r)
   }
 
@@ -18,13 +17,13 @@ abstract class RhoReplayBenchBaseState extends RhoBenchBaseState {
   override def doSetup(): Unit = {
     super.doSetup()
 
-    runTask.unsafeRunSync
+    runTask.runSyncUnsafe()
     (for {
       executionCheckpoint <- replayRuntime.createCheckpoint
       _                   <- replayRuntime.rig(executionCheckpoint.log)
       _                   <- replayRuntime.reset(executionCheckpoint.root)
       _                   <- createTest(setupTerm)(replayRuntime, randSetup)
       _                   = runTask = createTest(Some(term))(replayRuntime, randRun)
-    } yield ()).unsafeRunSync
+    } yield ()).runSyncUnsafe()
   }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/ExportImportTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ExportImportTests.scala
@@ -2,7 +2,6 @@ package coop.rchain.rspace
 
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.rspace.examples.StringExamples.implicits._
 import coop.rchain.rspace.examples.StringExamples.{Pattern, Wildcard}
@@ -314,6 +313,6 @@ trait InMemoryExportImportTestsBase[C, P, A, K] {
       importer2 <- historyRepository2.importer
 
       res <- f(space1, exporter1, importer1, space2, exporter2, importer2)
-    } yield { res }).unsafeRunSync
+    } yield { res }).runSyncUnsafe()
   }
 }

--- a/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/ReplayRSpaceTests.scala
@@ -3,10 +3,7 @@ package coop.rchain.rspace
 import cats.Functor
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
-import cats.effect._
-import cats.effect.concurrent.{Ref, Semaphore}
 import com.typesafe.scalalogging.Logger
-import coop.rchain.catscontrib.TaskContrib._
 import coop.rchain.catscontrib.ski._
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.rspace.examples.StringExamples._
@@ -1030,9 +1027,9 @@ trait ReplayRSpaceTests extends ReplayRSpaceTestsBase[String, Pattern, String, S
         (store, replayStore, space, replaySpace) =>
           Task.delay {
             for (i <- indices) {
-              replaySpace.produce("ch1", s"datum$i", false).unsafeRunSync
+              replaySpace.produce("ch1", s"datum$i", false).runSyncUnsafe()
             }
-            space.createCheckpoint().unsafeRunSync
+            space.createCheckpoint().runSyncUnsafe()
           }
       }
 
@@ -1309,7 +1306,7 @@ trait InMemoryReplayRSpaceTestsBase[C, P, A, K] extends ReplayRSpaceTestsBase[C,
         replayStore
       )
       res <- f(store, replayStore, space, replaySpace)
-    } yield { res }).unsafeRunSync
+    } yield { res }).runSyncUnsafe()
   }
 }
 

--- a/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/StorageTestsBase.scala
@@ -88,14 +88,7 @@ trait StorageTestsBase[F[_], C, P, A, K] extends AnyFlatSpec with Matchers with 
   }
 }
 
-import cats._
-import cats.effect._
-import coop.rchain.metrics.Metrics
-import coop.rchain.shared.Log
-
 trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, R, K] {
-  import coop.rchain.catscontrib.TaskContrib._
-
   import scala.concurrent.ExecutionContext
 
   implicit override val concurrentF: Concurrent[Task] =
@@ -115,8 +108,8 @@ trait TaskTests[C, P, A, R, K] extends StorageTestsBase[Task, C, P, R, K] {
       Task.shift(ec).bracket(_ => fa)(_ => Task.shift)
   }
 
-  override def run[RES](f: Task[RES]): RES =
-    f.unsafeRunSync(monix.execution.Scheduler.Implicits.global)
+  import monix.execution.Scheduler.Implicits.global
+  override def run[RES](f: Task[RES]): RES = f.runSyncUnsafe()
 }
 
 abstract class InMemoryHotStoreTestsBase[F[_]]

--- a/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
+++ b/rspace/src/test/scala/coop/rchain/rspace/concurrent/TwoStepLockTest.scala
@@ -1,10 +1,9 @@
 package coop.rchain.rspace.concurrent
 
+import coop.rchain.metrics.Metrics
 import monix.eval.Task
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import coop.rchain.catscontrib.TaskContrib._
-import coop.rchain.metrics.Metrics
 
 class TwoStepLockTest extends AnyFlatSpec with Matchers {
 
@@ -21,7 +20,7 @@ class TwoStepLockTest extends AnyFlatSpec with Matchers {
     val t4   = acquireLock(lock, List("a", "b"), List("w1", "w2"), { a = a - 8 })
 
     val r = Task.parSequenceUnordered(List(t1, t2, t3, t4))
-    r.unsafeRunSync
+    r.runSyncUnsafe()
   }
 
   def acquireLock(

--- a/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
+++ b/shared/src/main/scala/coop/rchain/catscontrib/taskOps.scala
@@ -3,11 +3,6 @@ package coop.rchain.catscontrib
 import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.shared.{Log, LogSource}
-import monix.eval.Task
-import monix.execution.Scheduler
-
-import scala.concurrent.Await
-import scala.concurrent.duration._
 
 object TaskContrib {
 
@@ -18,16 +13,4 @@ object TaskContrib {
       fa.onError { case ex => log.error(msg, ex) }
 
   }
-
-  implicit class TaskOps[A](val task: Task[A]) extends AnyVal {
-
-    // TODO: This is duplicated `Task#runSyncUnsafe` / it should be removed
-    def unsafeRunSync(implicit scheduler: Scheduler): A =
-      Await.result(
-        task.runToFuture,
-        Duration.Inf
-      )
-
-  }
-
 }

--- a/shared/src/test/scala/coop/rchain/shared/scalatestcontrib.scala
+++ b/shared/src/test/scala/coop/rchain/shared/scalatestcontrib.scala
@@ -2,7 +2,6 @@ package coop.rchain.shared
 
 import cats.Functor
 import cats.syntax.functor._
-import coop.rchain.catscontrib.TaskContrib.TaskOps
 import monix.eval.Task
 import monix.execution.Scheduler
 import org.scalatest.Assertion
@@ -20,6 +19,5 @@ object scalatestcontrib extends Matchers {
       )
   }
 
-  def effectTest[T](f: Task[T])(implicit scheduler: Scheduler): T =
-    f.unsafeRunSync(scheduler)
+  def effectTest[T](f: Task[T])(implicit scheduler: Scheduler): T = f.runSyncUnsafe()
 }


### PR DESCRIPTION
## Overview

Small refactoring. Replaced custom `unsafeRunSync` with Monix Task `runSyncUnsafe`. Implementation of `unsafeRunSync` has been removed.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
