### PR TITLE
Add split method to Strings in Rholang

### DIFF
--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/Reduce.scala
@@ -1431,13 +1431,13 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
       } yield result
   }
 
-  private[this] val explode: Method = new Method() {
+  private[this] val split: Method = new Method() {
 
-    def explode(baseExpr: Expr, sep: Expr): M[Expr] =
+    def split(baseExpr: Expr, sep: Expr): M[Expr] =
       (baseExpr.exprInstance, sep.exprInstance) match {
         case (GString(string), GString(sepStr)) =>
           val split = string.split(sepStr)
-          charge[M](toListCost(split.size) + explodeCost(string, sepStr, split.size)) >>
+          charge[M](toListCost(split.size) + splitCost(string, sepStr, split.size)) >>
             Expr(
               EListBody(
                 EList(
@@ -1448,19 +1448,19 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
             ).pure[M]
 
         case (other, _) =>
-          MethodNotDefined("explode", other.typ).raiseError[M, Expr]
+          MethodNotDefined("split", other.typ).raiseError[M, Expr]
       }
 
     override def apply(p: Par, args: Seq[Par])(implicit env: Env[Par]): M[Par] =
       for {
-        _ <- MethodArgumentNumberMismatch("explode", 1, args.length)
+        _ <- MethodArgumentNumberMismatch("split", 1, args.length)
               .raiseError[M, Unit]
               .whenA(args.length != 1)
 
         baseExpr <- evalSingleExpr(p)
         sep      <- evalSingleExpr(args(0))
 
-        result <- explode(baseExpr, sep)
+        result <- split(baseExpr, sep)
       } yield result
   }
 
@@ -1620,7 +1620,7 @@ class DebruijnInterpreter[M[_]: Sync: Parallel: _cost](
       "size"        -> size,
       "length"      -> length,
       "slice"       -> slice,
-      "explode"     -> explode,
+      "split"       -> split,
       "take"        -> take,
       "toList"      -> toList,
       "toSet"       -> toSet,

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -141,8 +141,8 @@ trait Costs {
   // if underlying string is shorter then the `to` value.
   def sliceCost(to: Int): Cost = Cost(to, "slice")
 
-  def explodeCost(str: String, sep: String, found: Int): Cost =
-    Cost(str.getBytes.size + found * sep.length, "explode")
+  def splitCost(str: String, sep: String, found: Int): Cost =
+    Cost(str.getBytes.size + found * sep.length, "split")
 
   def takeCost(to: Int): Cost = Cost(to, "take")
 

--- a/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
+++ b/rholang/src/main/scala/coop/rchain/rholang/interpreter/accounting/Costs.scala
@@ -141,6 +141,9 @@ trait Costs {
   // if underlying string is shorter then the `to` value.
   def sliceCost(to: Int): Cost = Cost(to, "slice")
 
+  def explodeCost(str: String, sep: String, found: Int): Cost =
+    Cost(str.getBytes.size + found * sep.length, "explode")
+
   def takeCost(to: Int): Cost = Cost(to, "take")
 
   def toListCost(size: Int): Cost = Cost(size, "toList")


### PR DESCRIPTION
## Overview

This PR adds additional method `split` to string type in Rholang. It accepts string argument by which input string should be separated in List of strings.

Related RCHIP: https://github.com/rchain/rchip-proposals/issues/52.

NOTE: A new PR is created because checkbox to allow write permission on the original PR by @Bill-Kunj was not present,
- #3777
- #3753

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
