### PR TITLE
Improve DAG visualizer for multi-parent finalizer with fringes in colors

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
+++ b/casper/src/main/scala/coop/rchain/casper/api/GraphGenerator.scala
@@ -1,186 +1,123 @@
 package coop.rchain.casper.api
 
-import cats.effect.{Concurrent, Sync}
+import cats.effect.Sync
 import cats.syntax.all._
-import cats.{Monad, _}
-import coop.rchain.blockstorage.BlockStore
-import coop.rchain.blockstorage.BlockStore.BlockStore
-import coop.rchain.casper._
-import coop.rchain.casper.syntax._
-import coop.rchain.catscontrib.Catscontrib._
-import coop.rchain.graphz._
-import coop.rchain.models.BlockHash.BlockHash
-import coop.rchain.shared.Log
+import cats.{Applicative, Monad}
+import coop.rchain.graphz.{GraphSerializer, _}
 
-final case class ValidatorBlock(
-    blockHash: String,
-    justifications: List[String]
-)
+import scala.collection.compat.immutable.LazyList
 
-final case class GraphConfig(showJustificationLines: Boolean = false)
-
-object GraphzGenerator {
+object GraphGenerator {
+  final case class ValidatorBlock(
+      id: String,
+      sender: String,
+      height: Long,
+      justifications: List[String],
+      fringe: Set[String]
+  ) {
+    override def hashCode(): Int = id.hashCode()
+  }
 
   type ValidatorsBlocks = Map[Long, List[ValidatorBlock]]
 
   final case class DagInfo(
       validators: Map[String, ValidatorsBlocks],
-      timeseries: List[Long]
+      timeseries: Set[Long]
   )
 
   object DagInfo {
-    def empty: DagInfo = DagInfo(validators = Map.empty, timeseries = List.empty)
+    def empty: DagInfo = DagInfo(validators = Map.empty, timeseries = Set.empty)
   }
 
-  def dagAsCluster[F[_]: Monad: Sync: Concurrent: Log: BlockStore](
-      topoSort: Vector[Vector[BlockHash]],
-      lastFinalizedBlockHash: String,
-      config: GraphConfig,
+  def dagAsCluster[F[_]: Sync](
+      blocks: Vector[ValidatorBlock],
       ser: GraphSerializer[F]
-  ): F[Graphz[F]] =
+  ): F[Graphz[F]] = {
+    val acc            = blocks.foldLeft(DagInfo.empty)(accumulateDagInfo)
+    val blockColorMap  = generateFringeColorMapping(blocks)
+    val timeseries     = acc.timeseries.toList.sorted
+    val lowestHeight   = timeseries.head
+    val validators     = acc.validators
+    val validatorsList = validators.toList.sortBy(_._1)
     for {
-      acc            <- topoSort.foldM(DagInfo.empty)(accumulateDagInfo[F](_, _))
-      timeseries     = acc.timeseries.reverse
-      firstTs        = timeseries.head
-      validators     = acc.validators
-      validatorsList = validators.toList.sortBy(_._1)
-      g              <- initGraph[F]("dag", ser)
+      g <- initGraph[F]("dag", ser)
       allAncestors = validatorsList
         .flatMap {
           case (_, blocks) =>
-            blocks.get(firstTs).map(_.flatMap(_.justifications)).getOrElse(List.empty[String])
+            blocks
+              .get(lowestHeight)
+              .map(_.flatMap(b => b.justifications))
+              .getOrElse(List.empty[String])
         }
         .distinct
         .sorted
-      // draw ancesotrs first
-      _ <- allAncestors.traverse(
-            ancestor =>
-              g.node(
-                ancestor,
-                style = styleFor(ancestor, lastFinalizedBlockHash),
-                shape = Box
-              )
-          )
-      // create invisible edges from ancestors to first node in each cluster for proper alligment
+
+      // create invisible edges from ancestors to first node in each cluster for proper alignment
       _ <- validatorsList.traverse {
-            case (id, blocks) =>
-              allAncestors.traverse(ancestor => {
-                val nodes = nodesForTs(id, firstTs, blocks, lastFinalizedBlockHash).keys.toList
+            case (valId, blocks) =>
+              allAncestors.traverse { ancestor =>
+                val nodes = nodesForHeight(lowestHeight, blocks, valId, blockColorMap).keys.toList
                 nodes.traverse(node => g.edge(ancestor, node, style = Some(Invis)))
-              })
+              }
           }
+
       // draw clusters per validator
       _ <- validatorsList.traverse {
             case (id, blocks) =>
-              validatorCluster(id, blocks, timeseries, lastFinalizedBlockHash, ser)
+              validatorCluster(id, blocks, timeseries, blockColorMap, ser)
           }
+
       // draw parent dependencies
       _ <- drawParentDependencies[F](g, validatorsList.map(_._2))
+
       // draw justification dotted lines
-      _ <- config.showJustificationLines.fold(
-            drawJustificationDottedLines[F](g, validators),
+      showJustificationLines = true
+      _ <- if (!showJustificationLines)
+            drawJustificationDottedLines[F](g, validators)
+          else
             ().pure[F]
-          )
       _ <- g.close
     } yield g
+  }
 
-  private def accumulateDagInfo[F[_]: Monad: Sync: Log: BlockStore](
+  private def accumulateDagInfo(
       acc: DagInfo,
-      blockHashes: Vector[BlockHash]
-  ): F[DagInfo] =
-    for {
-      blocks    <- blockHashes.traverse(BlockStore[F].getUnsafe)
-      timeEntry = blocks.head.blockNumber
-      validators = blocks.toList.map { b =>
-        val blockHash       = PrettyPrinter.buildString(b.blockHash)
-        val blockSenderHash = PrettyPrinter.buildString(b.sender)
-        val justifications = b.justifications
-          .map(PrettyPrinter.buildString)
-          .distinct
-        val validatorBlocks =
-          Map(timeEntry -> List(ValidatorBlock(blockHash, justifications)))
-        Map(blockSenderHash -> validatorBlocks)
-      }
-    } yield acc.copy(
-      timeseries = timeEntry :: acc.timeseries,
-      validators = acc.validators |+| Foldable[List].fold(validators)
-    )
-
-  private def initGraph[F[_]: Monad](
-      name: String,
-      ser: GraphSerializer[F]
-  ): F[Graphz[F]] =
-    Graphz[F](
-      name,
-      DiGraph,
-      ser,
-      rankdir = Some(BT),
-      splines = Some("false"),
-      node = Map("width" -> "0", "height" -> "0", "margin" -> "0.03", "fontsize" -> "8")
-    )
-
-  private def drawParentDependencies[F[_]: Applicative](
-      g: Graphz[F],
-      validators: List[ValidatorsBlocks]
-  ): F[Unit] =
-    validators
-      .flatMap(_.values.toList.flatten)
-      .traverse {
-        case ValidatorBlock(blockHash, justifications) =>
-          justifications.traverse(p => g.edge(blockHash, p, constraint = Some(false)))
-      }
-      .as(())
-
-  private def drawJustificationDottedLines[F[_]: Applicative](
-      g: Graphz[F],
-      validators: Map[String, ValidatorsBlocks]
-  ): F[Unit] =
-    validators.values.toList
-      .flatMap(_.values.toList.flatten)
-      .traverse {
-        case ValidatorBlock(blockHash, justifications) =>
-          justifications.traverse(
-            j =>
-              g.edge(
-                blockHash,
-                j,
-                style = Some(Dotted),
-                constraint = Some(false),
-                arrowHead = Some(NoneArrow)
-              )
-          )
-      }
-      .as(())
-
-  private def nodesForTs(
-      validatorId: String,
-      ts: Long,
-      blocks: ValidatorsBlocks,
-      lastFinalizedBlockHash: String
-  ): Map[String, Option[GraphStyle]] =
-    blocks.get(ts) match {
-      case Some(tsBlocks) =>
-        tsBlocks.map {
-          case ValidatorBlock(blockHash, _) =>
-            blockHash -> styleFor(blockHash, lastFinalizedBlockHash)
-        }.toMap
-      case None => Map(s"${ts.show}_$validatorId" -> Some(Invis))
-    }
+      block: ValidatorBlock
+  ): DagInfo = {
+    val blockHeight     = block.height
+    val validatorBlocks = Map(block.sender -> Map(blockHeight -> List(block)))
+    acc
+      .copy(
+        timeseries = acc.timeseries + blockHeight,
+        validators = acc.validators |+| validatorBlocks
+      )
+  }
 
   private def validatorCluster[F[_]: Monad](
-      id: String,
+      validatorId: String,
       blocks: ValidatorsBlocks,
       timeseries: List[Long],
-      lastFinalizedBlockHash: String,
+      blockColorMap: Map[String, (Option[String], Option[String])],
       ser: GraphSerializer[F]
   ): F[Graphz[F]] =
     for {
-      g     <- Graphz.subgraph[F](s"cluster_$id", DiGraph, ser, label = Some(id))
-      nodes = timeseries.map(ts => nodesForTs(id, ts, blocks, lastFinalizedBlockHash))
+      g     <- Graphz.subgraph[F](s"cluster_$validatorId", DiGraph, ser, label = Some(validatorId))
+      nodes = timeseries.map(ts => nodesForHeight(ts, blocks, validatorId, blockColorMap))
       _ <- nodes.traverse(
             ns =>
               ns.toList.traverse {
-                case (name, style) => g.node(name, style = style, shape = Box)
+                case (name, (style, fill, border)) =>
+                  // Node shape, style and color
+                  val borderWidth     = border >> 2.some
+                  val borderOrDefault = border orElse "#828282".some // or gray
+                  g.node(
+                    name,
+                    shape = DoubleOctagon,
+                    style = style,
+                    color = fill,
+                    border = borderOrDefault,
+                    borderWidth = borderWidth
+                  )
               }
           )
       _ <- nodes.zip(nodes.drop(1)).traverse {
@@ -189,13 +126,150 @@ object GraphzGenerator {
                 n2s.keys.toList.traverse { n2 =>
                   g.edge(n1, n2, style = Some(Invis))
                 }
-
               }
           }
       _ <- g.close
     } yield g
 
-  private def styleFor(blockHash: String, lastFinalizedBlockHash: String): Option[GraphStyle] =
-    if (blockHash == lastFinalizedBlockHash) Some(Filled) else None
+  private def initGraph[F[_]: Monad](name: String, ser: GraphSerializer[F]): F[Graphz[F]] = {
+    val fontSize = "12"
+    Graphz[F](
+      name,
+      DiGraph,
+      ser,
+      rankdir = Some(BT),
+      splines = Some("false"),
+      graph = Map("fontsize" -> fontSize),
+      node = Map("width"     -> "0", "height" -> "0", "margin" -> "\".1,.05\"", "fontsize" -> fontSize),
+      edge = Map(
+        "arrowsize" -> ".5",
+        // "arrowhead" -> "empty",
+        "arrowhead" -> "open",
+        "penwidth"  -> ".6"
+        // "color"     -> "\"#404040\""
+      )
+    )
+  }
 
+  private def drawParentDependencies[G[_]: Applicative](
+      g: Graphz[G],
+      validators: List[ValidatorsBlocks]
+  ): G[Unit] =
+    validators
+      .flatMap(_.values.toList.flatten)
+      .traverse {
+        case ValidatorBlock(id, _, _, justifications, _) =>
+          justifications.traverse(p => g.edge(id, p, constraint = Some(false)))
+      }
+      .as(())
+
+  private def drawJustificationDottedLines[G[_]: Applicative](
+      g: Graphz[G],
+      validators: Map[String, ValidatorsBlocks]
+  ): G[Unit] =
+    validators.values.toList
+      .flatMap(_.values.toList.flatten)
+      .traverse {
+        case ValidatorBlock(id, _, _, justifications, _) =>
+          justifications
+            .traverse { j =>
+              g.edge(
+                id,
+                j,
+                style = Some(Dotted),
+                constraint = Some(false),
+                arrowHead = Some(NoneArrow)
+              )
+            }
+      }
+      .as(())
+
+  /* Helper functions to generate block color mapping from fringes */
+
+  private def generateFringeColorMapping(
+      blocks: Vector[ValidatorBlock]
+  ): Map[String, (Option[String], Option[String])] = {
+    // Different color for each fringe
+    val colors = LazyList(
+      "#ff5e5e", // red
+      "#b561ff", // purple
+      "#00b803", // green
+      "#636eff", // blue
+      "#8dff87", // light green
+      "#00d9ff", // light blue
+      "#ffc400"  // yellow
+    )
+    val colorsInCycle = cycle(colors)
+
+    val blockMap = blocks.foldLeft(Map[String, ValidatorBlock]()) {
+      case (acc, b) =>
+        acc + ((b.id, b))
+    }
+
+    // Collect all fringes, remove duplicates and sort
+    val initFringeMap = Map[Set[ValidatorBlock], Set[ValidatorBlock]]()
+    val fringes = blocks
+      .foldLeft(initFringeMap) {
+        case (acc, b) =>
+          val fringe     = b.fringe.map(blockMap)
+          val seenFringe = acc.getOrElse(fringe, Set())
+          acc + ((fringe, seenFringe + b))
+      }
+      .filter(_._1.nonEmpty)
+      .toList
+      .sortBy(_._1.toList.map(_.height).maximumOption.getOrElse(-1L))
+
+    // Zip fringes with colors
+    val initColorMaps = (Map[String, String](), Map[String, String]())
+    val (fillMap, borderMap) =
+      fringes.zip(colorsInCycle).foldLeft(initColorMaps) {
+        case ((cAcc, bAcc), ((cs, bs), color)) =>
+          val newCs = cs.foldLeft(cAcc) { case (acc1, b) => acc1 + ((b.id, color)) }
+          val newBs = bs.foldLeft(bAcc) { case (acc1, b) => acc1 + ((b.id, color)) }
+          (newCs, newBs)
+      }
+    val keys = fillMap.keySet ++ borderMap.keySet
+    keys.map(x => x -> (fillMap.get(x), borderMap.get(x))).toMap
+  }
+
+  private def cycle(xs: LazyList[String]): LazyList[String] = xs #::: cycle(xs)
+
+  /* Helpers to generate node stype and color */
+
+  // Creates map of node styles on block height
+  private def nodesForHeight(
+      height: Long,
+      blocks: ValidatorsBlocks,
+      validatorId: String,
+      blockColorMap: Map[String, (Option[String], Option[String])]
+  ): Map[String, (Option[GraphStyle], Option[String], Option[String])] =
+    transformOnHeight(height, blocks)(styleForNode(_, blockColorMap))
+      .getOrElse(heightNoBlocks(height, validatorId))
+
+  // Node style for a block
+  private def styleForNode(
+      blockId: String,
+      blockColorMap: Map[String, (Option[String], Option[String])]
+  ): (Option[Filled.type], Option[String], Option[String]) =
+    blockColorMap
+      .get(blockId)
+      .map {
+        case (fill, border) =>
+          val style = fill.map(_ => Filled)
+          (style, fill, border)
+      }
+      .getOrElse((none, none, none))
+
+  // Node style on height without blocks
+  private def heightNoBlocks(
+      ts: Long,
+      validatorId: String
+  ): Map[String, (Option[Invis.type], Option[String], Option[String])] =
+    Map(s"${ts.show}_$validatorId" -> (Some(Invis), none, none))
+
+  // Transforms blocks on height
+  private def transformOnHeight[A](height: Long, blocks: ValidatorsBlocks)(
+      f: String => A
+  ): Option[Map[String, A]] =
+    blocks.get(height).map(_.map(v => v.id -> f(v.id)).toMap)
 }

--- a/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
+++ b/graphz/src/main/scala/coop/rchain/graphz/Graphz.scala
@@ -1,8 +1,6 @@
 package coop.rchain.graphz
 
-import java.io.FileOutputStream
 import cats._
-import cats.effect.{Concurrent, Sync}
 import cats.effect.concurrent.Ref
 import cats.syntax.all._
 
@@ -10,19 +8,12 @@ trait GraphSerializer[F[_]] {
   def push(str: String, suffix: String = "\n"): F[Unit]
 }
 
-class StringSerializer[F[_]: Concurrent](ref: Ref[F, StringBuffer]) extends GraphSerializer[F] {
+class StringSerializer[F[_]](ref: Ref[F, StringBuffer]) extends GraphSerializer[F] {
   override def push(str: String, suffix: String): F[Unit] = ref.update(_.append(str + suffix))
 }
 
-class ListSerializer[F[_]: Concurrent](ref: Ref[F, Vector[String]]) extends GraphSerializer[F] {
+class ListSerializer[F[_]](ref: Ref[F, Vector[String]]) extends GraphSerializer[F] {
   override def push(str: String, suffix: String): F[Unit] = ref.update(_ :+ (str + suffix))
-}
-
-class FileSerializer[F[_]: Sync](fos: FileOutputStream) extends GraphSerializer[F] {
-  override def push(str: String, suffix: String): F[Unit] = Sync[F].delay {
-    fos.write(str.getBytes)
-    fos.flush()
-  }
 }
 
 sealed trait GraphType
@@ -30,12 +21,13 @@ case object Graph   extends GraphType
 case object DiGraph extends GraphType
 
 sealed trait GraphShape
-case object Circle       extends GraphShape
-case object DoubleCircle extends GraphShape
-case object Box          extends GraphShape
-case object PlainText    extends GraphShape
-case object Msquare      extends GraphShape
-case object Record       extends GraphShape
+case object Circle        extends GraphShape
+case object DoubleCircle  extends GraphShape
+case object DoubleOctagon extends GraphShape
+case object Box           extends GraphShape
+case object PlainText     extends GraphShape
+case object Msquare       extends GraphShape
+case object Record        extends GraphShape
 
 sealed trait GraphRank
 case object Same   extends GraphRank
@@ -45,12 +37,14 @@ case object Max    extends GraphRank
 case object Sink   extends GraphRank
 
 sealed trait GraphRankDir
+
 case object TB extends GraphRankDir
 case object BT extends GraphRankDir
 case object LR extends GraphRankDir
 case object RL extends GraphRankDir
 
 sealed trait GraphStyle
+
 case object Solid  extends GraphStyle
 case object Bold   extends GraphStyle
 case object Filled extends GraphStyle
@@ -59,37 +53,35 @@ case object Dotted extends GraphStyle
 case object Dashed extends GraphStyle
 
 sealed trait GraphArrowType
+
 case object NormalArrow extends GraphArrowType
 case object InvArrow    extends GraphArrowType
 case object NoneArrow   extends GraphArrowType
 
 object Graphz {
 
-  implicit val showShape: Show[GraphShape] = new Show[GraphShape] {
-    def show(shape: GraphShape): String = shape match {
-      case Circle       => "circle"
-      case DoubleCircle => "doublecircle"
-      case Box          => "box"
-      case PlainText    => "plaintext"
-      case Msquare      => "Msquare"
-      case Record       => "record"
-    }
+  implicit val showShape: Show[GraphShape] = Show.show {
+    case Circle        => "circle"
+    case DoubleCircle  => "doublecircle"
+    case DoubleOctagon => "doubleoctagon"
+    case Box           => "box"
+    case PlainText     => "plaintext"
+    case Msquare       => "Msquare"
+    case Record        => "record"
   }
 
-  def smallToString[A]: Show[A] = (a: A) => a.toString.toLowerCase
+  def smallToString[A]: Show[A] = Show.show(_.toString.toLowerCase)
 
   implicit val showStyle: Show[GraphStyle]     = smallToString[GraphStyle]
   implicit val showRank: Show[GraphRank]       = smallToString[GraphRank]
   implicit val showRankDir: Show[GraphRankDir] = Show.fromToString[GraphRankDir]
-  implicit val showArrowType: Show[GraphArrowType] = new Show[GraphArrowType] {
-    def show(arrowType: GraphArrowType): String = arrowType match {
-      case NormalArrow => "normal"
-      case InvArrow    => "inv"
-      case NoneArrow   => "none"
-    }
+  implicit val showArrowType: Show[GraphArrowType] = Show.show {
+    case NormalArrow => "normal"
+    case InvArrow    => "inv"
+    case NoneArrow   => "none"
   }
 
-  def DefaultShape: GraphShape = Circle
+  val DefaultShape: GraphShape = Circle
 
   def apply[F[_]: Monad](
       name: String,
@@ -103,7 +95,9 @@ object Graphz {
       rankdir: Option[GraphRankDir] = None,
       style: Option[String] = None,
       color: Option[String] = None,
-      node: Map[String, String] = Map.empty
+      graph: Map[String, String] = Map.empty,
+      node: Map[String, String] = Map.empty,
+      edge: Map[String, String] = Map.empty
   ): F[Graphz[F]] = {
 
     def insert(str: Option[String], v: String => String): F[Unit] = {
@@ -120,7 +114,9 @@ object Graphz {
       _ <- insert(color, s => s"color=$s")
       _ <- insert(rank.map(_.show), r => s"rank=$r")
       _ <- insert(rankdir.map(_.show), r => s"rankdir=$r")
+      _ <- insert(attrMkStr(graph), n => s"graph $n")
       _ <- insert(attrMkStr(node), n => s"node $n")
+      _ <- insert(attrMkStr(edge), n => s"edge $n")
       _ <- insert(splines.map(_.show), s => s"splines=$s")
     } yield new Graphz[F](gtype, t, ser)
   }
@@ -172,6 +168,7 @@ object Graphz {
 class Graphz[F[_]: Monad](gtype: GraphType, t: String, val ser: GraphSerializer[F]) {
 
   def edge(edg: (String, String)): F[Unit] = edge(edg._1, edg._2)
+
   def edge(
       src: String,
       dst: String,
@@ -200,16 +197,24 @@ class Graphz[F[_]: Monad](gtype: GraphType, t: String, val ser: GraphSerializer[
       shape: GraphShape = Circle,
       style: Option[GraphStyle] = None,
       color: Option[String] = None,
+      border: Option[String] = None,
+      borderWidth: Option[Int] = None,
       label: Option[String] = None
   ): F[Unit] = {
     import Graphz.{showShape, showStyle}
     val attrShape: Map[String, String] =
       if (shape == Graphz.DefaultShape) Map.empty else Map("shape" -> shape.show)
     val attrStyle: Map[String, String] = style.map(s => Map("style" -> s.show)).getOrElse(Map.empty)
-    val attrColor: Map[String, String] = color.map(c => Map("color" -> c)).getOrElse(Map.empty)
+    val attrColor: Map[String, String] =
+      color.map(c => Map("fillcolor" -> s""""$c"""")).getOrElse(Map.empty)
+    val attrBorder: Map[String, String] =
+      border.map(c => Map("color" -> s""""$c"""")).getOrElse(Map.empty)
+    val attrBorderWidth: Map[String, String] =
+      borderWidth.map(w => Map("penwidth" -> s"$w")).getOrElse(Map.empty)
     val attrLabel: Map[String, String] = label.map(c => Map("label" -> c)).getOrElse(Map.empty)
 
-    val attrs: Map[String, String] = attrShape |+| attrColor |+| attrLabel |+| attrStyle
+    val attrs: Map[String, String] =
+      attrShape |+| attrColor |+| attrBorder |+| attrBorderWidth |+| attrLabel |+| attrStyle
     ser.push(t + Graphz.quote(name) + Graphz.attrMkStr(attrs).map(a => " " + a).getOrElse(""))
   }
 


### PR DESCRIPTION
## Overview

Improvement to DAG visualizer to support showing finalized fringes for the new multi-parent finalizer.

Different fringes are shown in different colors. Double border around blocks matches the color of the blocks part of the fringe by finalized by that block.

It also simplifies creation of input structure for GraphGenerator removing BlockStore dependency.

Example visualized GraphViz output. More examples can be fined in Finalizer Simulator repo.
https://github.com/tgrospic/rchain-dev-finalization

![image](https://user-images.githubusercontent.com/5306205/182689611-490ac14a-db8a-491d-94ce-ab65d5b20696.png)

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
