### PR TITLE
Add peek to NonNegativeNumber contract

### DIFF
--- a/casper/src/main/resources/NonNegativeNumber.rho
+++ b/casper/src/main/resources/NonNegativeNumber.rho
@@ -26,12 +26,16 @@ in {
     new this, valueStore in {
       contract this(@"add", @x, success) = {
         if (x >= 0) {
-          for(@v <- @(*MergeableTag, *valueStore)){
+          // Peek the value
+          for (@v <<- @(*MergeableTag, *valueStore)) {
             if (v + x >= v) {
-              @(*MergeableTag, *valueStore)!(v + x) | success!(true)
+              // No overflow => consume + replace and return success
+              for (_ <- @(*MergeableTag, *valueStore)) {
+                @(*MergeableTag, *valueStore)!(v + x) | success!(true)
+              }
             } else {
-              //overflow
-              @(*MergeableTag, *valueStore)!(v) | success!(false)
+              // Overflow => return failure
+              success!(false)
             }
           }
         } else {
@@ -40,11 +44,16 @@ in {
       } |
       contract this(@"sub", @x, success) = {
         if (x >= 0) {
-          for(@v <- @(*MergeableTag, *valueStore)) {
+          // Peek the value
+          for (@v <<- @(*MergeableTag, *valueStore)) {
             if (x <= v) {
-              @(*MergeableTag, *valueStore)!(v - x) | success!(true)
+              // Valid amount to subtract => consume + replace and return success
+              for (_ <- @(*MergeableTag, *valueStore)) {
+                @(*MergeableTag, *valueStore)!(v - x) | success!(true)
+              }
             } else {
-              @(*MergeableTag, *valueStore)!(v) | success!(false)
+              // Invalid amount to subtract => return failure
+              success!(false)
             }
           }
         } else {
@@ -52,14 +61,15 @@ in {
         }
       } |
       contract this(@"value", return) = {
-        for(@v <- @(*MergeableTag, *valueStore)) {
-          @(*MergeableTag, *valueStore)!(v) | return!(v)
+        // Peek the value
+        for (@v <<- @(*MergeableTag, *valueStore)) {
+          return!(v)
         }
       } |
       return!(bundle+{*this}) |
       match init { //Initial balance is zero if given is negative on non-integer
         Int => {
-          if (init >= 0) { @(*MergeableTag, *valueStore)!(init)  }
+          if (init >= 0) { @(*MergeableTag, *valueStore)!(init) }
           else           { @(*MergeableTag, *valueStore)!(0) }
         }
          _ => { @(*MergeableTag, *valueStore)!(0) }

--- a/casper/src/main/resources/NonNegativeNumber.rho
+++ b/casper/src/main/resources/NonNegativeNumber.rho
@@ -16,8 +16,8 @@
  */
 
 new
-  NonNegativeNumber,
-  MergeableTag,
+  NonNegativeNumber,  // Unforgeable contract location stored in registry
+  MergeableTag,       // Indirection for mergeability
   rs(`rho:registry:insertSigned:secp256k1`),
   uriOut,
   deployerId(`rho:rchain:deployerId`)
@@ -61,13 +61,14 @@ in {
         }
       } |
       contract this(@"value", return) = {
-        // Peek the value
+        // Peek the value and return
         for (@v <<- @(*MergeableTag, *valueStore)) {
           return!(v)
         }
       } |
       return!(bundle+{*this}) |
-      match init { //Initial balance is zero if given is negative on non-integer
+      // Initial balance is zero if `init` is negative or non-integer
+      match init {
         Int => {
           if (init >= 0) { @(*MergeableTag, *valueStore)!(init) }
           else           { @(*MergeableTag, *valueStore)!(0) }

--- a/casper/src/test/resources/NonNegativeNumberTest.rho
+++ b/casper/src/test/resources/NonNegativeNumberTest.rho
@@ -5,47 +5,76 @@ new
   rl(`rho:registry:lookup`), RhoSpecCh, NonNegativeNumberCh,
   test_initialize_with_negative_value, test_initialize_with_nonnegative_value,
   test_operations_with_negative_numbers, test_subtract_too_much, test_add_successful,
-  test_subtract_successful, test_fail_on_overflow
+  test_subtract_successful, test_fail_on_overflow, test_initialize_with_noninteger_value
 in {
   rl!(`rho:id:zphjgsfy13h1k85isc8rtwtgt3t9zzt5pjd5ihykfmyapfc4wt3x5h`, *RhoSpecCh) |
-  for(@(_, RhoSpec) <- RhoSpecCh) {
+  for (@(_, RhoSpec) <- RhoSpecCh) {
     @RhoSpec!("testSuite",
       [
-        ("Initially negative balances are be converted to 0.", *test_initialize_with_negative_value),
-        ("Positive initial balances are preserved.", *test_initialize_with_nonnegative_value),
-        ("Adding or subtracting a negative number fails.", *test_operations_with_negative_numbers),
-        ("Subtracting an amount larger than the balance fails.", *test_subtract_too_much),
-        ("Adding a positive number works if there's no overflow.", *test_add_successful),
+        ("Initially negative balances are converted to 0", *test_initialize_with_negative_value),
+        ("Initially noninteger balances are converted to 0", *test_initialize_with_noninteger_value),
+        ("Positive initial balances are preserved", *test_initialize_with_nonnegative_value),
+        ("Adding or subtracting a negative number fails", *test_operations_with_negative_numbers),
+        ("Subtracting an amount larger than the balance fails", *test_subtract_too_much),
+        ("Adding a positive number works if there's no overflow", *test_add_successful),
         ("Subtracting a positive number less than or equal to the balance works", *test_subtract_successful),
         ("Addition overflow is prevented", *test_fail_on_overflow)
       ])
   } |
 
   rl!(`rho:lang:nonNegativeNumber`, *NonNegativeNumberCh) |
-  for(@(_, NonNegativeNumber) <- NonNegativeNumberCh) {
+  for (@(_, NonNegativeNumber) <- NonNegativeNumberCh) {
     contract test_initialize_with_negative_value(rhoSpec, _, ackCh) = {
-      new ch1 in {
-        @NonNegativeNumber!(-1, *ch1) |
-        for (v1 <- ch1) {
+      new ch in {
+        @NonNegativeNumber!(-1, *ch) |
+        for (v <- ch) {
+          v!("value", *ch) |
+          rhoSpec!("assert", (0, "== <-", *ch), "-1 is converted to 0", *ackCh)
+        }
+      }
+    } |
+
+    contract test_initialize_with_noninteger_value(rhoSpec, _, ackCh) = {
+      new ch1, ch2, ch3, ch4, ch5 in {
+        @NonNegativeNumber!("a", *ch1) |
+        @NonNegativeNumber!(Nil, *ch2) |
+        @NonNegativeNumber!([], *ch3) |
+        @NonNegativeNumber!({}, *ch4) |
+        @NonNegativeNumber!(Set(), *ch5) |
+        for (v1 <- ch1 & v2 <- ch2 & v3 <- ch3 & v4 <- ch4 & v5 <- ch5) {
           v1!("value", *ch1) |
-          rhoSpec!("assert", (0, "== <-", *ch1), "-1 is converted to 0", *ackCh)
+          v2!("value", *ch2) |
+          v3!("value", *ch3) |
+          v4!("value", *ch4) |
+          v5!("value", *ch5) |
+          rhoSpec!("assertMany",
+            [
+              ((0, "== <-", *ch1), "string is converted to 0"),
+              ((0, "== <-", *ch2), "Nil is converted to 0"),
+              ((0, "== <-", *ch3), "list is converted to 0"),
+              ((0, "== <-", *ch4), "map is converted to 0"),
+              ((0, "== <-", *ch5), "set is converted to 0"),
+            ],
+            *ackCh)
         }
       }
     } |
 
     contract test_initialize_with_nonnegative_value(rhoSpec, _, ackCh) = {
       new ch1, ch2 in {
-        @NonNegativeNumber!(0, *ch1) |
-        @NonNegativeNumber!(1, *ch2) |
-        for (v1 <- ch1 & v2 <- ch2) {
-          v1!("value", *ch1) |
-          v2!("value", *ch2) |
-          rhoSpec!("assertMany",
-            [
-              ((0, "== <-", *ch1), "0 stays the same"),
-              ((1, "== <-", *ch2), "1 stays the same"),
-            ],
-            *ackCh)
+        let @init1 <- 0 & @init2 <- 1 in {
+          @NonNegativeNumber!(init1, *ch1) |
+          @NonNegativeNumber!(init2, *ch2) |
+          for (v1 <- ch1 & v2 <- ch2) {
+            v1!("value", *ch1) |
+            v2!("value", *ch2) |
+            rhoSpec!("assertMany",
+              [
+                ((init1, "== <-", *ch1), "Positive value initializes"),
+                ((init2, "== <-", *ch2), "Positive value initializes"),
+              ],
+              *ackCh)
+          }
         }
       }
     } |
@@ -78,17 +107,19 @@ in {
 
     contract test_add_successful(rhoSpec, _, ackCh) = {
       new ch in {
-        @NonNegativeNumber!(0, *ch) |
-        for (nn <- ch) {
-          nn!("add", 1, *ch) |
-          for (@result <- ch) {
-            nn!("value", *ch) |
-            rhoSpec!("assertMany",
-              [
-                ((true, "==", result), "add succeeds"),
-                ((1, "== <-", *ch), "result is correct"),
-              ],
-              *ackCh)
+        let @init <- 0 & @amt <- 1 in {
+          @NonNegativeNumber!(init, *ch) |
+          for (v <- ch) {
+            v!("add", amt, *ch) |
+            for (@result <- ch) {
+              v!("value", *ch) |
+              rhoSpec!("assertMany",
+                [
+                  ((true, "==", result), "add succeeds"),
+                  ((init + amt, "== <-", *ch), "result is correct"),
+                ],
+                *ackCh)
+            }
           }
         }
       }
@@ -96,17 +127,19 @@ in {
 
     contract test_subtract_successful(rhoSpec, _, ackCh) = {
       new ch in {
-        @NonNegativeNumber!(2, *ch) |
-        for (nn <- ch) {
-          nn!("sub", 1, *ch) |
-          for (@result <- ch) {
-            nn!("value", *ch) |
-            rhoSpec!("assertMany",
-              [
-                ((true, "==", result), "sub succeeds"),
-                ((1, "== <-", *ch), "result is correct"),
-              ],
-              *ackCh)
+        let @init <- 2 & @amt <- 1 in {
+          @NonNegativeNumber!(2, *ch) |
+          for (v <- ch) {
+            v!("sub", 1, *ch) |
+            for (@result <- ch) {
+              v!("value", *ch) |
+              rhoSpec!("assertMany",
+                [
+                  ((true, "==", result), "sub succeeds"),
+                  ((init - amt, "== <-", *ch), "result is correct"),
+                ],
+                *ackCh)
+            }
           }
         }
       }
@@ -114,10 +147,12 @@ in {
 
     contract test_fail_on_overflow(rhoSpec, _, ackCh) = {
       new ch in {
-        @NonNegativeNumber!(9223372036854775757, *ch) |
-        for (nn <- ch) {
-          nn!("add", 9223372036854775757, *ch) |
-          rhoSpec!("assert", (false, "== <-", *ch), "add fails", *ackCh)
+        let @max <- 9223372036854775757 in {
+          @NonNegativeNumber!(max, *ch) |
+          for (v <- ch) {
+            v!("add", max, *ch) |
+            rhoSpec!("assert", (false, "== <-", *ch), "add fails", *ackCh)
+          }
         }
       }
     }


### PR DESCRIPTION
## Overview
This PR removes the consume/replace pattern with peek where applicable in the NonNegativeNumber contract to avoid unnecessary conflicts. It also extends the NonNegativeNumberSpec to include unit tests for additional incorrect initiailizations.


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
