### PR TITLE
Attestations implementation

### DIFF
--- a/block-storage/src/main/scala/coop/rchain/blockstorage/dag/MessageMapSyntax.scala
+++ b/block-storage/src/main/scala/coop/rchain/blockstorage/dag/MessageMapSyntax.scala
@@ -1,6 +1,7 @@
 package coop.rchain.blockstorage.dag
 
 import cats.syntax.all._
+import coop.rchain.sdk.syntax.all.mapSyntax
 
 trait MessageMapSyntax {
   implicit def blockStorageSyntaxMessageMap[M, S](
@@ -48,4 +49,12 @@ final class MessageMapSyntaxOps[M, S](private val msgMap: Map[M, Message[M, S]])
     * Finds a message with empty parents
     */
   def findWithEmptyParents: Option[Msg] = msgMap.values.find(_.parents.isEmpty)
+
+  /**
+    * The highest fringe that is not required for merging.
+    */
+  def pruneFringe(
+      finalFringe: Set[M],
+      childMap: Map[M, Set[M]]
+  ): Set[Message[M, S]] = lowestFringe(finalFringe.flatMap(childMap).map(msgMap.getUnsafe))
 }

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
@@ -91,7 +91,7 @@ object MultiParentCasper {
       // If new fringe is finalized, merge it
       newFringeResult <- newFringeHashes.traverse { fringe =>
                           val (mScope, baseOpt) =
-                            MergeScope.fromDag(fringe, prevFringeHashes, msgMap)
+                            MergeScope.fromDag(fringe, prevFringeHashes, dag.childMap, msgMap)
                           for {
                             baseStateOpt <- baseOpt.traverse { h =>
                                              BlockStore[F]
@@ -129,7 +129,12 @@ object MultiParentCasper {
                                        .map(x => (x.toBlake2b256Hash, Set.empty[ByteString]))
                                    case _ =>
                                      val (mScope, baseOpt) =
-                                       MergeScope.fromDag(parentHashes, newFringe, msgMap)
+                                       MergeScope.fromDag(
+                                         parentHashes,
+                                         newFringe,
+                                         dag.childMap,
+                                         msgMap
+                                       )
                                      for {
                                        baseStateOpt <- baseOpt.traverse { h =>
                                                         BlockStore[F]

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
@@ -128,10 +128,8 @@ object MultiParentCasper {
                                        .map(_.postStateHash)
                                        .map(x => (x.toBlake2b256Hash, Set.empty[ByteString]))
                                    case _ =>
-                                     val lms    = dag.dagMessageState.latestMsgs.map(_.id)
-                                     val msgMap = dag.dagMessageState.msgMap
                                      val (mScope, baseOpt) =
-                                       MergeScope.fromDag(lms, prevFringeHashes, msgMap)
+                                       MergeScope.fromDag(parentHashes, newFringe, msgMap)
                                      for {
                                        baseStateOpt <- baseOpt.traverse { h =>
                                                         BlockStore[F]
@@ -140,13 +138,12 @@ object MultiParentCasper {
                                                       }
                                        r <- MergeScope.merge(
                                              mScope,
-                                             baseStateOpt.getOrElse(prevFringeState),
+                                             baseStateOpt.getOrElse(fringeState),
                                              dag.fringeStates,
                                              RuntimeManager[F].getHistoryRepo,
                                              BlockIndex.getBlockIndex[F](_)
                                            )
                                      } yield r
-
                                  }
       (preStateHash, csRejectedDeploys) = conflictScopeMergeResult
 

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/BlockCreator.scala
@@ -1,228 +1,109 @@
 package coop.rchain.casper.blocks.proposer
 
-import cats.effect.Concurrent
+import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
-import coop.rchain.models.syntax._
-import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
-import coop.rchain.blockstorage.syntax._
-import coop.rchain.casper.merging.ParentsMergedState
-import coop.rchain.casper.protocol._
+import coop.rchain.blockstorage.dag.BlockDagStorage.DeployId
+import coop.rchain.casper.protocol.{ProcessedDeploy, ProcessedSystemDeploy, RholangState}
 import coop.rchain.casper.rholang.RuntimeManager.StateHash
 import coop.rchain.casper.rholang.sysdeploys.{CloseBlockDeploy, SlashDeploy}
 import coop.rchain.casper.rholang.{BlockRandomSeed, InterpreterUtil, RuntimeManager}
-import coop.rchain.casper.util.{ConstructDeploy, ProtoUtil}
-import coop.rchain.casper.{MultiParentCasper, PrettyPrinter, ValidatorIdentity}
-import coop.rchain.crypto.PrivateKey
-import coop.rchain.crypto.hash.Blake2b512Random
-import coop.rchain.crypto.signatures.Signed
-import coop.rchain.crypto.PublicKey
+import coop.rchain.casper.util.ProtoUtil
+import coop.rchain.casper.{PrettyPrinter, ValidatorIdentity}
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.models.BlockVersion
 import coop.rchain.models.Validator.Validator
+import coop.rchain.models.syntax._
 import coop.rchain.rholang.interpreter.SystemProcesses.BlockData
 import coop.rchain.rspace.hashing.Blake2b256Hash
-import coop.rchain.shared.{Log, Stopwatch, Time}
+import coop.rchain.shared.Log
 
-object BlockCreator {
-  private[this] val ProcessDeploysAndCreateBlockMetricsSource =
-    Metrics.Source(Metrics.BaseSource, "create-block")
+final case class BlockCreator(id: ValidatorIdentity, shardId: String) {
+  type StateTransitionResult = (StateHash, Seq[ProcessedDeploy], Seq[ProcessedSystemDeploy])
 
-  /*
-   * Overview of createBlock
-   *
-   *  1. Rank each of the block cs's latest messages (blocks) via the LMD GHOST estimator.
-   *  2. Let each latest message have a score of 2^(-i) where i is the index of that latest message in the ranking.
-   *     Take a subset S of the latest messages such that the sum of scores is the greatest and
-   *     none of the blocks in S conflicts with each other. S will become the parents of the
-   *     about-to-be-created block.
-   *  3. Extract all valid deploys that aren't already in all ancestors of S (the parents).
-   *  4. Create a new block that contains the deploys from the previous step.
-   */
-  def create[F[_]: Concurrent: Time: RuntimeManager: BlockDagStorage: BlockStore: Log: Metrics: Span](
-      preState: ParentsMergedState,
-      validatorIdentity: ValidatorIdentity,
-      shardId: String,
-      dummyDeployOpt: Option[(PrivateKey, String)] = None
-  ): F[BlockCreatorResult] =
-    Span[F].trace(ProcessDeploysAndCreateBlockMetricsSource) {
-      val selfId         = ByteString.copyFrom(validatorIdentity.publicKey.bytes)
-      val nextSeqNum     = preState.maxSeqNums.get(selfId).map(_ + 1L).getOrElse(0L)
-      val nextBlockNum   = preState.maxBlockNum + 1
-      val justifications = preState.justifications.map(_.blockHash).toList
+  def create[F[_]: Concurrent: RuntimeManager: BlockDagStorage: BlockStore: Log: Metrics: Span](
+      preStateHash: Blake2b256Hash,
+      parents: Set[BlockHash],
+      bondsMap: Map[Validator, Long],
+      finalization: Set[DeployId], // deploys that are rejected on finalization done by the block being created
+      blockNum: Long,
+      seqNum: Long,
+      deploys: Seq[DeployId],
+      toSlash: Set[Validator],
+      changeEpoch: Boolean,
+      suppressAttestation: Boolean
+  ): F[BlockCreatorResult] = {
+    val creatorsPk    = id.publicKey
+    val blockData     = BlockData(blockNum, creatorsPk, seqNum)
+    val shouldPropose = deploys.nonEmpty || toSlash.nonEmpty || changeEpoch
 
-      def prepareUserDeploys(blockNumber: Long): F[Set[Signed[DeployData]]] =
-        for {
-          unfinalized         <- BlockDagStorage[F].pooledDeploys.map(_.values.toSet)
-          earliestBlockNumber = blockNumber - MultiParentCasper.deployLifespan
-          valid = unfinalized.filter { d =>
-            notFutureDeploy(blockNumber, d.data) &&
-            notExpiredDeploy(earliestBlockNumber, d.data)
-          }
-          // this is required to prevent resending the same deploy several times by validator
-//          validUnique = valid -- s.deploysInScope
-          // TODO: temp solution to filter duplicated deploys
-          validUnique <- valid.toList.filterA { d =>
-                          BlockDagStorage[F].lookupByDeployId(d.sig).map(_.isEmpty)
-                        }
-        } yield validUnique.toSet
+    def propose: F[StateTransitionResult] = {
+      val rand = BlockRandomSeed.randomGenerator(shardId, blockNum, creatorsPk, preStateHash)
+      // seeds from 0 to deploys.size are used in deploys execution, so system deploy seeds start from the next index
+      val slashSeeds =
+        (0 until toSlash.size).map(_ + deploys.size).map(i => rand.splitByte(i.toByte))
+      val closeSeed = rand.splitByte((deploys.size + toSlash.size).toByte)
 
-      def prepareSlashingDeploys(
-          ilmFromBonded: Seq[(Validator, BlockHash)],
-          rand: Blake2b512Random,
-          startIndex: Int
-      ): F[List[SlashDeploy]] = {
-        val slashingDeploysWithBlocks = ilmFromBonded.zipWithIndex.map {
-          case ((slashedValidator, invalidBlock), i) =>
-            (SlashDeploy(slashedValidator, rand.splitByte((i + startIndex).toByte)), invalidBlock)
-        }
-        slashingDeploysWithBlocks.toList.traverse {
-          case (sd, invalidBlock) =>
-            Log[F]
-              .info(
-                s"Issuing slashing deploy justified by block ${PrettyPrinter.buildString(invalidBlock)}"
-              )
-              .as(sd)
-        }
-      }
+      val slashDeploys = toSlash.toList.sorted.zip(slashSeeds).map(SlashDeploy.tupled)
+      val closeDeploy  = CloseBlockDeploy(closeSeed)
 
-      def prepareDummyDeploy(blockNumber: Long, shardId: String): Seq[Signed[DeployData]] =
-        dummyDeployOpt match {
-          case Some((privateKey, term)) =>
-            Seq(
-              ConstructDeploy.sourceDeployNow(
-                source = term,
-                sec = privateKey,
-                vabn = blockNumber - 1,
-                shardId = shardId
-              )
-            )
-          case None => Seq.empty[Signed[DeployData]]
-        }
-
-      val createBlockProcess = for {
-        _ <- Log[F].info(
-              s"Creating block #${nextBlockNum} (seqNum ${nextSeqNum})"
-            )
-        userDeploys  <- prepareUserDeploys(nextBlockNum)
-        dummyDeploys = prepareDummyDeploy(nextBlockNum, shardId)
-        // TODO: fix invalid blocks from non-finalized scope
-        ilm <- Seq[(Validator, BlockHash)]().pure[F]
-        ilmFromBonded = ilm.filter {
-          case (validator, _) => preState.fringeBondsMap.getOrElse(validator, 0L) > 0L
-        }
-        deploys = userDeploys ++ dummyDeploys
-        r <- if (deploys.nonEmpty || ilmFromBonded.nonEmpty) {
-              val blockData = BlockData(nextBlockNum, validatorIdentity.publicKey, nextSeqNum)
-              val rand = BlockRandomSeed.randomGenerator(
-                shardId,
-                nextBlockNum,
-                validatorIdentity.publicKey,
-                preState.preStateHash
-              )
-              for {
-                slashingDeploys <- prepareSlashingDeploys(ilmFromBonded, rand, deploys.size)
-                // make sure closeBlock is the last system Deploy
-                systemDeploys = slashingDeploys :+ CloseBlockDeploy(
-                  rand.splitByte((deploys.size + slashingDeploys.size).toByte)
-                )
-                preStateHash = preState.preStateHash.toByteString
-                checkpointData <- InterpreterUtil.computeDeploysCheckpoint(
-                                   deploys.toSeq,
-                                   systemDeploys,
-                                   rand,
-                                   blockData,
-                                   preStateHash
-                                 )
-                (postStateHash, processedDeploys, processedSystemDeploys) = checkpointData
-
-                _ <- Span[F].mark("before-packing-block")
-
-                // Create block and calculate block hash
-                unsignedBlock = packageBlock(
-                  validatorIdentity.publicKey,
-                  blockData,
-                  justifications,
-                  preStateHash,
-                  postStateHash,
-                  processedDeploys,
-                  processedSystemDeploys,
-                  shardId,
-                  BlockVersion.Current,
-                  // Bonds data in the block is referring to finalized fringe
-                  //  not bonds in conflict scope
-                  preState.fringeBondsMap,
-                  // Rejected data in the block is referring to finalized fringe
-                  //  not rejections in conflict scope
-                  preState.fringeRejectedDeploys
-                )
-                _ <- Span[F].mark("block-created")
-
-                // Sign a block (hash should not be changed)
-                signedBlock = validatorIdentity.signBlock(unsignedBlock)
-                _           <- Span[F].mark("block-signed")
-
-                // This check is temporary until signing function will re-hash the block
-                unsignedHash = PrettyPrinter.buildString(unsignedBlock.blockHash)
-                signedHash   = PrettyPrinter.buildString(signedBlock.blockHash)
-                _ = assert(
-                  unsignedBlock.blockHash == signedBlock.blockHash,
-                  s"Signed block has different block hash unsigned: $unsignedHash, signed: $signedHash."
-                )
-              } yield BlockCreatorResult.created(signedBlock)
-            } else
-              BlockCreatorResult.noNewDeploys.pure[F]
-      } yield r
-
-      for {
-        // Create block and measure duration
-        r                      <- Stopwatch.duration(createBlockProcess)
-        (blockStatus, elapsed) = r
-        _ <- blockStatus match {
-              case Created(block) =>
-                val blockInfo   = PrettyPrinter.buildString(block, short = true)
-                val deployCount = block.state.deploys.size
-                Log[F].info(s"Block created: $blockInfo (${deployCount}d) [$elapsed]")
-              case _ => ().pure[F]
-            }
-      } yield blockStatus
+      BlockDagStorage[F].pooledDeploys
+        .map(_.filterKeys(deploys.toSet).values.toSeq)
+        .flatMap(
+          InterpreterUtil.computeDeploysCheckpoint[F](
+            _,
+            slashDeploys :+ closeDeploy,
+            rand,
+            blockData,
+            preStateHash.toByteString
+          )
+        )
     }
 
-  private def packageBlock(
-      sender: PublicKey,
-      blockData: BlockData,
-      justifications: List[BlockHash],
-      preStateHash: StateHash,
-      postStateHash: StateHash,
-      deploys: Seq[ProcessedDeploy],
-      systemDeploys: Seq[ProcessedSystemDeploy],
-      shardId: String,
-      version: Int,
-      // Fringe data
-      bondsMap: Map[Validator, Long],
-      rejectedDeploys: Set[ByteString]
-  ): BlockMessage = {
-    val state = RholangState(deploys.toList, systemDeploys.toList)
-    ProtoUtil.unsignedBlockProto(
-      version,
-      shardId,
-      blockData.blockNumber,
-      sender,
-      blockData.seqNum,
-      preStateHash,
-      postStateHash,
-      justifications,
-      bondsMap,
-      rejectedDeploys,
-      state
-    )
+    /** Create attestation. */
+    def attest: F[StateTransitionResult] = Sync[F].delay {
+      val postStateHash          = preStateHash.toByteString
+      val processedDeploys       = Seq()
+      val processedSystemDeploys = Seq()
+      (postStateHash, processedDeploys, processedSystemDeploys)
+    }
+
+    val postState =
+      if (shouldPropose) propose.map(_.some)
+      else (!suppressAttestation).guard[Option].traverse(_ => attest)
+
+    postState.map {
+      case None                                                            => BlockCreatorResult.noNewDeploys
+      case Some((postStateHash, processedDeploys, processedSystemDeploys)) =>
+        // Create block and calculate block hash
+        val state = RholangState(processedDeploys.toList, processedSystemDeploys.toList)
+        val unsignedBlock = ProtoUtil.unsignedBlockProto(
+          version = BlockVersion.Current,
+          shardId,
+          blockData.blockNumber,
+          creatorsPk,
+          blockData.seqNum,
+          preStateHash.toByteString,
+          postStateHash,
+          parents.toList,
+          bondsMap,
+          finalization,
+          state
+        )
+
+        // Sign a block (hash should not be changed)
+        val signedBlock = id.signBlock(unsignedBlock)
+
+        // This check is temporary until signing function will re-hash the block
+        val unsignedHash = PrettyPrinter.buildString(unsignedBlock.blockHash)
+        val signedHash   = PrettyPrinter.buildString(signedBlock.blockHash)
+        assert(
+          unsignedBlock.blockHash == signedBlock.blockHash,
+          s"Signed block has different block hash unsigned: $unsignedHash, signed: $signedHash."
+        )
+        BlockCreatorResult.created(signedBlock)
+    }
   }
-
-  private def notExpiredDeploy(earliestBlockNumber: Long, d: DeployData): Boolean =
-    d.validAfterBlockNumber > earliestBlockNumber
-
-  private def notFutureDeploy(currentBlockNumber: Long, d: DeployData): Boolean =
-    d.validAfterBlockNumber < currentBlockNumber
 }

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -211,7 +211,7 @@ object Proposer {
                    preStateHash,
                    parentHashes,
                    finalBonds,
-                   preState.rejectedDeploys,
+                   preState.fringeRejectedDeploys,
                    nextBlockNum,
                    nextSeqNum,
                    deploys,

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -11,12 +11,14 @@ import coop.rchain.casper._
 import coop.rchain.casper.protocol.{BlockMessage, CommUtil}
 import coop.rchain.casper.rholang.RuntimeManager
 import coop.rchain.casper.syntax._
+import coop.rchain.casper.util.ConstructDeploy
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.metrics.Metrics.Source
 import coop.rchain.metrics.implicits._
 import coop.rchain.metrics.{Metrics, Span}
 import coop.rchain.models.Validator.Validator
 import coop.rchain.sdk.error.FatalError
+import coop.rchain.shared.syntax._
 import coop.rchain.shared.{Log, Time}
 
 sealed abstract class ProposerResult
@@ -118,6 +120,7 @@ object Proposer {
       validatorIdentity: ValidatorIdentity,
       shardId: String,
       minPhloPrice: Long,
+      epochLength: Int,
       dummyDeployOpt: Option[(PrivateKey, String)] = None
   ): Proposer[F] = {
     // TODO: refactor proposer to get this from parent pre state
@@ -128,10 +131,76 @@ object Proposer {
         maxSeqNum  = latestMsgs.find(_.sender == sender).map(_.senderSeq)
       } yield maxSeqNum.getOrElse(-1)
 
-    def createBlock(validatorIdentity: ValidatorIdentity) =
+    def createBlock(validatorIdentity: ValidatorIdentity): F[BlockCreatorResult] =
       for {
-        parentsPreState <- MultiParentCasper.getPreStateForNewBlock
-        result          <- BlockCreator.create(parentsPreState, validatorIdentity, shardId, dummyDeployOpt)
+        // merge pre state
+        preState <- MultiParentCasper.getPreStateForNewBlock
+        // misc
+        preStateHash      = preState.preStateHash
+        creatorsPk        = validatorIdentity.publicKey
+        creatorsId        = ByteString.copyFrom(creatorsPk.bytes)
+        creatorsLatestOpt = preState.justifications.find(_.sender == creatorsId)
+        nextSeqNum        = creatorsLatestOpt.map(_.seqNum + 1).getOrElse(0L)
+        nextBlockNum      = preState.justifications.map(_.blockNum).max + 1
+        parentHashes      = preState.justifications.map(_.blockHash)
+        finalBonds        = preState.fringeBondsMap
+        offenders         = preState.justifications.filter(_.validationFailed).map(_.sender)
+        // slashing
+        preStateBonds <- RuntimeManager[F].computeBonds(preStateHash.toByteString)
+        toSlash       = offenders intersect preStateBonds.filter { case (_, b) => b > 0 }.keySet
+        // epoch
+        changeEpoch = epochLength % nextBlockNum == 0
+        // attestation
+        // no need to attest if nothing meaningful to finalize. TODO analyse finalization to suppress more
+        dag <- BlockDagStorage[F].getRepresentation
+        conflictSet = {
+          val msgMap = dag.dagMessageState.msgMap
+          parentHashes.flatMap(msgMap(_).seen) -- preState.fringe.flatMap(msgMap(_).seen)
+        }
+        suppressAttestation <- conflictSet.toList
+                                .traverse(BlockStore[F].getUnsafe)
+                                .map(_.forall { b =>
+                                  b.state.systemDeploys.isEmpty && b.state.deploys.isEmpty
+                                })
+        // push dummy deploy if needed
+        p <- BlockDagStorage[F].pooledDeploys
+        _ <- dummyDeployOpt
+              .traverse {
+                case (privateKey, term) =>
+                  val deployData = ConstructDeploy.sourceDeployNow(
+                    source = term,
+                    sec = privateKey,
+                    vabn = nextBlockNum - 1,
+                    shardId = shardId
+                  )
+                  BlockDagStorage[F].addDeploy(deployData)
+              }
+              .whenA(p.isEmpty)
+        // user deploys
+        pooled <- BlockDagStorage[F].pooledDeploys
+        deploys <- pooled.toList
+                    .filterA {
+                      case (id, d) =>
+                        val future       = d.data.validAfterBlockNumber > nextBlockNum
+                        val expired      = d.data.validAfterBlockNumber < nextBlockNum - MultiParentCasper.deployLifespan
+                        val replayAttack = BlockDagStorage[F].lookupByDeployId(id).map(_.nonEmpty)
+                        (future.pure ||^ expired.pure ||^ replayAttack).not
+                    }
+                    .map(_.map(_._1))
+        // create block
+        _ <- Log[F].info(s"Creating block #${nextBlockNum} (seqNum ${nextSeqNum})")
+        result <- BlockCreator(validatorIdentity, shardId).create(
+                   preStateHash,
+                   parentHashes,
+                   finalBonds,
+                   preState.rejectedDeploys,
+                   nextBlockNum,
+                   nextSeqNum,
+                   deploys,
+                   toSlash,
+                   changeEpoch,
+                   suppressAttestation
+                 )
       } yield result
 
     def validateBlock(block: BlockMessage) =

--- a/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/proposer/Proposer.scala
@@ -1,5 +1,6 @@
 package coop.rchain.casper.blocks.proposer
 
+import cats.data.OptionT
 import cats.effect.concurrent.Deferred
 import cats.effect.{Concurrent, Timer}
 import cats.syntax.all._
@@ -180,31 +181,49 @@ object Proposer {
           }
         }
         suppressAttestation <- nothingToFinalize ||^ waitingForSupermajorityToAttest
-        // push dummy deploy if needed
-        p <- BlockDagStorage[F].pooledDeploys
-        _ <- dummyDeployOpt
-              .traverse {
-                case (privateKey, term) =>
-                  val deployData = ConstructDeploy.sourceDeployNow(
-                    source = term,
-                    sec = privateKey,
-                    vabn = nextBlockNum - 1,
-                    shardId = shardId
-                  )
-                  BlockDagStorage[F].addDeploy(deployData)
-              }
-              .whenA(p.isEmpty)
+//        // push dummy deploy if needed
+//        p <- BlockDagStorage[F].pooledDeploys
+//        _ <- dummyDeployOpt
+//              .traverse {
+//                case (privateKey, term) =>
+//                  val deployData = ConstructDeploy.sourceDeployNow(
+//                    source = term,
+//                    sec = privateKey,
+//                    vabn = nextBlockNum - 1,
+//                    shardId = shardId
+//                  )
+//                  BlockDagStorage[F].addDeploy(deployData)
+//              }
+//              .whenA(p.isEmpty)
         // user deploys
         pooled <- BlockDagStorage[F].pooledDeploys
-        deploys <- pooled.toList
-                    .filterA {
-                      case (id, d) =>
-                        val future       = d.data.validAfterBlockNumber > nextBlockNum
-                        val expired      = d.data.validAfterBlockNumber < nextBlockNum - MultiParentCasper.deployLifespan
-                        val replayAttack = BlockDagStorage[F].lookupByDeployId(id).map(_.nonEmpty)
-                        (future.pure ||^ expired.pure ||^ replayAttack).not
-                    }
-                    .map(_.map(_._1))
+        pooledOk <- pooled.toList
+                     .filterA {
+                       case (id, d) =>
+                         val future       = d.data.validAfterBlockNumber > nextBlockNum
+                         val expired      = d.data.validAfterBlockNumber < nextBlockNum - MultiParentCasper.deployLifespan
+                         val replayAttack = BlockDagStorage[F].lookupByDeployId(id).map(_.nonEmpty)
+                         (future.pure ||^ expired.pure ||^ replayAttack).not
+                     }
+                     .map(_.map(_._1))
+        deploys <- {
+          val dummy = dummyDeployOpt
+            .traverse {
+              case (privateKey, term) =>
+                val deployData = ConstructDeploy.sourceDeployNow(
+                  source = term,
+                  sec = privateKey,
+                  vabn = nextBlockNum - 1,
+                  shardId = shardId
+                )
+                BlockDagStorage[F].addDeploy(deployData).as(List(deployData.sig))
+            }
+          OptionT
+            .fromOption(pooledOk.nonEmpty.guard[Option].as(pooledOk))
+            .orElseF(dummy)
+            .value
+            .map(_.getOrElse(List()))
+        }
         // create block
         _ <- Log[F].info(s"Creating block #${nextBlockNum} (seqNum ${nextSeqNum})")
         result <- BlockCreator(validatorIdentity, shardId).create(

--- a/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
+++ b/casper/src/main/scala/coop/rchain/casper/dag/BlockDagKeyValueStorage.scala
@@ -11,6 +11,7 @@ import coop.rchain.blockstorage.dag._
 import coop.rchain.blockstorage.dag.codecs._
 import coop.rchain.blockstorage.syntax._
 import coop.rchain.casper.dag.BlockDagKeyValueStorage._
+import coop.rchain.casper.merging.BlockIndex
 import coop.rchain.casper.protocol.{BlockMessage, DeployData}
 import coop.rchain.casper.{MultiParentCasper, PrettyPrinter}
 import coop.rchain.crypto.signatures.Signed
@@ -110,6 +111,13 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
                 )
               }
 
+        // attempt to prune only when sender is the only outsider
+        lowestFringe            = dagState.msgMap.lowestFringe(dagState.latestMsgs).map(_.id)
+        outsiders               = dagState.latestMsgs.filter(_.fringe == lowestFringe).map(_.sender)
+        senderIsTheOnlyOutsider = outsiders == Set(blockMetadata.sender)
+        shouldPrune             = fringeDiff.nonEmpty && senderIsTheOnlyOutsider
+        _                       <- pruneDiff(dag.dagMessageState, dagState, childMap).whenA(shouldPrune)
+
         _ <- removeExpiredFromPool(deployStore, dag).map(
               _.map((_, ())).map((expiredMap.update _).tupled)
             )
@@ -120,6 +128,37 @@ final class BlockDagKeyValueStorage[F[_]: Concurrent: Log] private (
         .contains(blockMetadata.blockHash)
         .ifM(logAlreadyStored, doInsert)
     )
+  }
+
+  /**
+    * Fringe messages below which (+ messages of the fringe) can be pruned since they are not
+    * required for processing of any future message.
+    */
+  def dbPruneFringe(
+      dbState: DagMessageState[BlockHash, Validator],
+      childMap: Map[BlockHash, Set[BlockHash]]
+  ): Set[Message[BlockHash, Validator]] = {
+    val lowestFringe = dbState.msgMap.lowestFringe(dbState.latestMsgs).map(_.id)
+    dbState.msgMap.pruneFringe(lowestFringe, childMap)
+  }
+
+  /**
+    * Prune database.
+    * Remove data that is not required for processing any future block.
+    * TODO for now its just clean merging index cache, but can be used to prune the whole DB.
+    * `Diff` here is because data pruned is what is not required in new state compared to current state.
+    */
+  def pruneDiff(
+      newState: DagMessageState[BlockHash, Validator],
+      curState: DagMessageState[BlockHash, Validator],
+      childMap: Map[BlockHash, Set[BlockHash]]
+  ): F[Unit] = {
+    val newLPF = dbPruneFringe(newState, childMap)
+    val curLPF = dbPruneFringe(curState, childMap)
+    val toPune = (newState.msgMap.between(newLPF, curLPF) ++ curLPF).map(_.id)
+
+    toPune.toList.foreach(BlockIndex.cache.remove)
+    Log[F].info(s"Pruned ${toPune.size} merging indices, new size: ${BlockIndex.cache.size}")
   }
 
   override def lookup(blockHash: BlockHash): F[Option[BlockMetadata]] =

--- a/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/BlockIndex.scala
@@ -34,6 +34,7 @@ object BlockIndex {
     val cached = BlockIndex.cache.get(blockHash).map(_.pure)
     cached.getOrElse {
       for {
+        _            <- coop.rchain.shared.Log.log[F].info(s"Cache miss. Indexing ${blockHash.show}.")
         b            <- BlockStore[F].getUnsafe(blockHash)
         preState     = b.preStateHash
         postState    = b.postStateHash
@@ -49,6 +50,7 @@ object BlockIndex {
                        RuntimeManager[F].getHistoryRepo,
                        mergeableChs
                      )
+        _ = BlockIndex.cache.putIfAbsent(blockHash, blockIndex)
       } yield blockIndex
     }
   }

--- a/casper/src/main/scala/coop/rchain/casper/merging/MergeScope.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/MergeScope.scala
@@ -82,7 +82,7 @@ object MergeScope {
         val conflictSet = conflictScope.flatMap(_.deployChains)
         val finalSet    = finalScope.flatMap(_.deployChains)
         // finalization decisions made in final set
-        val (acceptedFinally, rejectedFinally) = {
+        val (rejectedFinally, acceptedFinally) = {
           val rejectionsMap = fringeStates.flatMap { case (k, v) => k.map((_, v.rejectedDeploys)) }
           finalScope.iterator
             .flatMap(b => b.deployChains.map(b.blockHash -> _))

--- a/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch1/MultiParentCasperDeploySpec.scala
@@ -28,10 +28,12 @@ class MultiParentCasperDeploySpec
     TestNode.networkEff(genesis, networkSize = 2).use { nodes =>
       val List(node0, node1) = nodes.toList
       for {
+
         deploy             <- ConstructDeploy.basicDeployData[Effect](0, shardId = genesis.genesisBlock.shardId)
         _                  <- node0.propagateBlock(deploy)(node1)
-        createBlockResult2 <- node1.createBlock(deploy)
-      } yield (createBlockResult2 should be(NoNewDeploys))
+        _                  <- node0.blockDagStorage.addDeploy(deploy)
+        createBlockResult2 <- node1.proposeSync.attempt
+      } yield createBlockResult2.isLeft shouldBe true
     }
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
+++ b/casper/src/test/scala/coop/rchain/casper/helper/TestNode.scala
@@ -169,11 +169,23 @@ case class TestNode[F[_]: Concurrent: Timer](
                 _   = assert(res.isRight, s"Deploy error ${deploy} with\n ${res.left}")
               } yield ()
           )
-      preState <- MultiParentCasper.getPreStateForNewBlock[F]
-      createBlockResult <- BlockCreator.create(
-                            preState,
-                            validatorIdOpt.get,
-                            shardName
+      preState          <- MultiParentCasper.getPreStateForNewBlock[F]
+      creatorsPk        = validatorIdOpt.get.publicKey
+      creatorsId        = ByteString.copyFrom(creatorsPk.bytes)
+      creatorsLatestOpt = preState.justifications.find(_.sender == creatorsId)
+      nextSeqNum        = creatorsLatestOpt.map(_.seqNum + 1).getOrElse(0L)
+      nextBlockNum      = preState.justifications.map(_.blockNum).max + 1
+      createBlockResult <- BlockCreator(validatorIdOpt.get, shardName).create(
+                            preState.preStateHash,
+                            preState.justifications.map(_.blockHash),
+                            preState.fringeBondsMap,
+                            preState.rejectedDeploys,
+                            nextBlockNum,
+                            nextSeqNum,
+                            deployDatums.map(_.sig),
+                            Set(),
+                            false,
+                            true
                           )
     } yield (createBlockResult, preState)
 
@@ -183,12 +195,25 @@ case class TestNode[F[_]: Concurrent: Timer](
   // This method assumes that block will be created successfully
   def createBlockUnsafe(deployDatums: Signed[DeployData]*): F[BlockMessage] =
     for {
-      _        <- deployDatums.toList.traverse(MultiParentCasper.deploy[F])
-      preState <- MultiParentCasper.getPreStateForNewBlock[F]
-      createBlockResult <- BlockCreator.create(
-                            preState,
-                            validatorIdOpt.get,
-                            shardName
+      _                 <- deployDatums.toList.traverse(MultiParentCasper.deploy[F])
+      preState          <- MultiParentCasper.getPreStateForNewBlock[F]
+      preState          <- MultiParentCasper.getPreStateForNewBlock[F]
+      creatorsPk        = validatorIdOpt.get.publicKey
+      creatorsId        = ByteString.copyFrom(creatorsPk.bytes)
+      creatorsLatestOpt = preState.justifications.find(_.sender == creatorsId)
+      nextSeqNum        = creatorsLatestOpt.map(_.seqNum + 1).getOrElse(0L)
+      nextBlockNum      = preState.justifications.map(_.blockNum).max + 1
+      createBlockResult <- BlockCreator(validatorIdOpt.get, shardName).create(
+                            preState.preStateHash,
+                            preState.justifications.map(_.blockHash),
+                            preState.fringeBondsMap,
+                            preState.rejectedDeploys,
+                            nextBlockNum,
+                            nextSeqNum,
+                            deployDatums.map(_.sig),
+                            Set(),
+                            false,
+                            true
                           )
       block <- createBlockResult match {
                 case Created(b) => b.pure[F]
@@ -442,7 +467,7 @@ object TestNode {
 
                  proposer = validatorId match {
                    case Some(vi) =>
-                     Proposer[F](vi, shardName, minPhloPrice).some
+                     Proposer[F](vi, shardName, minPhloPrice, Int.MaxValue).some
                    case None => None
                  }
                  // propose function in casper tests is always synchronous

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -149,6 +149,7 @@ object Setup {
           validatorIdentity,
           conf.casper.shardName,
           conf.casper.minPhloPrice,
+          conf.casper.genesisBlockData.epochLength,
           dummyDeployerKey.map((_, "Nil"))
         )
       }


### PR DESCRIPTION
## Overview
This PR adds implementation for attestation messages, which are the same block messages, but with pre state == post state and empty list of deploys.
The logic of block creation remains the same - there is an attempt to create block after each incoming block replayed.
But when there are no deploys to put in a block (no user deploys, no system deploys) - attestation is created. 

I'm not sure yet how to enable testing for this. Thinking about more refactoring.

Closes https://github.com/rchain/rchain/issues/3249

### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
