### PR TITLE
Fix of sync issue when block is received but not added to DAG

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
+++ b/casper/src/main/scala/coop/rchain/casper/blocks/BlockReceiver.scala
@@ -267,11 +267,9 @@ object BlockReceiver {
                                      BlockStore[F].contains(hash) &&^ dag.contains(hash).pure.not
                                    }
               _ <- unvalidatedParents.traverse { hash =>
-                    state.modify(_.beginStored(hash)) *>
-                      state.modify(_.endStored(hash, List.empty)) *>
+                    state.update(_.beginStored(hash)._1.endStored(hash, List.empty)._1) *>
                       receiverOutputQueue.enqueue1(hash)
                   }
-
               _ <- receiverOutputQueue.enqueue1(block.blockHash).whenA(hasAllDeps)
             } yield ()
           for {

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
@@ -228,7 +228,7 @@ class NodeRunning[F[_]
     * Check if block is stored in the BlockStore
     */
   private def checkBlockReceived(hash: BlockHash): F[Boolean] =
-    BlockStore[F].contains(hash)
+    BlockDagStorage[F].getRepresentation.map(_.contains(hash))
 
   def handle(peer: PeerNode, msg: CasperMessage): F[Unit] = msg match {
     case h: BlockHashMessage =>

--- a/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
+++ b/casper/src/main/scala/coop/rchain/casper/engine/NodeRunning.scala
@@ -228,7 +228,7 @@ class NodeRunning[F[_]
     * Check if block is stored in the BlockStore
     */
   private def checkBlockReceived(hash: BlockHash): F[Boolean] =
-    BlockDagStorage[F].getRepresentation.map(_.contains(hash))
+    BlockStore[F].contains(hash)
 
   def handle(peer: PeerNode, msg: CasperMessage): F[Unit] = msg match {
     case h: BlockHashMessage =>

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -46,7 +46,7 @@ class BlockReceiverEffectsSpec
           outList <- outStream.take(1).compile.toList
         } yield {
           bs.put(Seq((block.blockHash, block))) wasCalled once
-          bs.contains(Seq(block.blockHash)) wasCalled twice
+          bs.contains(Seq(block.blockHash)) wasCalled once
           br.ackReceived(block.blockHash) wasCalled once
           dagStorageWasNotModified(bds)
           outList shouldBe List(block.blockHash)
@@ -97,20 +97,6 @@ class BlockReceiverEffectsSpec
       }
   }
 
-  it should "discard known block" in withEnv[Task]("root") {
-    case (incomingQueue, _, outStream, bs, br, bds) =>
-      for {
-        block <- addBlock[Task](bs)
-        _     <- incomingQueue.enqueue1(block)
-      } yield {
-        bs.put(Seq((block.blockHash, block))) wasCalled once
-        bs.contains(*) wasNever called
-        br.ackReceived(*) wasNever called
-        dagStorageWasNotModified(bds)
-        outStream should notEmit
-      }
-  }
-
   it should "pass to output blocks with resolved dependencies" in withEnv[Task]("root") {
     case (incomingQueue, validatedQueue, outStream, bs, br, bds) =>
       for {
@@ -136,7 +122,7 @@ class BlockReceiverEffectsSpec
         bs.put(Seq((a2.blockHash, a2))) wasCalled once
 
         val bsContainsCaptor = ArgCaptor[Seq[BlockHash]]
-        bs.contains(bsContainsCaptor) wasCalled 6.times
+        bs.contains(bsContainsCaptor) wasCalled 4.times
         bsContainsCaptor.values should contain allOf (Seq(a1.blockHash), Seq(a2.blockHash))
 
         br.ackReceived(a1.blockHash) wasCalled once
@@ -202,7 +188,7 @@ class BlockReceiverEffectsSpec
 
       blockReceiver <- {
         implicit val (bsImp, brImp, bdsImp) = (bs, br, bds)
-        BlockReceiver(state, incomingBlockStream, validatedBlocksStream, shardId)
+        BlockReceiver(state, incomingBlockQueue, validatedBlocksStream, shardId)
       }
       res <- f(incomingBlockQueue, validatedBlocksQueue, blockReceiver, bs, br, bds)
     } yield res
@@ -224,11 +210,6 @@ class BlockReceiverEffectsSpec
     val block =
       makeDefaultBlock.copy(sender = pubKey.bytes.toByteString, justifications = justifications)
     ValidatorIdentity(privateKey).signBlock(block)
-  }
-
-  private def addBlock[F[_]: Sync](bs: BlockStore[F]): F[BlockMessage] = {
-    val block = makeBlock()
-    bs.put(Seq((block.blockHash, block))).as(block)
   }
 
   private def dagStorageWasNotModified[F[_]](bds: BlockDagStorage[F]) = {

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -46,7 +46,7 @@ class BlockReceiverEffectsSpec
           outList <- outStream.take(1).compile.toList
         } yield {
           bs.put(Seq((block.blockHash, block))) wasCalled once
-          bs.contains(Seq(block.blockHash)) wasCalled once
+          bs.contains(Seq(block.blockHash)) wasCalled twice
           br.ackReceived(block.blockHash) wasCalled once
           dagStorageWasNotModified(bds)
           outList shouldBe List(block.blockHash)
@@ -136,7 +136,7 @@ class BlockReceiverEffectsSpec
         bs.put(Seq((a2.blockHash, a2))) wasCalled once
 
         val bsContainsCaptor = ArgCaptor[Seq[BlockHash]]
-        bs.contains(bsContainsCaptor) wasCalled 4.times
+        bs.contains(bsContainsCaptor) wasCalled 6.times
         bsContainsCaptor.values should contain allOf (Seq(a1.blockHash), Seq(a2.blockHash))
 
         br.ackReceived(a1.blockHash) wasCalled once

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -188,7 +188,13 @@ class BlockReceiverEffectsSpec
 
       blockReceiver <- {
         implicit val (bsImp, brImp, bdsImp) = (bs, br, bds)
-        BlockReceiver(state, incomingBlockQueue, validatedBlocksStream, shardId)
+        BlockReceiver(
+          state,
+          incomingBlockStream,
+          validatedBlocksStream,
+          shardId,
+          incomingBlockQueue.enqueue1
+        )
       }
       res <- f(incomingBlockQueue, validatedBlocksQueue, blockReceiver, bs, br, bds)
     } yield res

--- a/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
+++ b/casper/src/test/scala/coop/rchain/casper/batch2/BlockReceiverEffectsSpec.scala
@@ -136,7 +136,7 @@ class BlockReceiverEffectsSpec
         bs.put(Seq((a2.blockHash, a2))) wasCalled once
 
         val bsContainsCaptor = ArgCaptor[Seq[BlockHash]]
-        bs.contains(bsContainsCaptor) wasCalled 3.times
+        bs.contains(bsContainsCaptor) wasCalled 4.times
         bsContainsCaptor.values should contain allOf (Seq(a1.blockHash), Seq(a2.blockHash))
 
         br.ackReceived(a1.blockHash) wasCalled once

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -169,6 +169,8 @@ object Setup {
 
       // Queue of received blocks from gRPC API
       incomingBlocksQueue <- Queue.unbounded[F, BlockMessage]
+      // Stream of blocks received over the network
+      incomingBlockStream = incomingBlocksQueue.dequeue
       // Queue of validated blocks, result of block processor
       validatedBlocksQueue <- Queue.unbounded[F, BlockMessage]
       // Validated blocks stream with auto-propose trigger
@@ -188,9 +190,10 @@ object Setup {
         implicit val (bs, bd, br) = (blockStore, blockDagStorage, blockRetriever)
         BlockReceiver[F](
           blockReceiverState,
-          incomingBlocksQueue,
+          incomingBlockStream,
           validatedBlocksStream,
-          conf.casper.shardName
+          conf.casper.shardName,
+          incomingBlocksQueue.enqueue1
         )
       }
       // Blocks from receiver with fork-choice tips request on idle

--- a/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
+++ b/node/src/main/scala/coop/rchain/node/runtime/Setup.scala
@@ -169,8 +169,6 @@ object Setup {
 
       // Queue of received blocks from gRPC API
       incomingBlocksQueue <- Queue.unbounded[F, BlockMessage]
-      // Stream of blocks received over the network
-      incomingBlockStream = incomingBlocksQueue.dequeue
       // Queue of validated blocks, result of block processor
       validatedBlocksQueue <- Queue.unbounded[F, BlockMessage]
       // Validated blocks stream with auto-propose trigger
@@ -190,7 +188,7 @@ object Setup {
         implicit val (bs, bd, br) = (blockStore, blockDagStorage, blockRetriever)
         BlockReceiver[F](
           blockReceiverState,
-          incomingBlockStream,
+          incomingBlocksQueue,
           validatedBlocksStream,
           conf.casper.shardName
         )


### PR DESCRIPTION
## Overview

We have problem with synchronization of nodes states when one of them interrupted during replay. In this case received block can be stored in BlockStore but not validated and stored into DAG. So when node starts again it cannot receive this block as missing dependency because it checks only BlockStore.

This situation illustrated in diagram below.

![image](https://user-images.githubusercontent.com/1443855/184878841-8e238088-6c73-42ea-975b-467bd373c1e8.png)

To solve this problem, we need to check that blocks were stored in BlockStore but missed in the DAG.

### How to check solution?

1. Run two paired nodes. The first one should create block #0 (genesis) and translate it to the second.
2. Create block (deploy + propose) on the first node. The second node should be stopped during block replay.
3. Create several new blocks on the first node.
4. Start second node again. It should add all missing blocks into the DAG

### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
