### PR TITLE
Make sbt native packager use use buildx instead of build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -346,6 +346,13 @@ lazy val node = (project in file("node"))
         ExecCmd("CMD", "run")
       )
     },
+    Docker / dockerBuildCommand := Seq(
+      "docker",
+      "buildx",
+      "build",
+      ".",
+      "--platform=linux/amd64" //"--platform=linux/amd64,linux/arm64"
+    ),
     // Replace unsupported character `+`
     Docker / version := { version.value.replace("+", "__") },
     Docker / mappings ++= {


### PR DESCRIPTION
## Overview
TODO


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
