### PR TITLE
Bugfix. Remove genesis from conflict set.

### DIFF
--- a/casper/src/main/scala/coop/rchain/casper/merging/MergeScope.scala
+++ b/casper/src/main/scala/coop/rchain/casper/merging/MergeScope.scala
@@ -75,7 +75,7 @@ object MergeScope {
       genesisOpt.map(_.id)
     }
 
-    (MergeScope(fScopeIds, cScopeIds), baseMsg)
+    (MergeScope(fScopeIds, cScopeIds -- baseMsg.toSet), baseMsg)
   }
 
   def merge[F[_]: Concurrent: Log](


### PR DESCRIPTION
## Overview
Closes https://github.com/rchain/rchain/issues/3804. Dumb mistake of mine lead to investigation of a rabbit hole of a descent size. The problem was that genesis has been merged into its post state in the very beginning of the network. After this change now network of 5 nodes seems ok and reach block #6200 now.


### Notes
<!-- Optional. Add any notes on caveats, approaches you tried that didn't work, or anything else. -->


### Please make sure that this PR:
- [x] is at most 200 lines of code (excluding tests),
- [x] meets [RChain development coding standards](https://rchain.atlassian.net/wiki/spaces/DOC/pages/28082177/Coding+Standards),
- [x] includes tests for all added features,
- [x] has a reviewer assigned,
- [x] has [all commits signed](https://rchain.atlassian.net/wiki/spaces/DOC/pages/498630673/How+to+sign+commits+to+rchain+rchain).

### [Bors](https://bors.tech/) cheat-sheet:

- `bors r+` runs integration tests and merges the PR (if it's approved),
- `bors try` runs integration tests for the PR,
- `bors delegate+` enables non-maintainer PR authors to run the above.
