### PR TITLE
Update string interpolation syntax in docs

### DIFF
--- a/models/src/main/protobuf/RhoTypes.proto
+++ b/models/src/main/protobuf/RhoTypes.proto
@@ -360,7 +360,7 @@ message EMatches {
 /**
  * String interpolation
  *
- * `"Hello, {name}" %% {"name": "Bob"}` denotes `"Hello, Bob"`
+ * `"Hello, ${name}" %% {"name": "Bob"}` denotes `"Hello, Bob"`
  */
 message EPercentPercent {
     Par p1 = 1 [(scalapb.field).no_box = true];

--- a/rholang/reference_doc/primitives/README.md
+++ b/rholang/reference_doc/primitives/README.md
@@ -11,7 +11,7 @@ Rholang's integers are 64-bit signed, represented internally as two's compliment
 | Integer Min Value | -9223372036854775808 |
 
 #### Arithmetic
-Integers support basic arithmetic operations natively, and other operations are being written in the [standard library](https://github.com/JoshOrndorff/librho/UnsafeMath)
+Integers support basic arithmetic operations natively
 
 ```rholang
 new stdout(`rho:io:stdout`) in {
@@ -26,6 +26,9 @@ new stdout(`rho:io:stdout`) in {
 
   // Integer Division
   stdout!(-90 / 6) |
+
+  // Modular arithmetic + remainder
+  stdout!(15 % 10) |
 
   // Watchout for overflow
   stdout!(9223372036854775800 + 10) |
@@ -83,11 +86,22 @@ new someNameCh, lookup(`rho:registry:lookup`) in {
 ```
 
 
-### Strings?
+### Strings
 Strings are covered in detail under [data structures](../data_structures). Here are a few basics
+
+#### Concatenation
 
 ```rholang
 new stdout(`rho:io:stdout`) in {
   stdout!("String" ++ "Concatenation")|
 }
+```
+
+#### Interpolation
+
+```rholang
+new stdout(`rho:io:stdout`) in {
+  stdout!("${a} + ${b}" %% {"a": 19, "b": "23", "c": true})
+}
+// prints "19 + 23 + true" to stdout
 ```


### PR DESCRIPTION
## Overview
Updates docs regarding string interpolation so I (and others) don't forget how to do it.

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
