### PR TITLE
Replace Secp256k1 maven dependency with module.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,8 @@ lazy val projectSettings = Seq(
   version := "0.1.0-SNAPSHOT",
   resolvers ++=
     Resolver.sonatypeOssRepos("releases") ++
-    Resolver.sonatypeOssRepos("snapshots") ++
-    Seq("jitpack" at "https://jitpack.io"),
+      Resolver.sonatypeOssRepos("snapshots") ++
+      Seq("jitpack" at "https://jitpack.io"),
   wartremoverExcluded += sourceManaged.value,
   Compile / compile / wartremoverErrors ++= Warts.allBut(
     // those we want
@@ -77,7 +77,7 @@ lazy val projectSettings = Seq(
     Seq(
       Compile / packageDoc / publishArtifact := false,
       packageDoc / publishArtifact := false,
-      Compile / doc / sources := Seq.empty,
+      Compile / doc / sources := Seq.empty
     )
   }
 
@@ -379,7 +379,7 @@ lazy val node = (project in file("node"))
     rpmUrl := Some("https://rchain.coop"),
     rpmLicense := Some("Apache 2.0"),
     Rpm / packageArchitecture := "noarch",
-    Rpm / maintainerScripts := maintainerScriptsAppendFromFile((Rpm/maintainerScripts).value)(
+    Rpm / maintainerScripts := maintainerScriptsAppendFromFile((Rpm / maintainerScripts).value)(
       RpmConstants.Post -> (sourceDirectory.value / "rpm" / "scriptlets" / "post")
     ),
     rpmPrerequisites := Seq(
@@ -410,7 +410,7 @@ lazy val rholang = (project in file("rholang"))
       "-Xfatal-warnings",
       "-Xlint:_,-missing-interpolator" // disable "possible missing interpolator" warning
     ),
-    Compile / packageDoc/ publishArtifact := false,
+    Compile / packageDoc / publishArtifact := false,
     packageDoc / publishArtifact := false,
     Compile / doc / sources := Seq.empty,
     libraryDependencies ++= commonDependencies ++ Seq(

--- a/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
+++ b/crypto/src/main/scala/coop/rchain/crypto/signatures/Secp256k1.scala
@@ -144,7 +144,7 @@ object Secp256k1 extends SignaturesAlg {
     */
   def toPublic(seckey: Array[Byte]): Array[Byte] =
     // WARNING: this code throws Assertion exception if input is not correct length
-    NativeSecp256k1.computePubkey(seckey)
+    NativeSecp256k1.computePubkey(seckey, false) // we use uncompressed keys
 
   override def toPublic(sec: PrivateKey): PublicKey = PublicKey(toPublic(sec.bytes))
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -94,8 +94,6 @@ object Dependencies {
   val scodecCore          = "org.scodec"                 %% "scodec-core"               % "1.11.7"
   val scodecCats          = "org.scodec"                 %% "scodec-cats"               % "1.1.0-M4"
   val scodecBits          = "org.scodec"                 %% "scodec-bits"               % "1.1.23"
-  // see https://jitpack.io/#rchain/secp256k1-java
-  val secp256k1Java       = "com.github.rchain"           % "secp256k1-java"            % "0.1"
   val shapeless           = "com.chuusai"                %% "shapeless"                 % "2.3.8"
   val slf4j               = "org.slf4j"                   % "slf4j-api"                 % slf4jVersion
   val weupnp              = "org.bitlet"                  % "weupnp"                    % "0.1.4"

--- a/project/Secp256k1.scala
+++ b/project/Secp256k1.scala
@@ -1,0 +1,18 @@
+import sbt.{taskKey, File, IO, URL}
+
+object Secp256k1 {
+
+  lazy val linux_x86_x64_local = "secp256k1/src/main/resources/secp256k1-native-linux-x86_64.so"
+  lazy val osx_x86_x64_local   = "secp256k1/src/main/resources/secp256k1-native-osx-x86_64.dylib"
+  lazy val osx_aarch64_local   = "secp256k1/src/main/resources/secp256k1-native-osx-aarch64.dylib"
+
+  lazy val linux_x86_x64_remote =
+    "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-linux-x86_64.so"
+  lazy val osx_x86_x64_remote =
+    "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-osx-x86_64.dylib"
+  lazy val osx_aarch64_remote =
+    "https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/secp256k1-native-osx-aarch64.dylib"
+
+  lazy val pullNativeLibs =
+    taskKey[Unit]("Download native libraries and place them into secp256k1 project")
+}

--- a/secp256k1/src/main/README.MD
+++ b/secp256k1/src/main/README.MD
@@ -1,0 +1,7 @@
+This is java bindings to secp256k1 native libraries.
+
+Native libraries are produced in https://github.com/rchain/secp256k1-native, and pulled from there by CI into 
+resources folder.
+
+The content of this module is taken from [bitcoin-core repo](https://github.com/bitcoin-core/secp256k1/pull/682),
+which deprecated JNI support. Tests are adjusted to be run with Scalatest.

--- a/secp256k1/src/main/java/org.bitcoin/NativeSecp256k1.java
+++ b/secp256k1/src/main/java/org.bitcoin/NativeSecp256k1.java
@@ -1,0 +1,588 @@
+/*
+ * Copyright 2013 Google Inc.
+ * Copyright 2014-2016 the libsecp256k1 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoin;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import java.math.BigInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static org.bitcoin.NativeSecp256k1Util.*;
+
+/**
+ * <p>This class holds native methods to handle ECDSA verification.</p>
+ *
+ * <p>You can find an example library that can be used for this at https://github.com/bitcoin-core/secp256k1</p>
+ *
+ * <p>To build secp256k1 for use with bitcoinj, run
+ * `./configure --enable-jni --enable-experimental --enable-module-ecdh`
+ * and `make` then copy `.libs/libsecp256k1.so` to your system library path
+ * or point the JVM to the folder containing it with -Djava.library.path
+ * </p>
+ */
+public class NativeSecp256k1 {
+
+    private static final ReentrantReadWriteLock rwl = new ReentrantReadWriteLock();
+    private static final Lock r = rwl.readLock();
+    private static final Lock w = rwl.writeLock();
+    private static ThreadLocal<ByteBuffer> nativeECDSABuffer = new ThreadLocal<ByteBuffer>();
+    /**
+     * Verifies the given secp256k1 signature in native code.
+     * Calling when enabled == false is undefined (probably library not loaded)
+     *
+     * @param data The data which was signed, must be exactly 32 bytes
+     * @param signature The signature
+     * @param pub The public key which did the signing
+     */
+    public static boolean verify(byte[] data, byte[] signature, byte[] pub) {
+        checkArgument(data.length == 32 && signature.length <= 520 && pub.length <= 520);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < 520) {
+            byteBuff = ByteBuffer.allocateDirect(520);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(data);
+        byteBuff.put(signature);
+        byteBuff.put(pub);
+
+        r.lock();
+        try {
+            return secp256k1_ecdsa_verify(byteBuff, Secp256k1Context.getContext(), signature.length, pub.length) == 1;
+        } finally {
+            r.unlock();
+        }
+    }
+
+    /**
+     * libsecp256k1 Create an ECDSA signature.
+     *
+     * @param data Message hash, 32 bytes
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @return sig byte array of signature
+     */
+    public static byte[] sign(byte[] data, byte[] seckey) throws AssertFailException{
+        checkArgument(data.length == 32 && seckey.length <= 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < 32 + 32) {
+            byteBuff = ByteBuffer.allocateDirect(32 + 32);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(data);
+        byteBuff.put(seckey);
+
+        byte[][] retByteArray;
+
+        r.lock();
+        try {
+            retByteArray = secp256k1_ecdsa_sign(byteBuff, Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] sigArr = retByteArray[0];
+        int sigLen = new BigInteger(new byte[] { retByteArray[1][0] }).intValue();
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        assertEquals(sigArr.length, sigLen, "Got bad signature length.");
+
+        return retVal == 0 ? new byte[0] : sigArr;
+    }
+
+    /**
+     * libsecp256k1 Create an ECDSA signature adding specified entropy.
+     *
+     * This can be used to include your own entropy to nonce generation
+     * in addition to the message and private key, while still doing so deterministically.
+     *
+     * In particular, this is used when generating low R signatures.
+     * See https://github.com/bitcoin/bitcoin/pull/13666/
+     *
+     * @param data Message hash, 32 bytes
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @param entropy 32 bytes of entropy
+     * @return sig byte array of signature
+     */
+    public static byte[] signWithEntropy(byte[] data, byte[] seckey, byte[] entropy) throws AssertFailException{
+        checkArgument(data.length == 32 && seckey.length == 32 && entropy.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < 32 + 32 + 32) {
+            byteBuff = ByteBuffer.allocateDirect(32 + 32 + 32);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        safeRewind(byteBuff);
+        byteBuff.put(data);
+        byteBuff.put(seckey);
+        byteBuff.put(entropy);
+
+        byte[][] retByteArray;
+
+        r.lock();
+        try {
+            retByteArray = secp256k1_ecdsa_sign_with_entropy(byteBuff, Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] sigArr = retByteArray[0];
+        int sigLen = new BigInteger(new byte[] { retByteArray[1][0] }).intValue();
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        assertEquals(sigArr.length, sigLen, "Got bad signature length.");
+
+        return retVal == 0 ? new byte[0] : sigArr;
+    }
+
+    /**
+     * libsecp256k1 Seckey Verify - Verifies an ECDSA secret key
+     *
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @return true if valid, false if invalid
+     */
+    public static boolean secKeyVerify(byte[] seckey) {
+        checkArgument(seckey.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < seckey.length) {
+            byteBuff = ByteBuffer.allocateDirect(seckey.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(seckey);
+
+        r.lock();
+        try {
+            return secp256k1_ec_seckey_verify(byteBuff,Secp256k1Context.getContext()) == 1;
+        } finally {
+            r.unlock();
+        }
+    }
+
+
+    /**
+     * libsecp256k1 Compute Pubkey - computes public key from secret key
+     *
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @param compressed Should the generated public key be compressed
+     * @return pubkey ECDSA Public key, 33 or 65 bytes
+     */
+    public static byte[] computePubkey(byte[] seckey, boolean compressed) throws AssertFailException{
+        checkArgument(seckey.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < seckey.length) {
+            byteBuff = ByteBuffer.allocateDirect(seckey.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(seckey);
+
+        byte[][] retByteArray;
+
+        r.lock();
+        try {
+            // last arg is hardcoded false since we use only uncompressed public keys
+            retByteArray = secp256k1_ec_pubkey_create(byteBuff, Secp256k1Context.getContext(), compressed);
+        } finally {
+            r.unlock();
+        }
+
+        byte[] pubArr = retByteArray[0];
+        int pubLen = new BigInteger(new byte[] { retByteArray[1][0] }).intValue();
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        assertEquals(pubArr.length, pubLen, "Got bad pubkey length.");
+
+        return retVal == 0 ? new byte[0]: pubArr;
+    }
+
+    /**
+     * libsecp256k1 Cleanup - This destroys the secp256k1 context object
+     * This should be called at the end of the program for proper cleanup of the context.
+     */
+    public static synchronized void cleanup() {
+        w.lock();
+        try {
+            secp256k1_destroy_context(Secp256k1Context.getContext());
+        } finally {
+            w.unlock();
+        }
+    }
+
+    public static long cloneContext() {
+        r.lock();
+        try {
+            return secp256k1_ctx_clone(Secp256k1Context.getContext());
+        } finally { r.unlock(); }
+    }
+
+    /**
+     * libsecp256k1 PrivKey Tweak-Mul - Tweak seckey by multiplying to it
+     *
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @param tweak some bytes to tweak with
+     */
+    public static byte[] privKeyTweakMul(byte[] seckey, byte[] tweak) throws AssertFailException{
+        checkArgument(seckey.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < seckey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(seckey.length + tweak.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(seckey);
+        byteBuff.put(tweak);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_privkey_tweak_mul(byteBuff,Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] privArr = retByteArray[0];
+
+        int privLen = (byte) new BigInteger(new byte[] { retByteArray[1][0] }).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        assertEquals(privArr.length, privLen, "Got bad pubkey length.");
+
+        assertEquals(retVal, 1, "Failed return value check.");
+
+        return privArr;
+    }
+
+    /**
+     * libsecp256k1 PrivKey Tweak-Add - Tweak seckey by adding to it
+     *
+     * @param seckey ECDSA Secret key, 32 bytes
+     * @param tweak some bytes to tweak with
+     */
+    public static byte[] privKeyTweakAdd(byte[] seckey, byte[] tweak) throws AssertFailException{
+        checkArgument(seckey.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < seckey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(seckey.length + tweak.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(seckey);
+        byteBuff.put(tweak);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_privkey_tweak_add(byteBuff,Secp256k1Context.getContext());
+        } finally {
+            r.unlock();
+        }
+
+        byte[] privArr = retByteArray[0];
+
+        int privLen = (byte) new BigInteger(new byte[] { retByteArray[1][0] }).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        assertEquals(privArr.length, privLen, "Got bad pubkey length.");
+
+        assertEquals(retVal, 1, "Failed return value check.");
+
+        return privArr;
+    }
+
+    /**
+     * libsecp256k1 PubKey Tweak-Add - Tweak pubkey by adding to it
+     *
+     * @param pubkey ECDSA Public key, 33 or 65 bytes
+     * @param tweak some bytes to tweak with
+     * @param compressed should the output public key be compressed
+     */
+    public static byte[] pubKeyTweakAdd(byte[] pubkey, byte[] tweak, boolean compressed) throws AssertFailException{
+        checkArgument(pubkey.length == 33 || pubkey.length == 65);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < pubkey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(pubkey.length + tweak.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(pubkey);
+        byteBuff.put(tweak);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_pubkey_tweak_add(byteBuff, Secp256k1Context.getContext(), pubkey.length, compressed);
+        } finally {
+            r.unlock();
+        }
+
+        byte[] pubArr = retByteArray[0];
+
+        int pubLen = (byte) new BigInteger(new byte[] { retByteArray[1][0] }).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        assertEquals(pubArr.length, pubLen, "Got bad pubkey length.");
+
+        assertEquals(retVal, 1, "Failed return value check.");
+
+        return pubArr;
+    }
+
+    /**
+     * libsecp256k1 PubKey Tweak-Mul - Tweak pubkey by multiplying to it
+     *
+     * @param pubkey ECDSA Public key, 33 or 65 bytes
+     * @param tweak some bytes to tweak with
+     * @param compressed should the output public key be compressed
+     */
+    public static byte[] pubKeyTweakMul(byte[] pubkey, byte[] tweak, boolean compressed) throws AssertFailException{
+        checkArgument(pubkey.length == 33 || pubkey.length == 65);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < pubkey.length + tweak.length) {
+            byteBuff = ByteBuffer.allocateDirect(pubkey.length + tweak.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(pubkey);
+        byteBuff.put(tweak);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_pubkey_tweak_mul(byteBuff,Secp256k1Context.getContext(), pubkey.length, compressed);
+        } finally {
+            r.unlock();
+        }
+
+        byte[] pubArr = retByteArray[0];
+
+        int pubLen = (byte) new BigInteger(new byte[] { retByteArray[1][0] }).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        assertEquals(pubArr.length, pubLen, "Got bad pubkey length.");
+
+        assertEquals(retVal, 1, "Failed return value check.");
+
+        return pubArr;
+    }
+
+    /**
+     * libsecp256k1 Decompress - Parse and decompress a variable-length pub key
+     *
+     * @param pubkey ECDSA Public key, 33 or 65 bytes
+     */
+    public static byte[] decompress(byte[] pubkey) throws AssertFailException{
+        checkArgument(pubkey.length == 33 || pubkey.length == 65);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < pubkey.length) {
+            byteBuff = ByteBuffer.allocateDirect(pubkey.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(pubkey);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_ec_pubkey_decompress(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+        } finally {
+            r.unlock();
+        }
+
+        byte[] pubArr = retByteArray[0];
+
+        int pubLen = (byte) new BigInteger(new byte[] { retByteArray[1][0] }).intValue() & 0xFF;
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        assertEquals(pubArr.length, pubLen, "Got bad pubkey length.");
+
+        assertEquals(retVal, 1, "Failed return value check.");
+
+        return pubArr;
+    }
+
+    /**
+     * libsecp256k1 IsValidPubKey - Checks if a pubkey is valid
+     *
+     * @param pubkey ECDSA Public key, 33 or 65 bytes
+     */
+    public static boolean isValidPubKey(byte[] pubkey) {
+        if (!(pubkey.length == 33 || pubkey.length == 65)) {
+            return false;
+        }
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < pubkey.length) {
+            byteBuff = ByteBuffer.allocateDirect(pubkey.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(pubkey);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_ec_pubkey_decompress(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+        } finally {
+            r.unlock();
+        }
+
+        int retVal = new BigInteger(new byte[] { retByteArray[1][1] }).intValue();
+
+        return retVal == 1;
+    }
+
+    /**
+     * libsecp256k1 create ECDH secret - constant time ECDH calculation
+     *
+     * @param seckey byte array of secret key used in exponentiaion
+     * @param pubkey byte array of public key used in exponentiaion
+     */
+    public static byte[] createECDHSecret(byte[] seckey, byte[] pubkey) throws AssertFailException{
+        checkArgument(seckey.length <= 32 && pubkey.length <= 65);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < 32 + pubkey.length) {
+            byteBuff = ByteBuffer.allocateDirect(32 + pubkey.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+
+        safeRewind(byteBuff);
+        byteBuff.put(seckey);
+        byteBuff.put(pubkey);
+
+        byte[][] retByteArray;
+        r.lock();
+        try {
+            retByteArray = secp256k1_ecdh(byteBuff, Secp256k1Context.getContext(), pubkey.length);
+        } finally {
+            r.unlock();
+        }
+
+        byte[] resArr = retByteArray[0];
+        int retVal = new BigInteger(new byte[] { retByteArray[1][0] }).intValue();
+
+        assertEquals(resArr.length, 32, "Got bad result length.");
+        assertEquals(retVal, 1, "Failed return value check.");
+
+        return resArr;
+    }
+
+    /**
+     * libsecp256k1 randomize - updates the context randomization
+     *
+     * @param seed 32-byte random seed
+     */
+    public static synchronized boolean randomize(byte[] seed) throws AssertFailException{
+        checkArgument(seed.length == 32);
+
+        ByteBuffer byteBuff = nativeECDSABuffer.get();
+        if (byteBuff == null || byteBuff.capacity() < seed.length) {
+            byteBuff = ByteBuffer.allocateDirect(seed.length);
+            byteBuff.order(ByteOrder.nativeOrder());
+            nativeECDSABuffer.set(byteBuff);
+        }
+        safeRewind(byteBuff);
+        byteBuff.put(seed);
+
+        w.lock();
+        try {
+            return secp256k1_context_randomize(byteBuff, Secp256k1Context.getContext()) == 1;
+        } finally {
+            w.unlock();
+        }
+    }
+
+
+    /**
+     * This helper method is needed to resolve issue 1524 on bitcoin-s
+     * This is because the API changed for ByteBuffer between jdks < 9 and jdk >= 9
+     * In the earlier versions of the jdk, a [[java.nio.Buffer]] is returned, but greather than jdk 8
+     * returns a [[ByteBuffer]]. This causes issues when compiling with jdk 11 but running with jdk 8
+     * as the APIs are incompatible.
+     * @see https://github.com/bitcoin-s/bitcoin-s/issues/1524
+     * @param byteBuff
+     */
+    private static void safeRewind(ByteBuffer byteBuff) {
+        ((Buffer) byteBuff).rewind();
+    }
+
+    private static native long secp256k1_ctx_clone(long context);
+
+    private static native int secp256k1_context_randomize(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_privkey_tweak_add(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_privkey_tweak_mul(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_pubkey_tweak_add(ByteBuffer byteBuff, long context, int pubLen, boolean compressed);
+
+    private static native byte[][] secp256k1_pubkey_tweak_mul(ByteBuffer byteBuff, long context, int pubLen, boolean compressed);
+
+    private static native void secp256k1_destroy_context(long context);
+
+    private static native int secp256k1_ecdsa_verify(ByteBuffer byteBuff, long context, int sigLen, int pubLen);
+
+    private static native byte[][] secp256k1_ecdsa_sign(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_ecdsa_sign_with_entropy(ByteBuffer byteBuff, long context);
+
+    private static native int secp256k1_ec_seckey_verify(ByteBuffer byteBuff, long context);
+
+    private static native byte[][] secp256k1_ec_pubkey_create(ByteBuffer byteBuff, long context, boolean compressed);
+
+    private static native byte[][] secp256k1_ec_pubkey_decompress(ByteBuffer byteBuff, long context, int inputLen);
+
+    private static native byte[][] secp256k1_ecdh(ByteBuffer byteBuff, long context, int inputLen);
+
+}

--- a/secp256k1/src/main/java/org.bitcoin/NativeSecp256k1Util.java
+++ b/secp256k1/src/main/java/org.bitcoin/NativeSecp256k1Util.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2016 the libsecp256k1 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoin;
+
+public class NativeSecp256k1Util{
+
+    public static void assertEquals( int val, int val2, String message ) throws AssertFailException{
+        if( val != val2 )
+            throw new AssertFailException("FAIL: " + message);
+    }
+
+    public static void assertEquals( boolean val, boolean val2, String message ) throws AssertFailException{
+        if( val != val2 )
+            throw new AssertFailException("FAIL: " + message);
+        else
+            System.out.println("PASS: " + message);
+    }
+
+    public static void assertEquals( String val, String val2, String message ) throws AssertFailException{
+        if( !val.equals(val2) )
+            throw new AssertFailException("FAIL: " + message);
+        else
+            System.out.println("PASS: " + message);
+    }
+
+    public static class AssertFailException extends Exception {
+        public AssertFailException(String message) {
+            super( message );
+        }
+    }
+
+    public static void checkArgument(boolean expression) {
+        if (!expression) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/secp256k1/src/main/java/org.bitcoin/Secp256k1Context.java
+++ b/secp256k1/src/main/java/org.bitcoin/Secp256k1Context.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2014-2016 the libsecp256k1 contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.bitcoin;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static java.io.File.createTempFile;
+import static java.lang.System.getProperty;
+import static java.lang.Thread.currentThread;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * This class holds the context reference used in native methods 
+ * to handle ECDSA operations.
+ */
+public class Secp256k1Context {
+    private static final boolean enabled; //true if the library is loaded
+    private static final long context; //ref to pointer to context obj
+
+
+    static { //static initializer
+        boolean isEnabled = true;
+        long contextRef = -1;
+
+        final String libToLoad;
+
+        final String arch = getProperty("os.arch");
+        final boolean arch64 = "x64".equals(arch) || "amd64".equals(arch)
+                || "x86_64".equals(arch);
+
+        final String os = getProperty("os.name");
+        final boolean linux = os.toLowerCase(ENGLISH).startsWith("linux");
+        final boolean osx = os.startsWith("Mac OS X");
+        final boolean osx_arm = "aarch64".equals(arch);
+        final boolean windows = os.startsWith("Windows");
+
+        try {
+            if (arch64 && linux) {
+                libToLoad = extract("secp256k1-native-linux-x86_64.so");
+            } else if (arch64 && osx) {
+                libToLoad = extract("secp256k1-native-osx-x86_64.dylib");
+            }  else if (arch64 && windows) {
+                libToLoad = extract("secp256k1-native-windows-x86_64.dll");
+            } else if (osx_arm) {
+                libToLoad = extract("secp256k1-native-osx-aarch64.dylib");
+            } else  {
+                throw new RuntimeException("No secp256k1-native library to extract");
+            }
+            System.load(libToLoad);
+            contextRef = secp256k1_init_context();
+        } catch (UnsatisfiedLinkError e) {
+            System.out.println("UnsatisfiedLinkError: " + e.toString());
+            isEnabled = false;
+        } catch (IOException e){
+            System.out.println("IOException: " + e.toString());
+            isEnabled = false;
+        } catch (NullPointerException e) {
+            System.out.println("Null pointer exception: " + e.toString());
+            isEnabled = false;
+        }
+        enabled = isEnabled;
+        context = contextRef;
+    }
+
+    @SuppressWarnings("PMD.AssignmentInOperand")
+    private static String extract(final String name) throws IOException {
+        final String suffix = name.substring(name.lastIndexOf('.'));
+        final File file;
+        try {
+            file = createTempFile("secp256k1-native-library-", suffix);
+            file.deleteOnExit();
+            final ClassLoader cl = currentThread().getContextClassLoader();
+            requireNonNull(cl.getResource(name), "Classpath resource not found");
+            try (InputStream in = cl.getResourceAsStream(name);
+                 OutputStream out = Files.newOutputStream(file.toPath())) {
+                int bytes;
+                final byte[] buffer = new byte[4_096];
+                while (-1 != (bytes = in.read(buffer))) {
+                    out.write(buffer, 0, bytes);
+                }
+            }
+            return file.getAbsolutePath();
+        } catch (final IOException e) {
+            throw new IOException("Failed to extract " + name, e);
+        }
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static long getContext() {
+        if(!enabled) return -1; //sanity check
+        return context;
+    }
+
+    private static native long secp256k1_init_context();
+}

--- a/secp256k1/src/main/resources/.gitignore
+++ b/secp256k1/src/main/resources/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/secp256k1/src/test/scala/coop/rchain/secp256k1java/NativeSecp256k1Test.scala
+++ b/secp256k1/src/test/scala/coop/rchain/secp256k1java/NativeSecp256k1Test.scala
@@ -1,0 +1,53 @@
+package coop.rchain.secp256k1java
+
+import coop.rchain.secp256k1java.NativeSecp256k1Tests._
+import org.bitcoin.NativeSecp256k1
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * This class holds test cases defined for testing this library.
+  */
+class NativeSecp256k1Test extends AnyFlatSpec with Matchers {
+
+  "Java bindings for Secp256k1 native library" should "work properly" in {
+    //Test verify() success/fail
+    testVerifyPos()
+    testVerifyNeg()
+
+    //Test secKeyVerify() success/fail
+    testSecKeyVerifyPos()
+    testSecKeyVerifyNeg()
+
+    //Test computePubkey() success/fail
+    testPubKeyCreatePos()
+    testPubKeyCreateNeg()
+
+    //Test sign() success/fail
+    testSignPos()
+    testSignNeg()
+
+    testSignWithEntropyPos()
+    testSignWithEntropyNeg()
+
+    //Test privKeyTweakAdd() 1
+    testPrivKeyTweakAdd()
+    testPrivKeyTweakMul()
+
+    testPubKeyTweakAdd()
+    testPubKeyTweakMul()
+
+    //Test randomize()
+    testRandomize()
+
+    testDecompressPubKey()
+
+    testIsValidPubKeyPos()
+    testIsValidPubKeyNeg()
+
+    //Test ECDH
+    testCreateECDHSecret()
+
+    NativeSecp256k1.cleanup()
+  }
+}

--- a/secp256k1/src/test/scala/coop/rchain/secp256k1java/NativeSecp256k1Tests.java
+++ b/secp256k1/src/test/scala/coop/rchain/secp256k1java/NativeSecp256k1Tests.java
@@ -1,0 +1,267 @@
+package coop.rchain.secp256k1java;
+import org.bitcoin.NativeSecp256k1;
+import static org.bitcoin.NativeSecp256k1Util.*;
+
+/**
+ * This class holds test cases defined for testing this library.
+ */
+public class NativeSecp256k1Tests {
+
+    //TODO improve comments/add more tests
+
+    /**
+     * This tests verify() for a valid signature
+     */
+    public static void testVerifyPos() throws AssertFailException {
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sig = toByteArray("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+
+        boolean result = NativeSecp256k1.verify(data, sig, pub);
+        assertEquals(result, true, "testVerifyPos");
+    }
+
+    /**
+     * This tests verify() for a non-valid signature
+     */
+    public static void testVerifyNeg() throws AssertFailException {
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A91"); //sha256hash of "testing"
+        byte[] sig = toByteArray("3044022079BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F817980220294F14E883B3F525B5367756C2A11EF6CF84B730B36C17CB0C56F0AAB2C98589");
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+
+        boolean result = NativeSecp256k1.verify(data, sig, pub);
+        assertEquals(result, false, "testVerifyNeg");
+    }
+
+    /**
+     * This tests secret key verify() for a valid secretkey
+     */
+    public static void testSecKeyVerifyPos() throws AssertFailException {
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+
+        boolean result = NativeSecp256k1.secKeyVerify(sec);
+        assertEquals(result, true, "testSecKeyVerifyPos");
+    }
+
+    /**
+     * This tests secret key verify() for a invalid secretkey
+     */
+    public static void testSecKeyVerifyNeg() throws AssertFailException {
+        byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+
+        boolean result = NativeSecp256k1.secKeyVerify(sec);
+        assertEquals(result, false, "testSecKeyVerifyNeg");
+    }
+
+    /**
+     * This tests public key create() for a valid secretkey
+     */
+    public static void testPubKeyCreatePos() throws AssertFailException {
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+
+        byte[] resultArr = NativeSecp256k1.computePubkey(sec, false);
+        String pubkeyString = toHex(resultArr);
+        assertEquals(pubkeyString, "04C591A8FF19AC9C4E4E5793673B83123437E975285E7B442F4EE2654DFFCA5E2D2103ED494718C697AC9AEBCFD19612E224DB46661011863ED2FC54E71861E2A6", "testPubKeyCreatePos");
+    }
+
+    /**
+     * This tests public key create() for a invalid secretkey
+     */
+    public static void testPubKeyCreateNeg() throws AssertFailException {
+        byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+
+        byte[] resultArr = NativeSecp256k1.computePubkey(sec, false);
+        String pubkeyString = toHex(resultArr);
+        assertEquals(pubkeyString, "", "testPubKeyCreateNeg");
+    }
+
+    /**
+     * This tests sign() for a valid secretkey
+     */
+    public static void testSignPos() throws AssertFailException {
+
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+
+        byte[] resultArr = NativeSecp256k1.sign(data, sec);
+        String sigString = toHex(resultArr);
+        assertEquals(sigString, "30440220182A108E1448DC8F1FB467D06A0F3BB8EA0533584CB954EF8DA112F1D60E39A202201C66F36DA211C087F3AF88B50EDF4F9BDAA6CF5FD6817E74DCA34DB12390C6E9", "testSignPos");
+    }
+
+    /**
+     * This tests sign() for a invalid secretkey
+     */
+    public static void testSignNeg() throws AssertFailException {
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+
+        byte[] resultArr = NativeSecp256k1.sign(data, sec);
+        String sigString = toHex(resultArr);
+        assertEquals(sigString, "", "testSignNeg");
+    }
+
+    /**
+     * This tests signWithEntropy() for a valid secretkey
+     */
+    public static void testSignWithEntropyPos() throws AssertFailException {
+
+        byte[] data = toByteArray("53702647283D86B3D6410ADEF184EC608372CC3DD8B9202795D731EB1EA54275");
+        byte[] sec = toByteArray("B4F62DE42D38D5D24B66FF01761C3FD0A6E7C8B719E0DC54D168FA013BFAF97F");
+        byte[] entropy = toByteArray("EDF312C904B610B11442320FFB94C4F976831051A481A17176CE2B81EB3A8B6F");
+
+        byte[] resultArr = NativeSecp256k1.signWithEntropy(data, sec, entropy);
+        String sigString = toHex(resultArr);
+        assertEquals(sigString, "30450221009D9714BE0CE9A3FD08497125C6D01362FDE2FF118FC817FDB14EE4C38CADFB7A022033B082E161F7D75ABC25642ED71226049DC59EC14AB19DF2A8EFEA47A6C75FAC", "testSignWithEntropyPos");
+    }
+
+    /**
+     * This tests signWithEntropy() for a invalid secretkey
+     */
+    public static void testSignWithEntropyNeg() throws AssertFailException {
+        byte[] data = toByteArray("CF80CD8AED482D5D1527D7DC72FCEFF84E6326592848447D2DC0B0E87DFC9A90"); //sha256hash of "testing"
+        byte[] sec = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+        byte[] entropy = toByteArray("EDF312C904B610B11442320FFB94C4F976831051A481A17176CE2B81EB3A8B6F");
+
+        byte[] resultArr = NativeSecp256k1.signWithEntropy(data, sec, entropy);
+        String sigString = toHex(resultArr);
+        assertEquals(sigString, "", "testSignWithEntropyNeg");
+    }
+
+    /**
+     * This tests private key tweak-add
+     */
+    public static void testPrivKeyTweakAdd() throws AssertFailException {
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
+
+        byte[] resultArr = NativeSecp256k1.privKeyTweakAdd(sec, data);
+        String seckeyString = toHex(resultArr);
+        assertEquals(seckeyString, "A168571E189E6F9A7E2D657A4B53AE99B909F7E712D1C23CED28093CD57C88F3", "testPrivKeyTweakAdd");
+    }
+
+    /**
+     * This tests private key tweak-mul
+     */
+    public static void testPrivKeyTweakMul() throws AssertFailException {
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
+
+        byte[] resultArr = NativeSecp256k1.privKeyTweakMul(sec, data);
+        String seckeyString = toHex(resultArr);
+        assertEquals(seckeyString, "97F8184235F101550F3C71C927507651BD3F1CDB4A5A33B8986ACF0DEE20FFFC", "testPrivKeyTweakMul");
+    }
+
+    /**
+     * This tests public key tweak-add
+     */
+    public static void testPubKeyTweakAdd() throws AssertFailException {
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+        byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
+
+        byte[] resultArr = NativeSecp256k1.pubKeyTweakAdd(pub, data, false);
+        String pubkeyString = toHex(resultArr);
+        byte[] resultArrCompressed = NativeSecp256k1.pubKeyTweakAdd(pub, data, true);
+        String pubkeyStringCompressed = toHex(resultArrCompressed);
+        assertEquals(pubkeyString, "0411C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF525A268E2A863C148555C48FB5FBA368E88718A46E205FABC3DBA2CCFFAB0796EF", "testPubKeyTweakAdd");
+        assertEquals(pubkeyStringCompressed, "0311C6790F4B663CCE607BAAE08C43557EDC1A4D11D88DFCB3D841D0C6A941AF52", "testPubKeyTweakAdd (compressed)");
+    }
+
+    /**
+     * This tests public key tweak-mul
+     */
+    public static void testPubKeyTweakMul() throws AssertFailException {
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+        byte[] data = toByteArray("3982F19BEF1615BCCFBB05E321C10E1D4CBA3DF0E841C2E41EEB6016347653C3"); //sha256hash of "tweak"
+
+        byte[] resultArr = NativeSecp256k1.pubKeyTweakMul(pub, data, false);
+        String pubkeyString = toHex(resultArr);
+        byte[] resultArrCompressed = NativeSecp256k1.pubKeyTweakMul(pub, data, true);
+        String pubkeyStringCompressed = toHex(resultArrCompressed);
+        assertEquals(pubkeyString, "04E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791EC060D4F412A794D5370F672BC94B722640B5F76914151CFCA6E712CA48CC589", "testPubKeyTweakMul");
+        assertEquals(pubkeyStringCompressed, "03E0FE6FE55EBCA626B98A807F6CAF654139E14E5E3698F01A9A658E21DC1D2791", "testPubKeyTweakMul (compressed)");
+    }
+
+    /**
+     * This tests seed randomization
+     */
+    public static void testRandomize() throws AssertFailException {
+        byte[] seed = toByteArray("A441B15FE9A3CF56661190A0B93B9DEC7D04127288CC87250967CF3B52894D11"); //sha256hash of "random"
+        boolean result = NativeSecp256k1.randomize(seed);
+        assertEquals(result, true, "testRandomize");
+    }
+
+    /**
+     * Tests that we can decompress valid public keys
+     *
+     * @throws AssertFailException
+     */
+    public static void testDecompressPubKey() throws AssertFailException {
+        byte[] compressedPubKey = toByteArray("0315EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD981");
+
+        byte[] result1 = NativeSecp256k1.decompress(compressedPubKey);
+        byte[] result2 = NativeSecp256k1.decompress(result1); // this is a no-op
+        String resultString1 = toHex(result1);
+        String resultString2 = toHex(result2);
+        assertEquals(resultString1, "0415EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD9817551BE3DF159C83045D9DFAC030A1A31DC9104082DB7719C098E87C1C4A36C19", "testDecompressPubKey (compressed)");
+        assertEquals(resultString2, "0415EAB529E7D5EB637214EA8EC8ECE5DCD45610E8F4B7CC76A35A6FC27F5DD9817551BE3DF159C83045D9DFAC030A1A31DC9104082DB7719C098E87C1C4A36C19", "testDecompressPubKey (no-op)");
+    }
+
+    /**
+     * Tests that we can check validity of public keys
+     *
+     * @throws AssertFailException
+     */
+    public static void testIsValidPubKeyPos() throws AssertFailException {
+        byte[] pubkey = toByteArray("0456b3817434935db42afda0165de529b938cf67c7510168a51b9297b1ca7e4d91ea59c64516373dd2fe6acc79bb762718bc2659fa68d343bdb12d5ef7b9ed002b");
+        byte[] compressedPubKey = toByteArray("03de961a47a519c5c0fc8e744d1f657f9ea6b9a921d2a3bceb8743e1885f752676");
+
+        boolean result1 = NativeSecp256k1.isValidPubKey(pubkey);
+        boolean result2 = NativeSecp256k1.isValidPubKey(compressedPubKey);
+        assertEquals(result1, true, "testIsValidPubKeyPos");
+        assertEquals(result2, true, "testIsValidPubKeyPos (compressed)");
+    }
+
+    public static void testIsValidPubKeyNeg() throws AssertFailException {
+        //do we have test vectors some where to test this more thoroughly?
+        byte[] pubkey = toByteArray("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+
+        boolean result1 = NativeSecp256k1.isValidPubKey(pubkey);
+        assertEquals(result1, false, "testIsValidPubKeyNeg");
+    }
+
+
+    public static void testCreateECDHSecret() throws AssertFailException {
+        byte[] sec = toByteArray("67E56582298859DDAE725F972992A07C6C4FB9F62A8FFF58CE3CA926A1063530");
+        byte[] pub = toByteArray("040A629506E1B65CD9D2E0BA9C75DF9C4FED0DB16DC9625ED14397F0AFC836FAE595DC53F8B0EFE61E703075BD9B143BAC75EC0E19F82A2208CAEB32BE53414C40");
+
+        byte[] resultArr = NativeSecp256k1.createECDHSecret(sec, pub);
+        String ecdhString = toHex(resultArr);
+        assertEquals(ecdhString, "2A2A67007A926E6594AF3EB564FC74005B37A9C8AEF2033C4552051B5C87F043", "testCreateECDHSecret");
+    }
+
+
+    //https://stackoverflow.com/a/19119453/967713
+    private static byte[] toByteArray(final String hex) {
+        int len = hex.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4)
+                    + Character.digit(hex.charAt(i + 1), 16));
+        }
+        return data;
+    }
+
+
+    //https://stackoverflow.com/a/9855338/967713
+    private final static char[] hexArray = "0123456789ABCDEF".toCharArray();
+
+    public static String toHex(byte[] bytes) {
+        char[] hexChars = new char[bytes.length * 2];
+        for (int j = 0; j < bytes.length; j++) {
+            int v = bytes[j] & 0xFF;
+            hexChars[j * 2] = hexArray[v >>> 4];
+            hexChars[j * 2 + 1] = hexArray[v & 0x0F];
+        }
+        return new String(hexChars);
+    }
+}


### PR DESCRIPTION
## Overview
This PR replaces https://github.com/rchain/secp256k1-java with the module inside main repo.
This is done in preparation for secp256k1 native libraries to be built separately.
Native libraries in resources folder have to be updated by CI from https://github.com/rchain/secp256k1-native.
Now they are temporarily pulled from https://github.com/nzpr/secp256k1-native/raw/aarch64/libs/


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
