### PR TITLE
Update lmdb-java version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val kamonZipkin         = "io.kamon"                   %% "kamon-zipkin"              % "1.0.0"
   val lightningj          = ("org.lightningj"             % "lightningj"                % "0.5.2-Beta")
     .intransitive() //we only use the lib for one util class (org.lightningj.util.ZBase32) that has no dependencies
-  val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.1"
+  val lmdbjava            = "org.lmdbjava"                % "lmdbjava"                  % "0.8.2"
   val logbackClassic      = "ch.qos.logback"              % "logback-classic"           % "1.2.3"
   val logstashLogback     = "net.logstash.logback"        % "logstash-logback-encoder"  % "6.6"
   val lz4                 = "org.lz4"                     % "lz4-java"                  % "1.7.1"
@@ -124,7 +124,7 @@ object Dependencies {
     "io.grpc"  % "grpc-core"         % "1.30.2",
     "io.netty" % "netty-codec-http2" % "4.1.48.Final",
     // Overrides for transitive dependencies (we don't use them directly, hence no val-s)
-    "com.github.jnr"         % "jnr-ffi"     % "2.1.15",
+    "com.github.jnr"         % "jnr-ffi"     % "2.2.12",
     "com.lihaoyi"            %% "geny"       % "0.6.10",
     "com.lihaoyi"            %% "sourcecode" % "0.2.1",
     "org.scala-lang.modules" %% "scala-xml"  % "1.3.0",


### PR DESCRIPTION
## Overview
Current lmdb-java does not work on Apple M1. Execution fails with
`An exception or error caused a run to abort: could not load FFI provider jnr.ffi.provider.jffi.Provider`

It turned out that the problem is in `jnr-ffi`.
Update of lmdbjava to the latest version `0.8.2` does not help, the solution is to couple update of `lmdbjava` (which uses `jnr-ffi @ 2.2.2` ) with update of `jnr-ffi` to the latest `2.2.12`.

NOTE: `lmdbjava @ 0.8.2` still does not have native library for ARM64 (https://github.com/lmdbjava/native/issues/10 is still open), so for `lmdbjava` to find proper arm64 native library it should be compiled manually. [This](https://github.com/lmdbjava/native/issues/10#issuecomment-984467831) provides woking example.


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
