### PR TITLE
Replace produceCounters reference in RSpace base class

### DIFF
--- a/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReplayRSpace.scala
@@ -182,7 +182,7 @@ class ReplayRSpace[F[_]: Concurrent: ContextShift: Log: Metrics: Span, C, P, A, 
               .filterA(matches(comm))
               .map(_.to[Seq])
           }
-          .map((c, _))
+          .map(c -> _)
     )
 
   private[this] def matches(comm: COMM)(datumWithIndex: (Datum[A], _)): F[Boolean] = {

--- a/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/ReportingRspace.scala
@@ -15,14 +15,13 @@ import coop.rchain.rspace.ReportingRspace.{
 }
 import coop.rchain.rspace.history.HistoryRepository
 import coop.rchain.rspace.internal._
-import coop.rchain.rspace.trace.{Produce, _}
-import coop.rchain.shared.SyncVarOps._
+import coop.rchain.rspace.trace._
 import coop.rchain.shared.{Log, Serialize}
 import coop.rchain.store.KeyValueStore
 import monix.execution.atomic.AtomicAny
 
 import scala.collection.SortedSet
-import scala.concurrent.{ExecutionContext, SyncVar}
+import scala.concurrent.ExecutionContext
 
 /**
   * ReportingRspace works exactly like how ReplayRspace works. It can replay the deploy and try to find if the

--- a/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
+++ b/rspace/src/main/scala/coop/rchain/rspace/trace/Event.scala
@@ -1,6 +1,6 @@
 package coop.rchain.rspace.trace
 
-import cats.effect.{Concurrent, ContextShift, Sync}
+import cats.effect.Sync
 import cats.syntax.all._
 import coop.rchain.rspace.hashing.Blake2b256Hash
 import coop.rchain.rspace.hashing.StableHashProvider._
@@ -25,7 +25,7 @@ final case class COMM(
 ) extends Event
 
 object COMM {
-  def apply[F[_]: Concurrent: ContextShift, C, A](
+  def apply[F[_]: Sync, C, A](
       dataCandidates: Seq[ConsumeCandidate[C, A]],
       consumeRef: Consume,
       peeks: SortedSet[Int],
@@ -34,7 +34,7 @@ object COMM {
     for {
       produceRefs <- Sync[F].delay(
                       dataCandidates
-                        .map(_.datum.source)(Seq.canBuildFrom)
+                        .map(_.datum.source)
                         .sortBy(p => (p.channelsHash, p.hash, p.persistent))
                     )
       counters <- produceCounters(produceRefs)


### PR DESCRIPTION
## Overview
n Scala 2.13 SyncVar is removed so we need to switch to alternative. Another reason is to use functional abstraction which is Ref[F, A] from cats library.


### Solution
Replace objects defined as SyncVar with Ref [concurrent mutable reference](https://typelevel.org/cats-effect/docs/2.x/concurrency/ref).


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.