### PR TITLE
Build node on Apple M1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ target/
 lib_managed/
 src_managed/
 boot/
+.bsp/
 
 # BNFC
 ###################

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.7.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 // Yes it's weird to do the following, but it's what is mandated by the scalapb documentation
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.10.8"
 


### PR DESCRIPTION
## Overview
This PR updates sbt-protoc plugin, latest version uses protoc version that is compatible with M1. Closes https://github.com/rchain/rchain/issues/3404

The second commits is not really necessary, but this warning occurred in sbt shell on M1 so sbt is also updated and deprecated syntax is adjusted.
```
Exception in thread "sbt-socket-server" java.lang.UnsatisfiedLinkError: Can't load library: /Users/nzpr/Library/Caches/JNA/temp/jna8192809878255910661.tmp
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2633)
	at java.base/java.lang.Runtime.load0(Runtime.java:768)
	at java.base/java.lang.System.load(System.java:1837)
	at com.sun.jna.Native.loadNativeDispatchLibraryFromClasspath(Native.java:1018)
	at com.sun.jna.Native.loadNativeDispatchLibrary(Native.java:988)
	at com.sun.jna.Native.<clinit>(Native.java:195)
	at com.sun.jna.Structure.setAlignType(Structure.java:280)
	at com.sun.jna.Structure.<init>(Structure.java:197)
	at com.sun.jna.Structure.<init>(Structure.java:193)
	at com.sun.jna.Structure.<init>(Structure.java:180)
	at com.sun.jna.Structure.<init>(Structure.java:172)
	at org.scalasbt.ipcsocket.UnixDomainSocketLibrary$SockaddrUn.<init>(UnixDomainSocketLibrary.java:83)
	at sbt.internal.server.Server$$anon$1$$anon$2.$anonfun$run$1(Server.scala:65)
	at scala.util.Try$.apply(Try.scala:213)
	at sbt.internal.server.Server$$anon$1$$anon$2.run(Server.scala:60)
```


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
