### PR TITLE
Refactor block validation logic - pure functions

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
@@ -1,0 +1,18 @@
+package coop.rchain.casper
+
+import coop.rchain.casper.Validate.signatureVerifiers
+import coop.rchain.casper.protocol.BlockMessage
+
+import scala.util.{Success, Try}
+
+object BlockValidationLogic {
+  def blockSignature(b: BlockMessage): Boolean =
+    signatureVerifiers
+      .get(b.sigAlgorithm)
+      .exists(verify => {
+        Try(verify(b.blockHash.toByteArray, b.sig.toByteArray, b.sender.toByteArray)) match {
+          case Success(true) => true
+          case _             => false
+        }
+      })
+}

--- a/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
@@ -3,6 +3,7 @@ package coop.rchain.casper
 import cats.syntax.all._
 import coop.rchain.casper.Validate.signatureVerifiers
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.models.BlockVersion
 import coop.rchain.models.syntax._
 
@@ -55,4 +56,6 @@ object BlockValidationLogic {
       BlockStatus.invalidDeployShardId.asLeft[ValidBlock]
     }
   }
+
+  def blockHash(b: BlockMessage): Boolean = b.blockHash == ProtoUtil.hashBlock(b)
 }

--- a/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
@@ -58,4 +58,17 @@ object BlockValidationLogic {
   }
 
   def blockHash(b: BlockMessage): Boolean = b.blockHash == ProtoUtil.hashBlock(b)
+
+  /**
+    * All of deploys must have greater or equal phloPrice then minPhloPrice
+    */
+  def phloPrice(
+      b: BlockMessage,
+      minPhloPrice: Long
+  ): ValidBlockProcessing =
+    if (b.state.deploys.forall(_.deploy.data.phloPrice >= minPhloPrice)) {
+      BlockStatus.valid.asRight[InvalidBlock]
+    } else {
+      BlockStatus.containsLowCostDeploy.asLeft[ValidBlock]
+    }
 }

--- a/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
@@ -2,6 +2,7 @@ package coop.rchain.casper
 
 import coop.rchain.casper.Validate.signatureVerifiers
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.syntax._
 
 import scala.util.{Success, Try}
 
@@ -15,4 +16,11 @@ object BlockValidationLogic {
           case _             => false
         }
       })
+
+  def formatOfFields(b: BlockMessage): Boolean =
+    b.blockHash.nonEmpty &&
+      b.sig.nonEmpty &&
+      b.sigAlgorithm.nonEmpty &&
+      b.shardId.nonEmpty &&
+      b.postStateHash.nonEmpty
 }

--- a/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
@@ -33,4 +33,13 @@ object BlockValidationLogic {
       .find(_.data.validAfterBlockNumber > b.blockNumber)
       .as(BlockStatus.containsFutureDeploy.asLeft[ValidBlock])
       .getOrElse(BlockStatus.valid.asRight[InvalidBlock])
+
+  def transactionExpiration(b: BlockMessage, expirationThreshold: Int): ValidBlockProcessing = {
+    val earliestAcceptableValidAfterBlockNumber = b.blockNumber - expirationThreshold
+    b.state.deploys
+      .map(_.deploy)
+      .find(_.data.validAfterBlockNumber <= earliestAcceptableValidAfterBlockNumber)
+      .as(BlockStatus.containsExpiredDeploy.asLeft[ValidBlock])
+      .getOrElse(BlockStatus.valid.asRight[InvalidBlock])
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
@@ -42,4 +42,17 @@ object BlockValidationLogic {
       .as(BlockStatus.containsExpiredDeploy.asLeft[ValidBlock])
       .getOrElse(BlockStatus.valid.asRight[InvalidBlock])
   }
+
+  // Validator should only process deploys from its own shard with shard names in ASCII characters only
+  def deploysShardIdentifier(
+      b: BlockMessage,
+      shardId: String
+  ): ValidBlockProcessing = {
+    assert(shardId.onlyAscii, "Shard name should contain only ASCII characters")
+    if (b.state.deploys.forall(_.deploy.data.shardId == shardId)) {
+      BlockStatus.valid.asRight[InvalidBlock]
+    } else {
+      BlockStatus.invalidDeployShardId.asLeft[ValidBlock]
+    }
+  }
 }

--- a/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
@@ -2,6 +2,7 @@ package coop.rchain.casper
 
 import coop.rchain.casper.Validate.signatureVerifiers
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockVersion
 import coop.rchain.models.syntax._
 
 import scala.util.{Success, Try}
@@ -23,4 +24,5 @@ object BlockValidationLogic {
       b.sigAlgorithm.nonEmpty &&
       b.shardId.nonEmpty &&
       b.postStateHash.nonEmpty
+  def version(b: BlockMessage): Boolean = BlockVersion.Supported.contains(b.version)
 }

--- a/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
+++ b/casper/src/main/scala/coop/rchain/casper/BlockValidationLogic.scala
@@ -31,47 +31,27 @@ object BlockValidationLogic {
         }
       })
 
-  def futureTransaction(b: BlockMessage): ValidBlockProcessing =
-    b.state.deploys
-      .map(_.deploy)
-      .find(_.data.validAfterBlockNumber > b.blockNumber)
-      .as(BlockStatus.containsFutureDeploy.asLeft[ValidBlock])
-      .getOrElse(BlockStatus.valid.asRight[InvalidBlock])
+  def futureTransaction(b: BlockMessage): Boolean =
+    !b.state.deploys.map(_.deploy).exists(_.data.validAfterBlockNumber > b.blockNumber)
 
-  def transactionExpiration(b: BlockMessage, expirationThreshold: Int): ValidBlockProcessing = {
+  def transactionExpiration(b: BlockMessage, expirationThreshold: Int): Boolean = {
     val earliestAcceptableValidAfterBlockNumber = b.blockNumber - expirationThreshold
-    b.state.deploys
+    !b.state.deploys
       .map(_.deploy)
-      .find(_.data.validAfterBlockNumber <= earliestAcceptableValidAfterBlockNumber)
-      .as(BlockStatus.containsExpiredDeploy.asLeft[ValidBlock])
-      .getOrElse(BlockStatus.valid.asRight[InvalidBlock])
+      .exists(_.data.validAfterBlockNumber <= earliestAcceptableValidAfterBlockNumber)
   }
 
   /**
     * Validator should only process deploys from its own shard with shard names in ASCII characters only
     */
-  def deploysShardIdentifier(
-      b: BlockMessage,
-      shardId: String
-  ): ValidBlockProcessing = {
+  def deploysShardIdentifier(b: BlockMessage, shardId: String): Boolean = {
     assert(shardId.onlyAscii, "Shard name should contain only ASCII characters")
-    if (b.state.deploys.forall(_.deploy.data.shardId == shardId)) {
-      BlockStatus.valid.asRight[InvalidBlock]
-    } else {
-      BlockStatus.invalidDeployShardId.asLeft[ValidBlock]
-    }
+    b.state.deploys.forall(_.deploy.data.shardId == shardId)
   }
 
   /**
     * All of deploys must have greater or equal phloPrice then minPhloPrice
     */
-  def phloPrice(
-      b: BlockMessage,
-      minPhloPrice: Long
-  ): ValidBlockProcessing =
-    if (b.state.deploys.forall(_.deploy.data.phloPrice >= minPhloPrice)) {
-      BlockStatus.valid.asRight[InvalidBlock]
-    } else {
-      BlockStatus.containsLowCostDeploy.asLeft[ValidBlock]
-    }
+  def phloPrice(b: BlockMessage, minPhloPrice: Long): Boolean =
+    b.state.deploys.forall(_.deploy.data.phloPrice >= minPhloPrice)
 }

--- a/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
+++ b/casper/src/main/scala/coop/rchain/casper/MultiParentCasper.scala
@@ -183,7 +183,7 @@ object MultiParentCasper {
 
         // This validation is only to punish validator which accepted lower price deploys.
         // And this can happen if not configured correctly.
-        status <- EitherT(Validate.phloPrice(block, minPhloPrice))
+        status <- EitherT(Sync[F].delay(BlockValidationLogic.phloPrice(block, minPhloPrice)))
                    .recoverWith {
                      case _ =>
                        val warnToLog = EitherT.liftF[F, InvalidBlock, Unit](

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -1,9 +1,9 @@
 package coop.rchain.casper
 
+import cats.Monad
 import cats.data.EitherT
 import cats.effect.{Concurrent, Sync}
 import cats.syntax.all._
-import cats.{Applicative, Monad}
 import com.google.protobuf.ByteString
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
@@ -170,24 +170,6 @@ object Validate {
                  } yield BlockStatus.invalidSequenceNumber.asLeft[ValidBlock]
                }
     } yield status
-
-  def blockHash[F[_]: Applicative: Log](b: BlockMessage): F[Boolean] = {
-    val blockHashComputed = ProtoUtil.hashBlock(b)
-    if (b.blockHash == blockHashComputed)
-      true.pure
-    else {
-      val computedHashString = PrettyPrinter.buildString(blockHashComputed)
-      val hashString         = PrettyPrinter.buildString(b.blockHash)
-      for {
-        _ <- Log[F].warn(
-              ignore(
-                b,
-                s"block hash $hashString does not match to computed value $computedHashString."
-              )
-            )
-      } yield false
-    }
-  }
 
   /**
     * Justification regression check.

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -37,31 +37,6 @@ object Validate {
 
   /* Validation of block with logging included */
 
-  def formatOfFields[F[_]: Monad: Log](b: BlockMessage): F[Boolean] =
-    if (b.blockHash.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block hash is empty."))
-      } yield false
-    } else if (b.sig.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block signature is empty."))
-      } yield false
-    } else if (b.sigAlgorithm.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block signature algorithm is empty."))
-      } yield false
-    } else if (b.shardId.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block shard identifier is empty."))
-      } yield false
-    } else if (b.postStateHash.isEmpty) {
-      for {
-        _ <- Log[F].warn(ignore(b, s"block post state hash is empty."))
-      } yield false
-    } else {
-      true.pure
-    }
-
   def version[F[_]: Monad: Log](b: BlockMessage): F[Boolean] = {
     val blockVersion = b.version
     if (BlockVersion.Supported.contains(blockVersion)) {

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -15,8 +15,8 @@ import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.dag.DagOps
 import coop.rchain.metrics.{Metrics, Span}
+import coop.rchain.models.BlockMetadata
 import coop.rchain.models.syntax._
-import coop.rchain.models.{BlockMetadata, BlockVersion}
 import coop.rchain.shared._
 
 // TODO: refactor all validation functions to separate logging from actual validation logic
@@ -36,17 +36,6 @@ object Validate {
     s"Ignoring block ${PrettyPrinter.buildString(b.blockHash)} because $reason"
 
   /* Validation of block with logging included */
-
-  def version[F[_]: Monad: Log](b: BlockMessage): F[Boolean] = {
-    val blockVersion = b.version
-    if (BlockVersion.Supported.contains(blockVersion)) {
-      true.pure
-    } else {
-      val versionsStr = BlockVersion.Supported.mkString(" or ")
-      val msg         = s"received block version $blockVersion is not the expected version $versionsStr."
-      Log[F].warn(ignore(b, msg)).as(false)
-    }
-  }
 
   def blockSummary[F[_]: Sync: BlockDagStorage: BlockStore: Log: Metrics: Span](
       block: BlockMessage,

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -40,7 +40,7 @@ object Validate {
       shardId: String,
       expirationThreshold: Int
   ): F[ValidBlockProcessing] = {
-    def validate(f: => Boolean, errorStatus: InvalidBlock): EitherT[F, InvalidBlock, ValidBlock] =
+    def validate(f: Boolean, errorStatus: => InvalidBlock): EitherT[F, InvalidBlock, ValidBlock] =
       EitherT.fromOption(Option(BlockStatus.valid).filter(_ => f), errorStatus)
 
     (for {

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -24,7 +24,6 @@ object Validate {
   type Data      = Array[Byte]
   type Signature = Array[Byte]
 
-  val DRIFT                                 = 15000 // 15 seconds
   implicit private val logSource: LogSource = LogSource(this.getClass)
   val signatureVerifiers: Map[String, (Data, Signature, PublicKey) => Boolean] =
     Map(

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -15,11 +15,9 @@ import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.crypto.signatures.Secp256k1
 import coop.rchain.dag.DagOps
 import coop.rchain.metrics.{Metrics, Span}
-import coop.rchain.models.{BlockMetadata, BlockVersion}
 import coop.rchain.models.syntax._
+import coop.rchain.models.{BlockMetadata, BlockVersion}
 import coop.rchain.shared._
-
-import scala.util.{Success, Try}
 
 // TODO: refactor all validation functions to separate logging from actual validation logic
 object Validate {
@@ -38,20 +36,6 @@ object Validate {
     s"Ignoring block ${PrettyPrinter.buildString(b.blockHash)} because $reason"
 
   /* Validation of block with logging included */
-
-  def blockSignature[F[_]: Applicative: Log](b: BlockMessage): F[Boolean] =
-    signatureVerifiers
-      .get(b.sigAlgorithm)
-      .map(verify => {
-        Try(verify(b.blockHash.toByteArray, b.sig.toByteArray, b.sender.toByteArray)) match {
-          case Success(true) => true.pure
-          case _             => Log[F].warn(ignore(b, "signature is invalid.")).map(_ => false)
-        }
-      }) getOrElse {
-      for {
-        _ <- Log[F].warn(ignore(b, s"signature algorithm ${b.sigAlgorithm} is unsupported."))
-      } yield false
-    }
 
   def formatOfFields[F[_]: Monad: Log](b: BlockMessage): F[Boolean] =
     if (b.blockHash.isEmpty) {

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -30,7 +30,7 @@ object Validate {
       "secp256k1" -> Secp256k1.verify
     )
 
-  def ignore(b: BlockMessage, reason: String): String =
+  private def ignore(b: BlockMessage, reason: String): String =
     s"Ignoring block ${PrettyPrinter.buildString(b.blockHash)} because $reason"
 
   /* Validation of block with logging included */

--- a/casper/src/main/scala/coop/rchain/casper/Validate.scala
+++ b/casper/src/main/scala/coop/rchain/casper/Validate.scala
@@ -248,17 +248,4 @@ object Validate {
       }
     }
   }
-
-  /**
-    * All of deploys must have greater or equal phloPrice then minPhloPrice
-    */
-  def phloPrice[F[_]: Log: Concurrent](
-      b: BlockMessage,
-      minPhloPrice: Long
-  ): F[ValidBlockProcessing] =
-    if (b.state.deploys.forall(_.deploy.data.phloPrice >= minPhloPrice)) {
-      BlockStatus.valid.asRight[InvalidBlock].pure
-    } else {
-      BlockStatus.containsLowCostDeploy.asLeft[ValidBlock].pure
-    }
 }

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
@@ -205,7 +205,7 @@ object BlockReceiver {
       // TODO: 1. validation and logging in these checks should be separated
       //       2. logging of these block should indicate that information cannot be trusted
       //           e.g. if block hash is invalid it cannot represent identity of a block
-      val validFormat = Validate.formatOfFields(b)
+      val validFormat = BlockValidationLogic.formatOfFields(b).pure
       val validHash   = Validate.blockHash(b)
       val validSig    = BlockValidationLogic.blockSignature(b).pure
       // TODO: check sender to be valid bonded validator

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
@@ -9,7 +9,7 @@ import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.syntax._
-import coop.rchain.casper.{BlockValidationLogic, PrettyPrinter, Validate}
+import coop.rchain.casper.{BlockValidationLogic, PrettyPrinter}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.Log
 import coop.rchain.shared.syntax._
@@ -205,14 +205,14 @@ object BlockReceiver {
       // TODO: 1. validation and logging in these checks should be separated
       //       2. logging of these block should indicate that information cannot be trusted
       //           e.g. if block hash is invalid it cannot represent identity of a block
-      val validFormat = BlockValidationLogic.formatOfFields(b).pure
-      val validHash   = Validate.blockHash(b)
-      val validSig    = BlockValidationLogic.blockSignature(b).pure
+      val validFormat = BlockValidationLogic.formatOfFields(b)
+      val validHash   = BlockValidationLogic.blockHash(b)
+      val validSig    = BlockValidationLogic.blockSignature(b)
       // TODO: check sender to be valid bonded validator
       //  - not always possible because now are new blocks downloaded from DAG tips
       //    which in case of epoch change sender can be unknown
       // TODO: check valid version (possibly part of hash checking)
-      validFormat &&^ validShard &&^ validHash &&^ validSig
+      validShard &&^ (validFormat && validHash && validSig).pure
     }
 
     // Check if block should be stored

--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
@@ -9,7 +9,7 @@ import coop.rchain.blockstorage.BlockStore.BlockStore
 import coop.rchain.blockstorage.dag.BlockDagStorage
 import coop.rchain.casper.protocol.BlockMessage
 import coop.rchain.casper.syntax._
-import coop.rchain.casper.{PrettyPrinter, Validate}
+import coop.rchain.casper.{BlockValidationLogic, PrettyPrinter, Validate}
 import coop.rchain.models.BlockHash.BlockHash
 import coop.rchain.shared.Log
 import coop.rchain.shared.syntax._
@@ -207,7 +207,7 @@ object BlockReceiver {
       //           e.g. if block hash is invalid it cannot represent identity of a block
       val validFormat = Validate.formatOfFields(b)
       val validHash   = Validate.blockHash(b)
-      val validSig    = Validate.blockSignature(b)
+      val validSig    = BlockValidationLogic.blockSignature(b).pure
       // TODO: check sender to be valid bonded validator
       //  - not always possible because now are new blocks downloaded from DAG tips
       //    which in case of epoch change sender can be unknown

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeSyncing.scala
@@ -1,7 +1,7 @@
 package coop.rchain.casper.engine
 
 import cats.effect.concurrent.{Deferred, Ref}
-import cats.effect.{Concurrent, Timer}
+import cats.effect.{Concurrent, Sync, Timer}
 import cats.syntax.all._
 import coop.rchain.blockstorage.BlockStore
 import coop.rchain.blockstorage.BlockStore.BlockStore
@@ -143,7 +143,7 @@ class NodeSyncing[F[_]
                              BlockStore[F].contains(_),
                              BlockStore[F].getUnsafe,
                              BlockStore[F].put(_, _),
-                             Validate.blockHash[F]
+                             block => Sync[F].delay(BlockValidationLogic.blockHash(block))
                            )
 
       // Request tuple space state for Last Finalized State

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockValidationLogicSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockValidationLogicSpec.scala
@@ -1,7 +1,9 @@
 package coop.rchain.casper.batch2
 
+import com.google.protobuf.ByteString
 import coop.rchain.casper.BlockValidationLogic
 import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.casper.util.ProtoUtil
 import coop.rchain.models.BlockVersion
 import coop.rchain.models.blockImplicits.arbBlockMessage
 import org.scalacheck.Arbitrary
@@ -11,9 +13,9 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 class BlockValidationLogicSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 
-  "Block version validation" should "allow supported versions" in {
-    implicit val aBlock: Arbitrary[BlockMessage] = arbBlockMessage
+  implicit private val aBlock: Arbitrary[BlockMessage] = arbBlockMessage
 
+  "Block version validation" should "allow supported versions" in {
     forAll { (block: BlockMessage, version: Int) =>
       val blockWithVersion = block.copy(version = version)
 
@@ -23,6 +25,25 @@ class BlockValidationLogicSpec extends AnyFlatSpec with Matchers with ScalaCheck
       val actualValid = BlockValidationLogic.version(blockWithVersion)
 
       actualValid shouldBe expectedValid
+    }
+  }
+
+  "Block hash format validation" should "fail on invalid hash" in {
+    forAll { (block: BlockMessage) =>
+      val hash           = ProtoUtil.hashBlock(block)
+      val blockValidHash = block.copy(blockHash = hash)
+
+      // Test valid block hash
+      val hashValid = BlockValidationLogic.blockHash(blockValidHash)
+
+      hashValid shouldBe true
+
+      val blockInValidHash = block.copy(blockHash = ByteString.copyFromUtf8("123"))
+
+      // Test invalid block hash
+      val hashInValid = BlockValidationLogic.blockHash(blockInValidHash)
+
+      hashInValid shouldBe false
     }
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockValidationLogicSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockValidationLogicSpec.scala
@@ -109,7 +109,7 @@ class BlockValidationLogicSpec extends AnyFlatSpec with Matchers with ScalaCheck
     val block  = getRandomBlock(setDeploys = Seq(ProcessedDeploy.empty(deploy)).some)
     val status = BlockValidationLogic.futureTransaction(block)
 
-    status shouldBe Right(Valid)
+    status shouldBe true
   }
 
   it should "not accept blocks with a deploy for a future block number" in {
@@ -117,7 +117,7 @@ class BlockValidationLogicSpec extends AnyFlatSpec with Matchers with ScalaCheck
     val block  = getRandomBlock(setDeploys = Seq(ProcessedDeploy.empty(deploy)).some)
     val status = BlockValidationLogic.futureTransaction(block)
 
-    status shouldBe Left(ContainsFutureDeploy)
+    status shouldBe false
   }
 
   private def signedBlock(privateKey: PrivateKey, publicKey: PublicKey): BlockMessage =
@@ -138,13 +138,13 @@ class BlockValidationLogicSpec extends AnyFlatSpec with Matchers with ScalaCheck
     val deploy = createDeploy(-1L)
     val block  = getRandomBlock(setDeploys = Seq(ProcessedDeploy.empty(deploy)).some)
     val status = BlockValidationLogic.transactionExpiration(block, expirationThreshold = 10)
-    status shouldBe Right(Valid)
+    status shouldBe true
   }
 
   it should "not accept blocks with a deploy that is expired" in {
     val deploy = createDeploy(Long.MinValue)
     val block  = getRandomBlock(setDeploys = Seq(ProcessedDeploy.empty(deploy)).some)
     val status = BlockValidationLogic.transactionExpiration(block, expirationThreshold = 10)
-    status shouldBe Left(ContainsExpiredDeploy)
+    status shouldBe false
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockValidationLogicSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockValidationLogicSpec.scala
@@ -96,20 +96,14 @@ class BlockValidationLogicSpec extends AnyFlatSpec with Matchers with ScalaCheck
     }
   }
 
-  "Future deploy validation" should "work" in {
-    val deploy = createDeploy(-1L)
-    val block  = getRandomBlock(setDeploys = Seq(ProcessedDeploy.empty(deploy)).some)
-    val status = BlockValidationLogic.futureTransaction(block)
+  "Future deploy validation" should "check that vabn does not exceed the block number" in {
+    // vabn = valid after block number
+    forAll(Gen.oneOf(-1L, 0L, 1L)) { vabn: Long =>
+      val deploy = createDeploy(vabn)
+      val block  = getRandomBlock(setDeploys = Seq(ProcessedDeploy.empty(deploy)).some)
 
-    status shouldBe true
-  }
-
-  it should "not accept blocks with a deploy for a future block number" in {
-    val deploy = createDeploy(Long.MaxValue)
-    val block  = getRandomBlock(setDeploys = Seq(ProcessedDeploy.empty(deploy)).some)
-    val status = BlockValidationLogic.futureTransaction(block)
-
-    status shouldBe false
+      BlockValidationLogic.futureTransaction(block) shouldBe (vabn <= block.blockNumber)
+    }
   }
 
   private def signedBlock(privateKey: PrivateKey, publicKey: PublicKey): BlockMessage =

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockValidationLogicSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockValidationLogicSpec.scala
@@ -1,0 +1,28 @@
+package coop.rchain.casper.batch2
+
+import coop.rchain.casper.BlockValidationLogic
+import coop.rchain.casper.protocol.BlockMessage
+import coop.rchain.models.BlockVersion
+import coop.rchain.models.blockImplicits.arbBlockMessage
+import org.scalacheck.Arbitrary
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+class BlockValidationLogicSpec extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
+
+  "Block version validation" should "allow supported versions" in {
+    implicit val aBlock: Arbitrary[BlockMessage] = arbBlockMessage
+
+    forAll { (block: BlockMessage, version: Int) =>
+      val blockWithVersion = block.copy(version = version)
+
+      // Expected one of hard-coded block versions supported by this version of RNode software
+      val expectedValid = BlockVersion.Supported.contains(version)
+      // Actual validation
+      val actualValid = BlockValidationLogic.version(blockWithVersion)
+
+      actualValid shouldBe expectedValid
+    }
+  }
+}

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -181,7 +181,7 @@ class ValidateTest
       } yield ()
   }
 
-  it should "return false for non-sequential numbering" in withStorage {
+  "Sequence number validation" should "return false for non-sequential numbering" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {
         chain <- createChain[Task](2)

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -490,28 +490,4 @@ class ValidateTest
         _ = BlockValidationLogic.formatOfFields(genesis.copy(postStateHash = ByteString.EMPTY)) shouldBe false
       } yield ()
   }
-
-  "Block hash format validation" should "fail on invalid hash" in {
-    implicit val aBlock = arbBlockMessage
-
-    forAll { (block: BlockMessage) =>
-      val hash           = ProtoUtil.hashBlock(block)
-      val blockValidHash = block.copy(blockHash = hash)
-
-      // Test valid block hash
-      val hashValid = BlockValidationLogic.blockHash(blockValidHash)
-
-      hashValid shouldBe true
-
-      val blockInValidHash = block.copy(blockHash = ByteString.copyFromUtf8("123"))
-
-      // Test invalid block hash
-      val hashInValid = BlockValidationLogic.blockHash(blockInValidHash)
-
-      hashInValid shouldBe false
-    }
-  }
-
-
-
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -521,7 +521,7 @@ class ValidateTest
       // Expected one of hard-coded block versions supported by this version of RNode software
       val expectedValid = BlockVersion.Supported.contains(version)
       // Actual validation
-      val actualValid = Validate.version[Task](blockWithVersion).runSyncUnsafe()
+      val actualValid = BlockValidationLogic.version(blockWithVersion)
 
       actualValid shouldBe expectedValid
     }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -482,14 +482,12 @@ class ValidateTest
         seqNum = getLatestSeqNum(sender, dag) + 1L
         genesis = ValidatorIdentity(sk)
           .signBlock(context.genesisBlock.copy(seqNum = seqNum))
-        _ <- Validate.formatOfFields[Task](genesis) shouldBeF true
-        _ <- Validate.formatOfFields[Task](genesis.copy(blockHash = ByteString.EMPTY)) shouldBeF false
-        _ <- Validate.formatOfFields[Task](genesis.copy(sig = ByteString.EMPTY)) shouldBeF false
-        _ <- Validate.formatOfFields[Task](genesis.copy(sigAlgorithm = "")) shouldBeF false
-        _ <- Validate.formatOfFields[Task](genesis.copy(shardId = "")) shouldBeF false
-        _ <- Validate.formatOfFields[Task](
-              genesis.copy(postStateHash = ByteString.EMPTY)
-            ) shouldBeF false
+        _ = BlockValidationLogic.formatOfFields(genesis) shouldBe true
+        _ = BlockValidationLogic.formatOfFields(genesis.copy(blockHash = ByteString.EMPTY)) shouldBe false
+        _ = BlockValidationLogic.formatOfFields(genesis.copy(sig = ByteString.EMPTY)) shouldBe false
+        _ = BlockValidationLogic.formatOfFields(genesis.copy(sigAlgorithm = "")) shouldBe false
+        _ = BlockValidationLogic.formatOfFields(genesis.copy(shardId = "")) shouldBe false
+        _ = BlockValidationLogic.formatOfFields(genesis.copy(postStateHash = ByteString.EMPTY)) shouldBe false
       } yield ()
   }
 

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -276,7 +276,7 @@ class ValidateTest
         block <- createGenesis[Task](
                   deploys = Seq(deploy)
                 )
-        status <- Validate.transactionExpiration[Task](block, expirationThreshold = 10)
+        status = BlockValidationLogic.transactionExpiration(block, expirationThreshold = 10)
         _      = status should be(Right(Valid))
       } yield ()
   }
@@ -294,8 +294,10 @@ class ValidateTest
         blockWithExpiredDeploy <- createGenesis[Task](
                                    deploys = Seq(deploy.copy(deploy = updatedDeployData))
                                  )
-        status <- Validate
-                   .transactionExpiration[Task](blockWithExpiredDeploy, expirationThreshold = 10)
+        status = BlockValidationLogic.transactionExpiration(
+          blockWithExpiredDeploy,
+          expirationThreshold = 10
+        )
         _ = status should be(Left(ContainsExpiredDeploy))
       } yield ()
   }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -12,7 +12,6 @@ import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkTestRNodeStoreManager
 import coop.rchain.casper.rholang.{BlockRandomSeed, InterpreterUtil, RuntimeManager}
-import coop.rchain.casper.syntax._
 import coop.rchain.casper.util.GenesisBuilder.buildGenesis
 import coop.rchain.casper.util._
 import coop.rchain.crypto.PrivateKey
@@ -247,7 +246,7 @@ class ValidateTest
         block <- createGenesis[Task](
                   deploys = Seq(deploy.copy(deploy = updatedDeployData))
                 )
-        status <- Validate.futureTransaction[Task](block)
+        status = BlockValidationLogic.futureTransaction(block)
         _      = status should be(Right(Valid))
       } yield ()
   }
@@ -265,7 +264,7 @@ class ValidateTest
         blockWithFutureDeploy <- createGenesis[Task](
                                   deploys = Seq(deploy.copy(deploy = updatedDeployData))
                                 )
-        status <- Validate.futureTransaction[Task](blockWithFutureDeploy)
+        status = BlockValidationLogic.futureTransaction(blockWithFutureDeploy)
         _      = status should be(Left(ContainsFutureDeploy))
       } yield ()
   }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -181,42 +181,6 @@ class ValidateTest
       } yield ()
   }
 
-  "Future deploy validation" should "work" in withStorage {
-    implicit blockStore => implicit blockDagStorage =>
-      for {
-        deploy     <- ConstructDeploy.basicProcessedDeploy[Task](0)
-        deployData = deploy.deploy.data
-        updatedDeployData = Signed(
-          deployData.copy(validAfterBlockNumber = -1),
-          Secp256k1,
-          ConstructDeploy.defaultSec
-        )
-        block <- createGenesis[Task](
-                  deploys = Seq(deploy.copy(deploy = updatedDeployData))
-                )
-        status = BlockValidationLogic.futureTransaction(block)
-        _      = status should be(Right(Valid))
-      } yield ()
-  }
-
-  "Future deploy validation" should "not accept blocks with a deploy for a future block number" in withStorage {
-    implicit blockStore => implicit blockDagStorage =>
-      for {
-        deploy     <- ConstructDeploy.basicProcessedDeploy[Task](0)
-        deployData = deploy.deploy.data
-        updatedDeployData = Signed(
-          deployData.copy(validAfterBlockNumber = Long.MaxValue),
-          Secp256k1,
-          ConstructDeploy.defaultSec
-        )
-        blockWithFutureDeploy <- createGenesis[Task](
-                                  deploys = Seq(deploy.copy(deploy = updatedDeployData))
-                                )
-        status = BlockValidationLogic.futureTransaction(blockWithFutureDeploy)
-        _      = status should be(Left(ContainsFutureDeploy))
-      } yield ()
-  }
-
   "Deploy expiration validation" should "work" in withStorage {
     implicit blockStore => implicit blockDagStorage =>
       for {

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -18,7 +18,6 @@ import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
 import coop.rchain.metrics.{Metrics, NoopSpan, Span}
 import coop.rchain.models.BlockHash.BlockHash
-import coop.rchain.models.BlockVersion
 import coop.rchain.models.Validator.Validator
 import coop.rchain.models.blockImplicits._
 import coop.rchain.models.syntax._
@@ -513,19 +512,6 @@ class ValidateTest
     }
   }
 
-  "Block version validation" should "allow supported versions" in {
-    implicit val aBlock = arbBlockMessage
 
-    forAll { (block: BlockMessage, version: Int) =>
-      val blockWithVersion = block.copy(version = version)
-
-      // Expected one of hard-coded block versions supported by this version of RNode software
-      val expectedValid = BlockVersion.Supported.contains(version)
-      // Actual validation
-      val actualValid = BlockValidationLogic.version(blockWithVersion)
-
-      actualValid shouldBe expectedValid
-    }
-  }
 
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -12,7 +12,6 @@ import coop.rchain.casper.helper.{BlockDagStorageFixture, BlockGenerator}
 import coop.rchain.casper.protocol._
 import coop.rchain.casper.rholang.Resources.mkTestRNodeStoreManager
 import coop.rchain.casper.rholang.{BlockRandomSeed, InterpreterUtil, RuntimeManager}
-import coop.rchain.casper.util.GenesisBuilder.buildGenesis
 import coop.rchain.casper.util._
 import coop.rchain.crypto.PrivateKey
 import coop.rchain.crypto.signatures.{Secp256k1, Signed}
@@ -470,24 +469,5 @@ class ValidateTest
           } yield result
         }
       } yield result
-  }
-
-  "Field format validation" should "succeed on a valid block and fail on empty fields" in withStorage {
-    _ => implicit blockDagStorage =>
-      val context  = buildGenesis()
-      val (sk, pk) = context.validatorKeyPairs.head
-      for {
-        dag    <- blockDagStorage.getRepresentation
-        sender = ByteString.copyFrom(pk.bytes)
-        seqNum = getLatestSeqNum(sender, dag) + 1L
-        genesis = ValidatorIdentity(sk)
-          .signBlock(context.genesisBlock.copy(seqNum = seqNum))
-        _ = BlockValidationLogic.formatOfFields(genesis) shouldBe true
-        _ = BlockValidationLogic.formatOfFields(genesis.copy(blockHash = ByteString.EMPTY)) shouldBe false
-        _ = BlockValidationLogic.formatOfFields(genesis.copy(sig = ByteString.EMPTY)) shouldBe false
-        _ = BlockValidationLogic.formatOfFields(genesis.copy(sigAlgorithm = "")) shouldBe false
-        _ = BlockValidationLogic.formatOfFields(genesis.copy(shardId = "")) shouldBe false
-        _ = BlockValidationLogic.formatOfFields(genesis.copy(postStateHash = ByteString.EMPTY)) shouldBe false
-      } yield ()
   }
 }

--- a/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/ValidateTest.scala
@@ -500,14 +500,14 @@ class ValidateTest
       val blockValidHash = block.copy(blockHash = hash)
 
       // Test valid block hash
-      val hashValid = Validate.blockHash[Task](blockValidHash).runSyncUnsafe()
+      val hashValid = BlockValidationLogic.blockHash(blockValidHash)
 
       hashValid shouldBe true
 
       val blockInValidHash = block.copy(blockHash = ByteString.copyFromUtf8("123"))
 
       // Test invalid block hash
-      val hashInValid = Validate.blockHash[Task](blockInValidHash).runSyncUnsafe()
+      val hashInValid = BlockValidationLogic.blockHash(blockInValidHash)
 
       hashInValid shouldBe false
     }

--- a/models/src/main/scala/coop/rchain/models/ByteStringSyntax.scala
+++ b/models/src/main/scala/coop/rchain/models/ByteStringSyntax.scala
@@ -39,4 +39,6 @@ final class ByteStringOps(
 
   def toBlake2b256Hash: Blake2b256Hash = Blake2b256Hash.fromByteString(bs)
 
+  def nonEmpty: Boolean = !bs.isEmpty
+
 }


### PR DESCRIPTION
## Overview

The validation functions are made pure (outside the F-context). These functions are moved in a separate file. The corresponding tests have also been moved to a separate file.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
